### PR TITLE
Adjust PSQL mapping of DateTime so it maps to Date

### DIFF
--- a/src/SQLProvider/Providers.Postgresql.fs
+++ b/src/SQLProvider/Providers.Postgresql.fs
@@ -122,9 +122,14 @@ module PostgreSQL =
                 yield { ProviderTypeName = Some "SETOF refcursor"; ClrType = (typeof<SqlEntity[]>).ToString(); DbType = DbType.Object; ProviderType = None; }
             ]
 
+        let adjustments = 
+            [(typeof<System.DateTime>.ToString(),System.Data.DbType.Date) ] 
+            |> List.map (fun (``type``,dbType) -> ``type``,mappings |> List.find (fun mp -> mp.ClrType = ``type`` && mp.DbType = dbType))
+
         let clrMappings =
             mappings
             |> List.map (fun m -> m.ClrType, m)
+            |> (fun tys -> List.append tys adjustments)
             |> Map.ofList
 
         let dbMappings = 


### PR DESCRIPTION
The PSQL provider fails with DateTimes. Consider this example (based on the bundled tests):
```
let ctx = ...

let Job = query{
    for job in ctx.``[PUBLIC].[JOBS]`` do
    where (job.JOB_ID = "IT_PROG")
    select job
    head
    }

let Turing = ctx.``[PUBLIC].[EMPLOYEES]``.Create("turing@domain.com",DateTime.Now,Job.JOB_ID,"Turing")
Turing.EMPLOYEE_ID <- 348456
ctx.SubmitUpdates()
```

This fails because an IDBDataParameter is created such that it's "Value" property is a DateTime object and it's "DbType" property is a System.Data.DbType.Time. PSQL requires it to be a "Date". The fix is a bit odd, but this is because types get mapped in the order they get listed by the "Enum.GetName" function and "Map.fromList" always takes the last key/value pair from the list as the actual mapping in case of repeated entries.