### PR TITLE
Rewrite Skip support for MySql.

### DIFF
--- a/src/SQLProvider/Providers.MySql.fs
+++ b/src/SQLProvider/Providers.MySql.fs
@@ -345,16 +345,14 @@ type internal MySqlProvider(resolutionPath) as this =
                 ~~"ORDER BY "
                 orderByBuilder()
 
-            if sqlQuery.Take.IsSome && sqlQuery.Skip.IsSome then 
-                ~~(sprintf " LIMIT %i,%i;" sqlQuery.Skip.Value sqlQuery.Take.Value)
-            else if sqlQuery.Take.IsSome then 
-                ~~(sprintf " LIMIT %i;" sqlQuery.Take.Value)
-            else if sqlQuery.Skip.IsSome then 
-                ~~(sprintf " LIMIT %i,%i;" sqlQuery.Take.Value System.UInt64.MaxValue)
+            match sqlQuery.Take, sqlQuery.Skip with
+            | Some take, Some skip ->  ~~(sprintf " LIMIT %i OFFSET %i;" take skip)
+            | Some take, None ->  ~~(sprintf " LIMIT %i;" take)
+            | None, Some skip -> ~~(sprintf " LIMIT %i OFFSET %i;" System.UInt64.MaxValue skip)
+            | None, None -> ()
 
             let sql = sb.ToString()
-            (sql,parameters)
-        
+            (sql,parameters)        
         member this.ProcessUpdates(con, entities) =
             let sb = Text.StringBuilder()
             let (~~) (t:string) = sb.Append t |> ignore


### PR DESCRIPTION
Use "LIMIT take OFFSET skip" instead of "LIMIT skip,take"
Use match expression instead of if-else.
## 

LIMIT x OFFSET y is more understandable than LIMIT y,x.
Match is a bit cleaner and more F#ish then using if-else.
