### PR TITLE
Fix for issue #99 (SQLite not releasing database file)

### DIFF
--- a/src/SQLProvider/Providers.SQLite.fs
+++ b/src/SQLProvider/Providers.SQLite.fs
@@ -79,7 +79,7 @@ type internal SQLiteProvider(resolutionPath, referencedAssemblies) as this =
 
     interface ISqlProvider with
         member __.CreateConnection(connectionString) = Activator.CreateInstance(connectionType,[|box connectionString|]) :?> IDbConnection
-        member __.CreateCommand(connection,commandText) =  Activator.CreateInstance(commandType,[|box commandText;box connection|]) :?> IDbCommand
+        member __.CreateCommand(connection,commandText) = Activator.CreateInstance(commandType,[|box commandText;box connection|]) :?> IDbCommand
         member __.CreateCommandParameter(param,value) = 
             let p = Activator.CreateInstance(paramterType,[|box param.Name;box value|]) :?> IDbDataParameter
             p.DbType <- param.TypeMapping.DbType
@@ -332,7 +332,7 @@ type internal SQLiteProvider(resolutionPath, referencedAssemblies) as this =
 
             con.Open()
             let createInsertCommand (entity:SqlEntity) =                 
-                let cmd = (this :> ISqlProvider).CreateCommand(con,"")
+                use cmd = (this :> ISqlProvider).CreateCommand(con,"")
                 cmd.Connection <- con 
                 let pk = pkLookup.[entity.Table.FullName] 
                 let columnNames, values = 
@@ -357,7 +357,7 @@ type internal SQLiteProvider(resolutionPath, referencedAssemblies) as this =
                 cmd
 
             let createUpdateCommand (entity:SqlEntity) changedColumns =
-                let cmd = (this :> ISqlProvider).CreateCommand(con,"")
+                use cmd = (this :> ISqlProvider).CreateCommand(con,"")
                 cmd.Connection <- con 
                 let pk = pkLookup.[entity.Table.FullName] 
                 sb.Clear() |> ignore
@@ -396,7 +396,7 @@ type internal SQLiteProvider(resolutionPath, referencedAssemblies) as this =
                 cmd
             
             let createDeleteCommand (entity:SqlEntity) =
-                let cmd = (this :> ISqlProvider).CreateCommand(con,"")
+                use cmd = (this :> ISqlProvider).CreateCommand(con,"")
                 cmd.Connection <- con 
                 sb.Clear() |> ignore
                 let pk = pkLookup.[entity.Table.FullName] 

--- a/src/SQLProvider/SqlRuntime.Linq.fs
+++ b/src/SQLProvider/SqlRuntime.Linq.fs
@@ -39,7 +39,8 @@ module internal QueryImplementation =
        use cmd = provider.CreateCommand(con,query)
        for p in parameters do cmd.Parameters.Add p |> ignore
        if con.State <> ConnectionState.Open then con.Open()
-       let results = SqlEntity.FromDataReader(dc,baseTable.FullName, cmd.ExecuteReader())
+       use reader = cmd.ExecuteReader()
+       let results = SqlEntity.FromDataReader(dc,baseTable.FullName, reader)
        let results = seq { for e in results -> projector.DynamicInvoke(e) } |> Seq.cache :> System.Collections.IEnumerable
        if (provider.GetType() <> typeof<Providers.MSAccessProvider>) then con.Close() //else get 'COM object that has been separated from its underlying RCW cannot be used.'
        results

--- a/src/SQLProvider/Utils.fs
+++ b/src/SQLProvider/Utils.fs
@@ -133,8 +133,7 @@ module internal Sql =
         com.ExecuteReader()    
 
     let executeSqlAsDataTable createCommand sql con = 
-        executeSql createCommand sql con
-        |> (fun r -> 
-             let dt = new DataTable(); 
-             dt.Load(r); 
-             dt)
+        use r = executeSql createCommand sql con
+        let dt = new DataTable()
+        dt.Load(r)
+        dt


### PR DESCRIPTION
After doing a query with SQLProvider on a SQLite DB, it's not possible
to delete the file as System.Data.SQLite has not released the file.

As explained in the following link, the issue is that every instance of
SQLiteCommand and SQLiteDataReader needs to be properly disposed. There
were a few missing cases of this which are fixed in this commit.

http://stackoverflow.com/questions/12532729/sqlite-keeps-the-database-locked-even-after-the-connection-is-closed/12679840#12679840
