### PR TITLE
Fix array for IN and NOT IN expressions in PSQL. Fixed generic calls.

### DIFF
--- a/src/SQLProvider/Providers.Postgresql.fs
+++ b/src/SQLProvider/Providers.Postgresql.fs
@@ -527,11 +527,11 @@ type internal PostgresqlProvider(resolutionPath, owner, referencedAssemblies) as
                         preds |> List.iteri( fun i (alias,col,operator,data) ->
                                 let extractData data = 
                                      match data with
-                                     | Some(x) when (box x :? string array) -> 
+                                     | Some(x) when box x :? string array || operator = FSharp.Data.Sql.In || operator = FSharp.Data.Sql.NotIn -> 
                                          // in and not in operators pass an array
-                                         let strings = box x :?> string array
-                                         strings |> Array.map createParam
-                                     | Some(x) -> [|createParam (box x)|]
+                                            (box x :?> obj []) |> Array.map createParam
+                                     | Some(x) -> 
+                                         [|createParam (box x)|]
                                      | None ->    [|createParam DBNull.Value|]
 
                                 let prefix = if i>0 then (sprintf " %s " op) else ""

--- a/src/SQLProvider/SqlDesignTime.fs
+++ b/src/SQLProvider/SqlDesignTime.fs
@@ -238,7 +238,7 @@ type SqlTypeProvider(config: TypeProviderConfig) as this =
                                               let meth = typeof<SqlEntity>.GetMethod("GetColumn").MakeGenericMethod([|ty|])
                                               Expr.Call(args.[0],meth,[Expr.Value name])),
                                           SetterCode = (fun args ->
-                                              let meth = typeof<SqlEntity>.GetMethod "SetColumn"
+                                              let meth = typeof<SqlEntity>.GetMethod("SetColumn").MakeGenericMethod([|typeof<obj>|])
                                               Expr.Call(args.[0],meth,[Expr.Value name;Expr.Coerce(args.[1], typeof<obj>)])))
                                   rt.AddMember prop)
                               resultType.AddMember(rt)

--- a/src/SQLProvider/SqlRuntime.Common.fs
+++ b/src/SQLProvider/SqlRuntime.Common.fs
@@ -105,7 +105,7 @@ type SqlEntity(dc:ISqlDataContext,tableName:string) =
     member e.SetColumnSilent(key,value) =
         data.[key] <- value                
 
-    member e.SetColumn(key,value) =        
+    member e.SetColumn<'t>(key,value : 't) =        
         data.[key] <- value
         e.UpdateField key        
         e.TriggerPropertyChange key


### PR DESCRIPTION
I tried running the test suite: PostgreSQLTests and failed for two errors.

1) Whenever the 'IN' or 'NOT IN' operators where used, the PSQL provider created a parameter having the whole array as parameter instead of separating the array into multiple parameters. I fixed this by checking what the operation is when pattern matching since the IN and NOT IN operators always take an array as argument.

2) The SetColumns method was not being treated as a generic method by .Net reflection (don't know about Mono) so I added an explicit generic parameter to avoid confusion.