### PR TITLE
[#78] Add DbName parameter to SqlDataContext

### DIFF
--- a/src/SQLProvider/SqlRuntime.DataContext.fs
+++ b/src/SQLProvider/SqlRuntime.DataContext.fs
@@ -8,7 +8,7 @@ open FSharp.Data.Sql
 open FSharp.Data.Sql.Common
 open FSharp.Data.Sql.Schema
 
-type public SqlDataContext (typeName,connectionString:string,providerType,resolutionPath, owner) =   
+type public SqlDataContext (typeName,connectionString:string,providerType,resolutionPath,dbName,owner) =   
     let pendingChanges = HashSet<SqlEntity>()
     static let providerCache = Dictionary<string,ISqlProvider>()
     do
@@ -16,7 +16,7 @@ type public SqlDataContext (typeName,connectionString:string,providerType,resolu
             match providerCache .TryGetValue typeName with
             | true, _ -> ()
             | false,_ -> 
-                let prov = Utilities.createSqlProvider providerType resolutionPath owner
+                let prov = Utilities.createSqlProvider providerType resolutionPath dbName owner
                 use con = prov.CreateConnection(connectionString)
                 con.Open()
                 // create type mappings and also trigger the table info read so the provider has 

--- a/src/SQLProvider/SqlRuntime.QueryExpression.fs
+++ b/src/SQLProvider/SqlRuntime.QueryExpression.fs
@@ -3,10 +3,10 @@
     module internal Utilities =
         open FSharp.Data.Sql.Providers
 
-        let createSqlProvider vendor resolutionPath owner =
+        let createSqlProvider vendor resolutionPath dbName owner =
             match vendor with                
             | DatabaseProviderTypes.MSSQLSERVER -> MSSqlServerProvider() :> ISqlProvider
-            | DatabaseProviderTypes.SQLITE -> SQLiteProvider(resolutionPath) :> ISqlProvider
+            | DatabaseProviderTypes.SQLITE -> SQLiteProvider(resolutionPath, dbName) :> ISqlProvider
             | DatabaseProviderTypes.POSTGRESQL -> PostgresqlProvider(resolutionPath) :> ISqlProvider
             | DatabaseProviderTypes.MYSQL -> MySqlProvider(resolutionPath) :> ISqlProvider
             | DatabaseProviderTypes.ORACLE -> OracleProvider(resolutionPath, owner) :> ISqlProvider


### PR DESCRIPTION
Used by SQLite provider to create actual connection string relative to ResolutionFolder.

DbName is only used on case ConnectionString is empty/""

Solves problem I mentioned in issue #78
