### PR TITLE
Fixes for using option values inside query expressions.

### DIFF
--- a/src/SqlRuntime.Common.fs
+++ b/src/SqlRuntime.Common.fs
@@ -73,8 +73,9 @@ type SqlEntity(tableName) =
         [ while reader.Read() = true do
           let e = SqlEntity(name)          
           for i = 0 to reader.FieldCount - 1 do 
-              let value = reader.GetValue(i)
-              if value <> null then e.SetColumn(reader.GetName(i),value)
+              match reader.GetValue(i) with
+              | null | :? DBNull -> ()
+              | value -> e.SetColumn(reader.GetName(i),value)
           yield e ]
 
     /// creates a new sql entity from alias data in this entity

--- a/src/SqlRuntime.QueryExpression.fs
+++ b/src/SqlRuntime.QueryExpression.fs
@@ -64,7 +64,7 @@ module internal QueryExpressionTransformer =
         override x.VisitMethodCall(exp) =
             let(|PropName|) (pi:PropertyInfo) = pi.Name
             match exp with
-            | MethodCall(Some(ParamName name | PropertyGet(_,PropName name)),(MethodWithName "GetColumn"),[FSharp.Data.Sql.Patterns.String key]) ->
+            | MethodCall(Some(ParamName name | PropertyGet(_,PropName name)),(MethodWithName "GetColumn" | MethodWithName "GetColumnOption"),[FSharp.Data.Sql.Patterns.String key]) ->
                 // add this attribute to the select list for the alias
                 let alias = if tupleIndex.Count = 0 then singleEntityName else Utilities.resolveTuplePropertyName name tupleIndex
                 match x.ProjectionMap.TryGetValue alias with


### PR DESCRIPTION
Found some more bugs:

When query expression created projection in which only option types were selected, the underlying SQL would instead query all columns from database. Because of that behavior, `distinct` queries were not working for option types.

Another problem was with retrieving `NULL` values. Because Npgsql driver returns `DBNull` instead of `null`, some nulls were getting through and causing `InvalidCastException` in `SqlEntity::GetColumnOption<'T>(key)` method.
