### PR TITLE
Bugs in the LINQ expression converter

### DIFF
--- a/src/SQLProvider/SqlRuntime.QueryExpression.fs
+++ b/src/SQLProvider/SqlRuntime.QueryExpression.fs
@@ -115,9 +115,23 @@ module internal QueryExpressionTransformer =
                                                                                          upcast resultParam
                                                                                     | _ -> upcast e
             | ExpressionType.MemberAccess,       (:? MemberExpression as e)      -> upcast Expression.MakeMemberAccess(transform en e.Expression, e.Member)
-            | ExpressionType.Call,               (:? MethodCallExpression as e)  -> upcast Expression.Call( (if e.Object = null then null else transform en e.Object), e.Method, e.Arguments |> Seq.map(fun a -> transform en a))
-            | ExpressionType.Lambda,             (:? LambdaExpression as e)      -> upcast Expression.Lambda(transform en e.Body, e.Parameters)
-            | ExpressionType.New,                (:? NewExpression as e)         -> upcast Expression.New(e.Constructor, e.Arguments |> Seq.map(fun a -> transform en a), e.Members)
+            | ExpressionType.Call,               (:? MethodCallExpression as e)  ->
+              let o = e.Object
+              let last = transform en e.Object
+              let args' = e.Arguments |> Seq.map(fun a -> transform en a)
+              let _ = Expression.Call(last,e.Method,args')
+              upcast Expression.Call( (if e.Object = null then null else transform en e.Object), e.Method, e.Arguments |> Seq.map(fun a -> transform en a))
+            | ExpressionType.Lambda,             (:? LambdaExpression as e)      -> let exType = e.GetType()
+                                                                                    if  exType.IsGenericType 
+                                                                                        && exType.GetGenericTypeDefinition() = typeof<Expression<obj>>.GetGenericTypeDefinition() 
+                                                                                        && exType.GenericTypeArguments.[0].IsSubclassOf typeof<Delegate> then
+                                                                                        upcast Expression.Lambda(e.GetType().GenericTypeArguments.[0],transform en e.Body, e.Parameters)
+                                                                                    else
+                                                                                        upcast Expression.Lambda(transform en e.Body, e.Parameters)
+            | ExpressionType.New,                (:? NewExpression as e)         -> if e.Members = null then
+                                                                                      upcast Expression.New(e.Constructor, e.Arguments |> Seq.map(fun a -> transform en a))
+                                                                                    else
+                                                                                      upcast Expression.New(e.Constructor, e.Arguments |> Seq.map(fun a -> transform en a), e.Members)
             | ExpressionType.NewArrayInit,       (:? NewArrayExpression as e)    -> upcast Expression.NewArrayInit(e.Type.GetElementType(), e.Expressions |> Seq.map(fun e -> transform en e))
             | ExpressionType.NewArrayBounds,     (:? NewArrayExpression as e)    -> upcast Expression.NewArrayBounds(e.Type.GetElementType(), e.Expressions |> Seq.map(fun e -> transform en e))
             | ExpressionType.Invoke,             (:? InvocationExpression as e)  -> upcast Expression.Invoke(transform en e.Expression, e.Arguments |> Seq.map(fun a -> transform en a))
@@ -125,6 +139,7 @@ module internal QueryExpressionTransformer =
             | ExpressionType.ListInit,           (:? ListInitExpression as e)    -> upcast Expression.ListInit( (transform en e.NewExpression) :?> NewExpression, e.Initializers)
             | _ -> failwith "encountered unknown LINQ expression"                                                                                                    
  
+
         let newProjection =
             match projection with
             | SingleTable(OptionalQuote(Lambda([ParamName _],ParamName x))) -> 

--- a/src/SQLProvider/SqlRuntime.QueryExpression.fs
+++ b/src/SQLProvider/SqlRuntime.QueryExpression.fs
@@ -115,12 +115,7 @@ module internal QueryExpressionTransformer =
                                                                                          upcast resultParam
                                                                                     | _ -> upcast e
             | ExpressionType.MemberAccess,       (:? MemberExpression as e)      -> upcast Expression.MakeMemberAccess(transform en e.Expression, e.Member)
-            | ExpressionType.Call,               (:? MethodCallExpression as e)  ->
-              let o = e.Object
-              let last = transform en e.Object
-              let args' = e.Arguments |> Seq.map(fun a -> transform en a)
-              let _ = Expression.Call(last,e.Method,args')
-              upcast Expression.Call( (if e.Object = null then null else transform en e.Object), e.Method, e.Arguments |> Seq.map(fun a -> transform en a))
+            | ExpressionType.Call,               (:? MethodCallExpression as e)  -> upcast Expression.Call( (if e.Object = null then null else transform en e.Object), e.Method, e.Arguments |> Seq.map(fun a -> transform en a))
             | ExpressionType.Lambda,             (:? LambdaExpression as e)      -> let exType = e.GetType()
                                                                                     if  exType.IsGenericType 
                                                                                         && exType.GetGenericTypeDefinition() = typeof<Expression<obj>>.GetGenericTypeDefinition() 

--- a/tests/SqlProvider.Tests/PostgreSQLTests.fsx
+++ b/tests/SqlProvider.Tests/PostgreSQLTests.fsx
@@ -68,13 +68,13 @@ type Simple = {First : string}
 
 type Dummy<'t> = D of 't
 
-let employeesFirstName = 
+let employeesFirstName1 = 
     query {
         for emp in ctx.``[PUBLIC].[EMPLOYEES]`` do
         select (D {First=emp.FIRST_NAME})
     } |> Seq.toList
 
-let employeesFirstName = 
+let employeesFirstName2 = 
     query {
         for emp in ctx.``[PUBLIC].[EMPLOYEES]`` do
         select ({First=emp.FIRST_NAME} |> D)

--- a/tests/SqlProvider.Tests/PostgreSQLTests.fsx
+++ b/tests/SqlProvider.Tests/PostgreSQLTests.fsx
@@ -64,6 +64,22 @@ let topSales5ByCommission =
     |> Seq.map (fun e -> e.MapTo<Employee>())
     |> Seq.toList
 
+type Simple = {First : string}
+
+type Dummy<'t> = D of 't
+
+let employeesFirstName = 
+    query {
+        for emp in ctx.``[PUBLIC].[EMPLOYEES]`` do
+        select (D {First=emp.FIRST_NAME})
+    } |> Seq.toList
+
+let employeesFirstName = 
+    query {
+        for emp in ctx.``[PUBLIC].[EMPLOYEES]`` do
+        select ({First=emp.FIRST_NAME} |> D)
+    } |> Seq.toList
+
 #r @"..\..\packages\Newtonsoft.Json.6.0.3\lib\net45\Newtonsoft.Json.dll"
 
 open Newtonsoft.Json


### PR DESCRIPTION
The two new tests included in this pull request fail w/o the changes:

#1 It is not clear from the documentation (https://msdn.microsoft.com/en-us/library/bb549042%28v=vs.110%29.aspx) if Expression.New can be called when the "members" argument is null but apparently doing so causes the employeesFirstName1 function to crash.

#2 The F# compiler internally adds some calls to the FSharpFunc.Convert method which takes as an argument a Delegate from the Converter class. When constructed lambdas that are passed as arguments to this function, one must make sure they are a subclass of the Converter class. Adding this conversion makes the test employeesFirstName2 no longer crash.