### PR TITLE
Case-sensitivity fixed.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.suo
 *.user
 *.sln.docstates
+*.vs/
 
 # Build results
 

--- a/src/DatabaseScripts/MSSQLServer/DATA.sql
+++ b/src/DatabaseScripts/MSSQLServer/DATA.sql
@@ -1,7 +1,7 @@
-EXEC sp_msforeachtable "ALTER TABLE ? NOCHECK CONSTRAINT all"
+EXEC sp_MSforeachtable "ALTER TABLE ? NOCHECK CONSTRAINT all"
 
 -- delete data in all tables
-EXEC sp_MSForEachTable "DELETE FROM ?"
+EXEC sp_MSforeachtable "DELETE FROM ?"
 Insert into dbo.REGIONS (REGION_ID,REGION_NAME) values (1,'Europe');
 Insert into dbo.REGIONS (REGION_ID,REGION_NAME) values (2,'Americas');
 Insert into dbo.REGIONS (REGION_ID,REGION_NAME) values (3,'Asia');
@@ -219,4 +219,4 @@ Insert into dbo.LOCATIONS (LOCATION_ID,STREET_ADDRESS,POSTAL_CODE,CITY,STATE_PRO
 Insert into dbo.LOCATIONS (LOCATION_ID,STREET_ADDRESS,POSTAL_CODE,CITY,STATE_PROVINCE,COUNTRY_ID) values (3100,'Pieter Breughelstraat 837','3029SK','Utrecht','Utrecht','NL');
 Insert into dbo.LOCATIONS (LOCATION_ID,STREET_ADDRESS,POSTAL_CODE,CITY,STATE_PROVINCE,COUNTRY_ID) values (3200,'Mariano Escobedo 9991','11932','Mexico City','Distrito Federal,','MX');
 -- enable all constraints
-EXEC sp_msforeachtable "ALTER TABLE ? WITH CHECK CHECK CONSTRAINT all"
+EXEC sp_MSforeachtable "ALTER TABLE ? WITH CHECK CHECK CONSTRAINT all"

--- a/src/DatabaseScripts/MySql/LOGINUSER.sql
+++ b/src/DatabaseScripts/MySql/LOGINUSER.sql
@@ -1,0 +1,4 @@
+CREATE USER 'admin'@'localhost' IDENTIFIED BY 'password';
+CREATE DATABASE HR;
+GRANT ALL ON HR.* TO 'admin'@'localhost';
+FLUSH PRIVILEGES;

--- a/src/SQLProvider/Providers.MSAccess.fs
+++ b/src/SQLProvider/Providers.MSAccess.fs
@@ -71,7 +71,7 @@ type internal MSAccessProvider() =
             upcast p
         member __.ExecuteSprocCommand(com,definition,retCols,values) =  raise(NotImplementedException())
         member __.CreateTypeMappings(con) = createTypeMappings (con:?>OleDbConnection)     
-        member __.GetTables(con) =
+        member __.GetTables(con,cs) =
             if con.State <> ConnectionState.Open then con.Open()
             let con = con:?>OleDbConnection
             let tables = 

--- a/src/SQLProvider/Providers.MySql.fs
+++ b/src/SQLProvider/Providers.MySql.fs
@@ -24,7 +24,7 @@ module MySql =
     let findType name = 
         match assembly.Value with
         | Some(assembly) -> assembly.GetTypes() |> Array.find(fun t -> t.Name = name)
-        | None -> failwithf "Unable to resolve mysql assemblies. One of %s must exist in the resolution path" (String.Join(", ", assemblyNames |> List.toArray))
+        | None -> failwithf "Unable to resolve mysql assemblies. One of %s must exist in the resolution path: %s" (String.Join(", ", assemblyNames |> List.toArray)) resolutionPath
 
    
     let connectionType =  lazy (findType "MySqlConnection")
@@ -615,7 +615,7 @@ type internal MySqlProvider(resolutionPath, owner, referencedAssemblies) as this
                     match entity.GetColumnOption<obj> pk with
                     | Some v -> v
                     | None -> failwith "Error - you cannot delete an entity that does not have a primary key."
-                let p = (this :> ISqlProvider).CreateCommandParameter(QueryParameter.Create("@pk", 0),pkValue)
+                let p = (this :> ISqlProvider).CreateCommandParameter(QueryParameter.Create("@id", 0),pkValue)
                 cmd.Parameters.Add(p) |> ignore
                 ~~(sprintf "DELETE FROM %s WHERE %s = @id" (entity.Table.FullName.Replace("[","`").Replace("]","`")) pk )
                 cmd.CommandText <- sb.ToString()

--- a/src/SQLProvider/Providers.Odbc.fs
+++ b/src/SQLProvider/Providers.Odbc.fs
@@ -70,7 +70,7 @@ type internal OdbcProvider(resolutionPath) =
         member __.ExecuteSprocCommand(com,definition,retCols,values) = ReturnValueType.Unit //  raise(NotImplementedException())
 
         member __.CreateTypeMappings(con) = createTypeMappings (con:?>OdbcConnection)     
-        member __.GetTables(con) =
+        member __.GetTables(con,cs) =
             let con = con :?> OdbcConnection
             if con.State <> ConnectionState.Open then con.Open()
             let dataTables = con.GetSchema("Tables").Rows |> Seq.cast<DataRow> |> Seq.map (fun i -> i.ItemArray)

--- a/src/SQLProvider/Providers.Oracle.fs
+++ b/src/SQLProvider/Providers.Oracle.fs
@@ -26,7 +26,7 @@ module internal Oracle =
     let findType name = 
         match assembly.Value with
         | Some(assembly) -> assembly.GetTypes() |> Array.find(fun t -> t.Name = name)
-        | None -> failwithf "Unable to resolve oracle assemblies. One of %s must exist in the resolution path" (String.Join(", ", assemblyNames |> List.toArray))
+        | None -> failwithf "Unable to resolve oracle assemblies. One of %s must exist in the resolution path: %s" (String.Join(", ", assemblyNames |> List.toArray)) resolutionPath
 
     let connectionType = lazy  (findType "OracleConnection")
     let commandType =  lazy   (findType "OracleCommand")

--- a/src/SQLProvider/Providers.Oracle.fs
+++ b/src/SQLProvider/Providers.Oracle.fs
@@ -364,7 +364,7 @@ type internal OracleProvider(resolutionPath, owner, referencedAssemblies) =
                 Oracle.createTypeMappings con
                 primaryKeyCache <- ((Oracle.getPrimaryKeys con) |> dict))
 
-        member __.GetTables(con) =
+        member __.GetTables(con,cs) =
                match tableCache with
                | [] ->
                     let tables = Sql.connect con Oracle.getTables

--- a/src/SQLProvider/Providers.Postgresql.fs
+++ b/src/SQLProvider/Providers.Postgresql.fs
@@ -353,7 +353,7 @@ type internal PostgresqlProvider(resolutionPath, owner, referencedAssemblies) as
         member __.ExecuteSprocCommand(con, definition:SprocDefinition,retCols, values:obj array) = PostgreSQL.executeSprocCommand con definition retCols values
         member __.CreateTypeMappings(_) = PostgreSQL.createTypeMappings()
 
-        member __.GetTables(con) =
+        member __.GetTables(con,cs) =
             use reader = executeSql con (sprintf "SELECT  table_schema,
                                                           table_name,
                                                           table_type

--- a/src/SQLProvider/Providers.Postgresql.fs
+++ b/src/SQLProvider/Providers.Postgresql.fs
@@ -23,7 +23,7 @@ module PostgreSQL =
     let tryFindType name =
         match assembly.Value with
         | Some(assembly) -> assembly.GetTypes() |> Array.tryFind (fun t -> t.Name = name)
-        | None -> failwithf "Unable to resolve postgresql assemblies. One of %s must exist in the resolution path" (String.Join(", ", assemblyNames |> List.toArray))
+        | None -> failwithf "Unable to resolve postgresql assemblies. One of %s must exist in the resolution path: %s" (String.Join(", ", assemblyNames |> List.toArray)) resolutionPath
 
     let findType name =
         match tryFindType name with

--- a/src/SQLProvider/Providers.SQLite.fs
+++ b/src/SQLProvider/Providers.SQLite.fs
@@ -90,7 +90,7 @@ type internal SQLiteProvider(resolutionPath, referencedAssemblies) as this =
             if con.State <> ConnectionState.Open then con.Open()
             createTypeMappings con
             con.Close()
-        member __.GetTables(con) =            
+        member __.GetTables(con,cs) =            
             if con.State <> ConnectionState.Open then con.Open()
             let ret =
                 [ for row in (getSchemaMethod.Invoke(con,[|"Tables"|]) :?> DataTable).Rows do 

--- a/src/SQLProvider/Providers.SQLite.fs
+++ b/src/SQLProvider/Providers.SQLite.fs
@@ -30,8 +30,7 @@ type internal SQLiteProvider(resolutionPath, referencedAssemblies) as this =
     let findType pred = 
         match assembly.Value with
         | Some(assembly) -> assembly.GetTypes() |> Array.find pred
-        | None -> failwithf "Unable to resolve sql lite assemblies. One of %s must exist in the resolution path" (String.Join(", ", assemblyNames |> List.toArray))
-
+        | None -> failwithf "Unable to resolve sql lite assemblies. One of %s must exist in the resolution path: %s" (String.Join(", ", assemblyNames |> List.toArray)) resolutionPath
    
     let connectionType =  (findType (fun t -> t.Name = if isMono then "SqliteConnection" else "SQLiteConnection"))
     let commandType =     (findType (fun t -> t.Name = if isMono then "SqliteCommand" else "SQLiteCommand"))
@@ -78,7 +77,7 @@ type internal SQLiteProvider(resolutionPath, referencedAssemblies) as this =
         com.ExecuteReader()
 
     interface ISqlProvider with
-        member __.CreateConnection(connectionString) = Activator.CreateInstance(connectionType,[|box connectionString|]) :?> IDbConnection
+        member __.CreateConnection(connectionString) = Activator.CreateInstance(connectionType,[|box (connectionString |> ConfigHelpers.parseConnectionString)|]) :?> IDbConnection
         member __.CreateCommand(connection,commandText) = Activator.CreateInstance(commandType,[|box commandText;box connection|]) :?> IDbCommand
         member __.CreateCommandParameter(param,value) = 
             let p = Activator.CreateInstance(paramterType,[|box param.Name;box value|]) :?> IDbDataParameter

--- a/src/SQLProvider/SqlDesignTime.fs
+++ b/src/SQLProvider/SqlDesignTime.fs
@@ -22,7 +22,12 @@ type SqlTypeProvider(config: TypeProviderConfig) as this =
     let ns = "FSharp.Data.Sql";   
     let asm = Assembly.GetExecutingAssembly()
      
-    let createTypes(connnectionString, conStringName,dbVendor,resolutionPath,individualsAmount,useOptionTypes,owner, rootTypeName) =       
+    let createTypes(connnectionString, conStringName,dbVendor,resolutionPath,individualsAmount,useOptionTypes,owner,caseSensitivity, rootTypeName) = 
+        let caseInsensitivityCheck = 
+            match caseSensitivity with
+            | CaseSensitivity.TOLOWER -> (fun (x:string) -> x.ToLower())
+            | CaseSensitivity.TOUPPER -> (fun (x:string) -> x.ToUpper())
+            | _ -> (fun x -> x)
         let prov = ProviderBuilder.createProvider dbVendor resolutionPath config.ReferencedAssemblies owner
         let conString = 
             match ConfigHelpers.tryGetConnectionString false config.ResolutionFolder conStringName connnectionString with
@@ -85,6 +90,7 @@ type SqlTypeProvider(config: TypeProviderConfig) as this =
                    // for each column in the entity except the primary key, create a new type that will read ``As Column 1`` etc
                    // inside that type the individuals will be listed again but with the text for the relevant column as the name 
                    // of the property and the primary key e.g. ``1, Dennis The Squirrel``
+                   let buildFieldName = SchemaProjections.buildFieldName >> caseInsensitivityCheck
                    let propertyMap =
                       prov.GetColumns(con,table)
                       |> Seq.choose(fun col -> 
@@ -93,7 +99,7 @@ type SqlTypeProvider(config: TypeProviderConfig) as this =
                         let ty = ProvidedTypeDefinition(name, None, HideObjectMethods = true )
                         ty.AddMember(ProvidedConstructor([ProvidedParameter("sqlService", typeof<ISqlDataContext>)]))
                         individualsTypes.Add ty
-                        Some(col.Name,(ty,ProvidedProperty(sprintf "As %s" (SchemaProjections.buildFieldName col.Name),ty, GetterCode = fun args -> <@@ ((%%args.[0] : obj) :?> ISqlDataContext)@@> ))))
+                        Some(col.Name,(ty,ProvidedProperty(sprintf "As %s" (buildFieldName col.Name),ty, GetterCode = fun args -> <@@ ((%%args.[0] : obj) :?> ISqlDataContext)@@> ))))
                       |> Map.ofSeq
                  
                    // special case for guids as they are not a supported quotable constant in the TP mechanics,
@@ -157,9 +163,10 @@ type SqlTypeProvider(config: TypeProviderConfig) as this =
                         let ty = Type.GetType c.TypeMapping.ClrType
                         let propTy = if nullable then typedefof<option<_>>.MakeGenericType(ty) else ty
                         let name = c.Name
+                        let buildFieldName = SchemaProjections.buildFieldName >> caseInsensitivityCheck
                         let prop = 
                             ProvidedProperty(
-                                SchemaProjections.buildFieldName(name),propTy,
+                                buildFieldName(name),propTy,
                                 GetterCode = (fun args ->
                                     let meth = if nullable then typeof<SqlEntity>.GetMethod("GetColumnOption").MakeGenericMethod([|ty|])
                                                else  typeof<SqlEntity>.GetMethod("GetColumn").MakeGenericMethod([|ty|])
@@ -178,7 +185,8 @@ type SqlTypeProvider(config: TypeProviderConfig) as this =
                     List.map createColumnProperty columns
                 let relProps = 
                     let bts = baseTypes.Force()       
-                    [ for r in children do               
+                    [ for r in children do       
+                       if bts.ContainsKey(r.PrimaryTable) then
                         let (tt,_,_) = (bts.[r.ForeignTable])
                         let ty = typedefof<System.Linq.IQueryable<_>>
                         let ty = ty.MakeGenericType tt
@@ -212,7 +220,8 @@ type SqlTypeProvider(config: TypeProviderConfig) as this =
                 |> List.filter (fun p -> p.Direction = ParameterDirection.Input || p.Direction = ParameterDirection.InputOutput)
                 |> List.map(fun p -> ProvidedParameter(p.Name,Type.GetType p.TypeMapping.ClrType))
 
-            let rt = ProvidedTypeDefinition(SchemaProjections.buildSprocName(sproc.Name.DbName),Some typeof<ISqlDataContext>, HideObjectMethods = true)
+            let buildSprocName = SchemaProjections.buildSprocName >> caseInsensitivityCheck
+            let rt = ProvidedTypeDefinition(buildSprocName(sproc.Name.DbName),Some typeof<ISqlDataContext>, HideObjectMethods = true)
             let resultType = ProvidedTypeDefinition("Result",Some typeof<ISqlDataContext>, HideObjectMethods = true)
             resultType.AddMember(ProvidedConstructor([ProvidedParameter("sqlDataContext", typeof<ISqlDataContext>)]))
             rt.AddMember(ProvidedConstructor([ProvidedParameter("sqlDataContext", typeof<ISqlDataContext>)]))
@@ -250,7 +259,8 @@ type SqlTypeProvider(config: TypeProviderConfig) as this =
                     ProvidedMethod("Invoke", parameters, returnType, InvokeCode = QuotationHelpers.quoteRecord sproc (fun args var ->                      
                         <@@ ((%%args.[0] : ISqlDataContext)).CallSproc(%%var, %%retColsExpr,  %%Expr.NewArray(typeof<obj>,List.map(fun e -> Expr.Coerce(e,typeof<obj>)) args.Tail)) @@>)))
 
-            ProvidedProperty(SchemaProjections.buildSprocName(sproc.Name.ProcName), resultType, GetterCode = (fun args -> <@@ (%%args.[0] : ISqlDataContext) @@>) ) 
+            let buildSprocName = SchemaProjections.buildSprocName >> caseInsensitivityCheck
+            ProvidedProperty(buildSprocName(sproc.Name.ProcName), resultType, GetterCode = (fun args -> <@@ (%%args.[0] : ISqlDataContext) @@>) ) 
             
         
         let rec walkSproc (path:string list) (containerType:ProvidedTypeDefinition option) (previousType:ProvidedTypeDefinition option) (createdTypes:Map<string list,ProvidedTypeDefinition>) (sproc:Sproc) =
@@ -364,8 +374,8 @@ type SqlTypeProvider(config: TypeProviderConfig) as this =
                      yield create3 :> MemberInfo } |> Seq.toList
                 )
 
-   
-                let prop = ProvidedProperty(SchemaProjections.buildTableName(ct.Name),ct, GetterCode = fun args -> <@@ ((%%args.[0] : obj) :?> ISqlDataContext).CreateEntities(key) @@> )
+                let buildTableName = SchemaProjections.buildTableName >> caseInsensitivityCheck
+                let prop = ProvidedProperty(buildTableName(ct.Name),ct, GetterCode = fun args -> <@@ ((%%args.[0] : obj) :?> ISqlDataContext).CreateEntities(key) @@> )
                 prop.AddXmlDoc (sprintf "<summary>%s</summary>" desc)
                 yield entityType :> MemberInfo
                 yield ct         :> MemberInfo                
@@ -428,6 +438,7 @@ type SqlTypeProvider(config: TypeProviderConfig) as this =
     let individualsAmount = ProvidedStaticParameter("IndividualsAmount",typeof<int>,1000)
     let owner = ProvidedStaticParameter("Owner", typeof<string>, "")    
     let resolutionPath = ProvidedStaticParameter("ResolutionPath",typeof<string>,"")    
+    let caseSensitivity = ProvidedStaticParameter("CaseSensitivity",typeof<CaseSensitivity>,CaseSensitivity.TOUPPER)
     let helpText = "<summary>Typed representation of a database</summary>
                     <param name='ConnectionString'>The connection string for the SQL database</param>
                     <param name='ConnectionStringName'>The connection string name to select from a configuration file</param>
@@ -435,9 +446,10 @@ type SqlTypeProvider(config: TypeProviderConfig) as this =
                     <param name='IndividualsAmount'>The amount of sample entities to project into the type system for each SQL entity type. Default 1000.</param>
                     <param name='UseOptionTypes'>If true, F# option types will be used in place of nullable database columns.  If false, you will always receive the default value of the column's type even if it is null in the database.</param>
                     <param name='ResolutionPath'>The location to look for dynamically loaded assemblies containing database vendor specific connections and custom types.</param>
-                    <param name='Owner'>The owner of the schema for this provider to resolve (Oracle Only)</param>"
+                    <param name='Owner'>The owner of the schema for this provider to resolve (Oracle Only)</param>
+                    <param name='CaseSensitivity'>Should we do ToUpper or ToLower when generating table names?</param>"
         
-    do paramSqlType.DefineStaticParameters([dbVendor;conString;connStringName;resolutionPath;individualsAmount;optionTypes;owner], fun typeName args -> 
+    do paramSqlType.DefineStaticParameters([dbVendor;conString;connStringName;resolutionPath;individualsAmount;optionTypes;owner;caseSensitivity], fun typeName args -> 
         createTypes(args.[1] :?> string,                  // ConnectionString URL
                     args.[2] :?> string,                  // ConnectionString Name
                     args.[0] :?> DatabaseProviderTypes,   // db vendor
@@ -445,6 +457,7 @@ type SqlTypeProvider(config: TypeProviderConfig) as this =
                     args.[4] :?> int,                     // Individuals Amount
                     args.[5] :?> bool,                    // Use option types?
                     args.[6] :?> string,                  // Schema owner currently only used for oracle
+                    args.[7] :?> CaseSensitivity,       // Should we do ToUpper or ToLower when generating table names?
                     typeName))
 
     do paramSqlType.AddXmlDoc helpText               

--- a/src/SQLProvider/SqlRuntime.Common.fs
+++ b/src/SQLProvider/SqlRuntime.Common.fs
@@ -19,6 +19,11 @@ type DatabaseProviderTypes =
     | MSACCESS = 5
     | ODBC = 6
 type RelationshipDirection = Children = 0 | Parents = 1 
+
+type CaseSensitivity =
+    | ORIGINAL = 0
+    | TOUPPER = 1
+    | TOLOWER = 2
     
 module public QueryEvents =
    let private expressionEvent = new Event<System.Linq.Expressions.Expression>()

--- a/src/SQLProvider/SqlRuntime.Common.fs
+++ b/src/SQLProvider/SqlRuntime.Common.fs
@@ -20,11 +20,11 @@ type DatabaseProviderTypes =
     | ODBC = 6
 type RelationshipDirection = Children = 0 | Parents = 1 
 
-type CaseSensitivity =
+type CaseSensitivityChange =
     | ORIGINAL = 0
     | TOUPPER = 1
     | TOLOWER = 2
-    
+
 module public QueryEvents =
    let private expressionEvent = new Event<System.Linq.Expressions.Expression>()
    let private sqlEvent = new Event<string>()
@@ -382,7 +382,7 @@ and internal ISqlProvider =
     /// to generate a cache of type mappings, and to set the three mapping function properties
     abstract CreateTypeMappings : IDbConnection -> Unit
     /// Queries the information schema and returns a list of table information
-    abstract GetTables  : IDbConnection -> Table list
+    abstract GetTables  : IDbConnection * CaseSensitivityChange -> Table list
     /// Queries the given table and returns a list of its columns
     /// this function should also populate a primary key cache for tables that
     /// have a single non-composite primary key

--- a/src/SQLProvider/SqlRuntime.DataContext.fs
+++ b/src/SQLProvider/SqlRuntime.DataContext.fs
@@ -23,7 +23,7 @@ module internal ProviderBuilder =
         | DatabaseProviderTypes.ODBC -> OdbcProvider(resolutionPath) :> ISqlProvider
         | _ -> failwith "Unsupported database provider" 
 
-type public SqlDataContext (typeName,connectionString:string,providerType,resolutionPath, referencedAssemblies, owner) =   
+type public SqlDataContext (typeName,connectionString:string,providerType,resolutionPath, referencedAssemblies, owner, caseSensitivity) =   
     let pendingChanges = HashSet<SqlEntity>()
     static let providerCache = Dictionary<string,ISqlProvider>()
     do
@@ -37,7 +37,7 @@ type public SqlDataContext (typeName,connectionString:string,providerType,resolu
                 // create type mappings and also trigger the table info read so the provider has 
                 // the minimum base set of data available
                 prov.CreateTypeMappings(con)
-                prov.GetTables(con) |> ignore
+                prov.GetTables(con,caseSensitivity) |> ignore
                 if (providerType.GetType() <> typeof<Providers.MSAccessProvider>) then con.Close()
                 providerCache.Add(typeName,prov))
 

--- a/src/SQLProvider/Utils.fs
+++ b/src/SQLProvider/Utils.fs
@@ -61,13 +61,27 @@ module ConfigHelpers =
             | None -> None
         else Some(connectionString)
 
+    let parseConnectionString conn =
+        let isMono = (Type.GetType "Mono.Runtime") <> null
+        let builder = System.Data.Common.DbConnectionStringBuilder()
+        builder.ConnectionString <- conn
+        match builder.ContainsKey "data source" with
+        | false -> conn
+        | true ->
+            let ds = builder.["data source"].ToString()
+            if isMono then
+                builder.["data source"] <- ds.Replace(@"\", "/")
+            else
+                builder.["data source"] <- ds.Replace("/", @"\")
+            builder.ConnectionString
+
 module internal SchemaProjections = 
     
-    let buildTableName (tableName:string) = tableName.Substring(0,tableName.LastIndexOf("]")+1).ToUpper()
+    let buildTableName (tableName:string) = tableName.Substring(0,tableName.LastIndexOf("]")+1)
 
-    let buildFieldName (fieldName:string) = fieldName.ToUpper()
+    let buildFieldName (fieldName:string) = fieldName
 
-    let buildSprocName (sprocName:string) = sprocName.ToUpper()
+    let buildSprocName (sprocName:string) = sprocName
 
 module internal Reflection = 
     

--- a/tests/SqlProvider.Tests/MSAccessTests.fsx
+++ b/tests/SqlProvider.Tests/MSAccessTests.fsx
@@ -1,4 +1,4 @@
-﻿#r @"C:\code_root\SQLProvider\bin\FSharp.Data.SQLProvider.dll"
+﻿#r @"..\..\bin\FSharp.Data.SQLProvider.dll"
 open System
 open System.Linq
 open FSharp.Data.Sql

--- a/tests/SqlProvider.Tests/MySqlTests.fsx
+++ b/tests/SqlProvider.Tests/MySqlTests.fsx
@@ -1,12 +1,12 @@
-﻿#r @"..\..\bin\FSharp.Data.SqlProvider.dll"
+﻿#r @"../../bin/FSharp.Data.SqlProvider.dll"
 
 open System
 open FSharp.Data.Sql
 
 [<Literal>]
-let connStr = "Server=MYSQL;Database=HR;Uid=admin;Pwd=password;"
+let connStr = "Server=localhost;Database=HR;Uid=admin;Pwd=password;"
 [<Literal>]
-let resolutionFolder = @"D:\Appdev\SqlProvider\tests\SqlProvider.Tests"
+let resolutionFolder = __SOURCE_DIRECTORY__
 FSharp.Data.Sql.Common.QueryEvents.SqlQueryEvent |> Event.add (printfn "Executing SQL: %s")
 
 let processId = System.Diagnostics.Process.GetCurrentProcess().Id;
@@ -64,7 +64,7 @@ let topSales5ByCommission =
     |> Seq.map (fun e -> e.MapTo<Employee>())
     |> Seq.toList
 
-#r @"..\..\packages\Newtonsoft.Json.6.0.3\lib\net45\Newtonsoft.Json.dll"
+#r @"../../packages/Newtonsoft.Json.6.0.3/lib/net45/Newtonsoft.Json.dll"
 
 open Newtonsoft.Json
 
@@ -98,14 +98,16 @@ let countries =
 
 //************************ CRUD *************************//
 
+let fetchAntartica () =
+    query {
+        for reg in ctx.``[HR].[REGIONS]`` do
+        where (reg.REGION_ID = 5u)
+        select reg
+    } |> Seq.toList
+
 
 let antartica =
-    let result =
-        query {
-            for reg in ctx.``[HR].[REGIONS]`` do
-            where (reg.REGION_ID = 5u)
-            select reg
-        } |> Seq.toList
+    let result = fetchAntartica ()
     match result with
     | [ant] -> ant
     | _ -> 
@@ -118,8 +120,12 @@ let antartica =
 antartica.REGION_NAME <- "ant"
 ctx.SubmitUpdates()
 
+let arctica2 = fetchAntartica () |> Seq.head
+if antartica.REGION_NAME <> arctica2.REGION_NAME then failwith "Update test fails!"
+
 antartica.Delete()
 ctx.SubmitUpdates()
+if fetchAntartica() |> Seq.length <> 0 then failwith "Delete test fails!"
 
 //********************** Procedures **************************//
 

--- a/tests/SqlProvider.Tests/SQLLiteTests.fsx
+++ b/tests/SqlProvider.Tests/SQLLiteTests.fsx
@@ -1,10 +1,11 @@
-﻿#r @"..\..\bin\FSharp.Data.SqlProvider.dll"
+﻿#I @"../../bin/"
+#r @"../../bin/FSharp.Data.SqlProvider.dll"
 
 open System
 open FSharp.Data.Sql
 
 [<Literal>]
-let connectionString = "Data Source=" + __SOURCE_DIRECTORY__ + @"\northwindEF.db;Version=3"
+let connectionString = "Data Source=" + __SOURCE_DIRECTORY__ + @"/northwindEF.db;Version=3"
 
 [<Literal>]
 let resolutionPath = __SOURCE_DIRECTORY__ 

--- a/tests/SqlProvider.Tests/SqlServerTests.fsx
+++ b/tests/SqlProvider.Tests/SqlServerTests.fsx
@@ -5,6 +5,8 @@ open FSharp.Data.Sql
 
 [<Literal>]
 let connStr = "Data Source=SQLSERVER;Initial Catalog=HR;User Id=sa;Password=password"
+//let connStr = "Data Source=localhost;Initial Catalog=HR; Integrated Security=True"
+
 [<Literal>]
 let resolutionFolder = __SOURCE_DIRECTORY__
 FSharp.Data.Sql.Common.QueryEvents.SqlQueryEvent |> Event.add (printfn "Executing SQL: %s")
@@ -122,14 +124,15 @@ let countries =
 
 //************************ CRUD *************************//
 
+let fetchAntartica () =
+    query {
+        for reg in ctx.``[DBO].[REGIONS]`` do
+        where (reg.REGION_ID = 5)
+        select reg
+    } |> Seq.toList
 
 let antartica =
-    let result =
-        query {
-            for reg in ctx.``[DBO].[REGIONS]`` do
-            where (reg.REGION_ID = 5)
-            select reg
-        } |> Seq.toList
+    let result = fetchAntartica ()
     match result with
     | [ant] -> ant
     | _ -> 
@@ -142,8 +145,12 @@ let antartica =
 antartica.REGION_NAME <- "ant"
 ctx.SubmitUpdates()
 
+let arctica2 = fetchAntartica () |> Seq.head
+if antartica.REGION_NAME <> arctica2.REGION_NAME then failwith "Update test fails!"
+
 antartica.Delete()
 ctx.SubmitUpdates()
+if fetchAntartica() |> Seq.length <> 0 then failwith "Delete test fails!"
 
 //********************** Procedures **************************//
 


### PR DESCRIPTION
The problem was these (PostgreSQL-changes, in src/SQLProvider/Utils.fs) to common code that it stored table name, column names and sporc names to .ToUpper() and the corresponding case conversion was not used when fetching the items by different providers (GetTables, GetColumns): case sensitive databases couldn't find tables corresponding tables from the schema and corresponding columns from the tables.

There may be a good reason to modify the schema and table names, so "case-sensitivity manually changed" is now one parameter to the GetTables. I don't see any reason to modify the column and sproc names to uppercase as they are read from the system data and used as they are. So I removed the upper case from buildFieldName method, but if that is really needed, then the GetColumns should also transfer this information to the database level.

That was the major change. Other minor modifications of these two commits:
 - There is now one more optional parameter to the constructor: do you want to cast table names to upper or lower case or leave them as original. Default is ToUpper, as it was the current functionality of this repo.
 - sp_MSforeachtable is the correct system procedure case in SQL-server
 - Added database creation script for MySQL/MariaDB for easier setup
 - Added resolution path display to the error messages that the database driver file was missing from a path.
 -  Corrected MySQL delete procedure parameter name
 - For Mono, if you are ever planning to run CI test with the SQLite, the connection string that tells the database should understand unix-path-delimiter (slash, not backslash). This is now fixed.
 - Some unit test had absolute paths to creator's hard drive, changed to `__SOURCE_DIRECTORY__`
 - Added Antarcitca-test to ensure that the modifications are committed to the database.

I have played with these: MS-SQL, SQLite, MySQL (on Windows and on Mono/Mac).
