### PR TITLE
Fix single table ordered queries.

### DIFF
--- a/src/SQLProvider/SqlRuntime.QueryExpression.fs
+++ b/src/SQLProvider/SqlRuntime.QueryExpression.fs
@@ -16,7 +16,7 @@ module internal QueryExpressionTransformer =
     let transform (projection:Expression) (tupleIndex:string ResizeArray) (resultParam:ParameterExpression) baseTableAlias (aliasEntityDict:Map<string,Table>) =
         
         let (|SingleTable|MultipleTables|) = function
-            | MethodCall(None, MethodWithName "Select", [Constant(_, t) ;exp]) when t = typeof<System.Linq.IQueryable<SqlEntity>> -> 
+            | MethodCall(None, MethodWithName "Select", [Constant(_, t) ;exp]) when t = typeof<System.Linq.IQueryable<SqlEntity>> || t = typeof<System.Linq.IOrderedQueryable<SqlEntity>> ->
                 SingleTable exp
             | MethodCall(None, MethodWithName "Select", [_ ;exp]) ->
                 MultipleTables exp


### PR DESCRIPTION
Queries which contain only `sortBy` clause were not resolved as SingleTable expressions, so that following query would fail with exception:

```
query {
    for product in db.``[MAIN].[PRODUCTS]`` do
    sortBy product.PRODUCTNAME
    select { Product = { Name = product.PRODUCTNAME }
             Num = query { for _ in product.FK_OrderDetails_0 do count } }
} |> Seq.iter (fun x -> printfn "%s; %d" x.Product.Name x.Num)
```
