### PR TITLE
Use correct database type value instead of null in Postgresql provider.

### DIFF
--- a/src/Providers.Postgresql.fs
+++ b/src/Providers.Postgresql.fs
@@ -304,7 +304,7 @@ type internal PostgresqlProvider(resolutionPath) as this =
                                          let strings = box x :?> string array
                                          strings |> Array.map createParam
                                      | Some(x) -> [|createParam (box x)|]
-                                     | None ->    [|createParam null|]
+                                     | None ->    [|createParam DBNull.Value|]
 
                                 let prefix = if i>0 then (sprintf " %s " op) else ""
                                 let paras = extractData data


### PR DESCRIPTION
Using `null` as NpgsqlParameter value, caused exception in query expression involving option types.

```
System.Reflection.AmbiguousMatchException: Ambiguous matching in method resolution
  at System.Reflection.Binder+Default.GetBetterMethod (System.Reflection.MethodBase m1, System.Reflection.MethodBase m2, System.Type[] types) [0x00000] in <filename unknown>:0 
  at System.Reflection.Binder+Default.SelectMethod (BindingFlags bindingAttr, System.Reflection.MethodBase[] match, System.Type[] types, System.Reflection.ParameterModifier[] modifiers, Boolean allowByRefMatch, System.Object[]& arguments) [0x00000] in <filename unknown>:0 
  at System.Reflection.Binder+Default.BindToMethod (BindingFlags bindingAttr, System.Reflection.MethodBase[] match, System.Object[]& args, System.Reflection.ParameterModifier[] modifiers, System.Globalization.CultureInfo culture, System.String[] names, System.Object& state) [0x00000] in <filename unknown>:0 
  at System.Activator.CreateInstance (System.Type type, BindingFlags bindingAttr, System.Reflection.Binder binder, System.Object[] args, System.Globalization.CultureInfo culture, System.Object[] activationAttributes) [0x00000] in <filename unknown>:0 
  at System.Activator.CreateInstance (System.Type type, System.Object[] args, System.Object[] activationAttributes) [0x00000] in <filename unknown>:0 
  at System.Activator.CreateInstance (System.Type type, System.Object[] args) [0x00000] in <filename unknown>:0 
  at FSharp.Data.Sql.Providers.PostgresqlProvider.FSharp-Data-Sql-Common-ISqlProvider-CreateCommandParameter (System.String name, System.Object value, Microsoft.FSharp.Core.FSharpOption`1 dbType) [0x00000] in <filename unknown>:0 
  at <StartupCode$FSharp-Data-SqlProvider>.$Providers.Postgresql.createParam@290-1 (FSharp.Data.Sql.Providers.PostgresqlProvider this, Microsoft.FSharp.Core.FSharpRef`1 param, System.Object value) [0x00000] in <filename unknown>:0 
  at <StartupCode$FSharp-Data-SqlProvider>.$Providers.Postgresql.extractData@300-2[Object] (FSharp.Data.Sql.Providers.PostgresqlProvider this, Microsoft.FSharp.Core.FSharpRef`1 param, Microsoft.FSharp.Core.FSharpOption`1 data) [0x00000] in <filename unknown>:0 
  at <StartupCode$FSharp-Data-SqlProvider>.$Providers.Postgresql+build@299-33[System.Object].Invoke (Int32 i, System.Tuple`4 tupledArg) [0x00000] in <filename unknown>:0 
  at Microsoft.FSharp.Primitives.Basics.List.loop@180-14[Tuple`4] (Microsoft.FSharp.Core.FSharpFunc`3 f, Int32 n, Microsoft.FSharp.Collections.FSharpList`1 x) [0x00000] in <filename unknown>:0 
  at Microsoft.FSharp.Primitives.Basics.List.iteri[Tuple`4] (Microsoft.FSharp.Core.FSharpFunc`2 action, Microsoft.FSharp.Collections.FSharpList`1 x) [0x00000] in <filename unknown>:0 
  at Microsoft.FSharp.Collections.ListModule.IterateIndexed[Tuple`4] (Microsoft.FSharp.Core.FSharpFunc`2 action, Microsoft.FSharp.Collections.FSharpList`1 list) [0x00000] in <filename unknown>:0 
  at <StartupCode$FSharp-Data-SqlProvider>.$Providers.Postgresql.build@297-32[Object] (FSharp.Data.Sql.Providers.PostgresqlProvider this, System.Text.StringBuilder sb, System.Collections.Generic.List`1 parameters, Microsoft.FSharp.Core.FSharpRef`1 param, System.String op, Microsoft.FSharp.Collections.FSharpList`1 preds, Microsoft.FSharp.Core.FSharpOption`1 rest) [0x00000] in <filename unknown>:0 
  at <StartupCode$FSharp-Data-SqlProvider>.$Providers.Postgresql.filterBuilder@294-2 (FSharp.Data.Sql.Providers.PostgresqlProvider this, System.Text.StringBuilder sb, System.Collections.Generic.List`1 parameters, Microsoft.FSharp.Core.FSharpRef`1 param, Microsoft.FSharp.Collections.FSharpList`1 _arg4) [0x00000] in <filename unknown>:0 
  at <StartupCode$FSharp-Data-SqlProvider>.$Providers.Postgresql.aux@329-4[Object] (FSharp.Data.Sql.Providers.PostgresqlProvider this, System.Text.StringBuilder sb, System.Collections.Generic.List`1 parameters, Microsoft.FSharp.Core.FSharpRef`1 param, System.String op, Microsoft.FSharp.Collections.FSharpList`1 preds, Microsoft.FSharp.Collections.FSharpList`1 _arg5) [0x00000] in <filename unknown>:0 
  at <StartupCode$FSharp-Data-SqlProvider>.$Providers.Postgresql+aux@329-5[System.Object].Invoke (Microsoft.FSharp.Collections.FSharpList`1 _arg5) [0x00000] in <filename unknown>:0 
  at Microsoft.FSharp.Core.OptionModule.Iterate[FSharpList`1] (Microsoft.FSharp.Core.FSharpFunc`2 action, Microsoft.FSharp.Core.FSharpOption`1 option) [0x00000] in <filename unknown>:0 
  at <StartupCode$FSharp-Data-SqlProvider>.$Providers.Postgresql.build@297-32[Object] (FSharp.Data.Sql.Providers.PostgresqlProvider this, System.Text.StringBuilder sb, System.Collections.Generic.List`1 parameters, Microsoft.FSharp.Core.FSharpRef`1 param, System.String op, Microsoft.FSharp.Collections.FSharpList`1 preds, Microsoft.FSharp.Core.FSharpOption`1 rest) [0x00000] in <filename unknown>:0 
  at <StartupCode$FSharp-Data-SqlProvider>.$Providers.Postgresql.filterBuilder@294-2 (FSharp.Data.Sql.Providers.PostgresqlProvider this, System.Text.StringBuilder sb, System.Collections.Generic.List`1 parameters, Microsoft.FSharp.Core.FSharpRef`1 param, Microsoft.FSharp.Collections.FSharpList`1 _arg4) [0x00000] in <filename unknown>:0 
  at FSharp.Data.Sql.Providers.PostgresqlProvider.FSharp-Data-Sql-Common-ISqlProvider-GenerateQueryText (FSharp.Data.Sql.Common.SqlQuery sqlQuery, System.String baseAlias, FSharp.Data.Sql.Schema.Table baseTable, System.Collections.Generic.Dictionary`2 projectionColumns) [0x00000] in <filename unknown>:0 
  at FSharp.Data.Sql.QueryExpression.QueryExpressionTransformer.convertExpression (FSharp.Data.Sql.Common.SqlExp exp, System.Collections.Generic.List`1 entityIndex, IDbConnection con, ISqlProvider provider) [0x00000] in <filename unknown>:0 
  at FSharp.Data.Sql.Runtime.QueryImplementation.executeQuery (System.String conString, ISqlProvider provider, FSharp.Data.Sql.Common.SqlExp sqlExp, System.Collections.Generic.List`1 ti) [0x00000] in <filename unknown>:0 
  at FSharp.Data.Sql.Runtime.QueryImplementation+SqlQueryable`1[System.String].System-Collections-Generic-IEnumerable`1-GetEnumerator () [0x00000] in <filename unknown>:0 
  at Microsoft.FSharp.Collections.SeqModule.ToArray[String] (IEnumerable`1 source) [0x00000] in <filename unknown>:0 
  at <StartupCode$FSI_0001>.$FSI_0001.main@ () [0x00000] in <filename unknown>:0 
  at (wrapper managed-to-native) System.Reflection.MonoMethod:InternalInvoke (System.Reflection.MonoMethod,object,object[],System.Exception&)
  at System.Reflection.MonoMethod.Invoke (System.Object obj, BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x00000] in <filename unknown>:0 
Stopped due to error
```

For example, I used [sample postgresql dvdrental database](http://www.postgresqltutorial.com/postgresql-sample-database/) with option types enabled, and following query caused the exception:

``` fsharp
query {
    for x in ctx.``[public].[address]`` do
    where (x.postal_code.IsSome)
    select x.address
}
```

Haven't checked if same issue is present with other database engines.
