### PR TITLE
Fix string type mapping for CLR types.

### DIFF
--- a/src/SQLProvider/Providers.Postgresql.fs
+++ b/src/SQLProvider/Providers.Postgresql.fs
@@ -157,7 +157,8 @@ module PostgreSQL =
             enumMappings @ [{ refCursor with ProviderTypeName = Some "SETOF refcursor" }]
 
         let adjustments =
-            [(typeof<System.DateTime>.ToString(),System.Data.DbType.Date) ]
+            [ (typeof<DateTime>.ToString(), DbType.Date)
+              (typeof<string>.ToString(), DbType.String) ]
             |> List.map (fun (``type``,dbType) -> ``type``,mappings |> List.find (fun mp -> mp.ClrType = ``type`` && mp.DbType = dbType))
 
         let clrMappings =

--- a/tests/SqlProvider.Tests/PostgreSQLTests.fsx
+++ b/tests/SqlProvider.Tests/PostgreSQLTests.fsx
@@ -23,24 +23,24 @@ type Employee = {
 }
 
 //***************** Individuals ***********************//
-let indv = ctx.``[PUBLIC].[EMPLOYEES]``.Individuals.``As FIRST_NAME``.``100, Steven``
+let indv = ctx.``[PUBLIC].[EMPLOYEES]``.Individuals.``As first_name``.``100, Steven``
 
-indv.FIRST_NAME + " " + indv.LAST_NAME + " " + indv.EMAIL
+indv.first_name + " " + indv.last_name + " " + indv.email
 
 
 //*************** QUERY ************************//
 let employeesFirstName = 
     query {
         for emp in ctx.``[PUBLIC].[EMPLOYEES]`` do
-        select (emp.FIRST_NAME, emp.LAST_NAME)
+        select (emp.first_name, emp.last_name)
     } |> Seq.toList
 
 let salesNamedDavid = 
     query {
             for emp in ctx.``[PUBLIC].[EMPLOYEES]`` do
-            join d in ctx.``[PUBLIC].[DEPARTMENTS]`` on (emp.DEPARTMENT_ID = d.DEPARTMENT_ID)
-            where (d.DEPARTMENT_NAME |=| [|"Sales";"IT"|] && emp.FIRST_NAME =% "David")
-            select (d.DEPARTMENT_NAME, emp.FIRST_NAME, emp.LAST_NAME)
+            join d in ctx.``[PUBLIC].[DEPARTMENTS]`` on (emp.department_id = d.department_id)
+            where (d.department_name |=| [|"Sales";"IT"|] && emp.first_name =% "David")
+            select (d.department_name, emp.first_name, emp.last_name)
             
     } |> Seq.toList
 
@@ -48,16 +48,16 @@ let employeesJob =
     query {
             for emp in ctx.``[PUBLIC].[EMPLOYEES]`` do
             for manager in emp.employees_manager_id_fkey do
-            join dept in ctx.``[PUBLIC].[DEPARTMENTS]`` on (emp.DEPARTMENT_ID = dept.DEPARTMENT_ID)
-            where ((dept.DEPARTMENT_NAME |=| [|"Sales";"Executive"|]) && emp.FIRST_NAME =% "David")
-            select (emp.FIRST_NAME, emp.LAST_NAME, manager.FIRST_NAME, manager.LAST_NAME )
+            join dept in ctx.``[PUBLIC].[DEPARTMENTS]`` on (emp.department_id = dept.department_id)
+            where ((dept.department_name |=| [|"Sales";"Executive"|]) && emp.first_name =% "David")
+            select (emp.first_name, emp.last_name, manager.first_name, manager.last_name )
     } |> Seq.toList
 
 //Can map SQLEntities to a domain type
 let topSales5ByCommission = 
     query {
         for emp in ctx.``[PUBLIC].[EMPLOYEES]`` do
-        sortByDescending emp.COMMISSION_PCT
+        sortByDescending emp.commission_pct
         select emp
         take 5
     } 
@@ -71,13 +71,13 @@ type Dummy<'t> = D of 't
 let employeesFirstName1 = 
     query {
         for emp in ctx.``[PUBLIC].[EMPLOYEES]`` do
-        select (D {First=emp.FIRST_NAME})
+        select (D {First=emp.first_name})
     } |> Seq.toList
 
 let employeesFirstName2 = 
     query {
         for emp in ctx.``[PUBLIC].[EMPLOYEES]`` do
-        select ({First=emp.FIRST_NAME} |> D)
+        select ({First=emp.first_name} |> D)
     } |> Seq.toList
 
 #r @"..\..\packages\Newtonsoft.Json.6.0.3\lib\net45\Newtonsoft.Json.dll"
@@ -119,19 +119,19 @@ let antartica =
     let result =
         query {
             for reg in ctx.``[PUBLIC].[REGIONS]`` do
-            where (reg.REGION_ID = 5)
+            where (reg.region_id = 5)
             select reg
         } |> Seq.toList
     match result with
     | [ant] -> ant
     | _ -> 
         let newRegion = ctx.``[PUBLIC].[REGIONS]``.Create() 
-        newRegion.REGION_NAME <- "Antartica"
-        newRegion.REGION_ID <- 5
+        newRegion.region_name <- "Antartica"
+        newRegion.region_id <- 5
         ctx.SubmitUpdates()
         newRegion
 
-antartica.REGION_NAME <- "ant"
+antartica.region_name <- "ant"
 ctx.SubmitUpdates()
 
 antartica.Delete()
@@ -141,19 +141,19 @@ ctx.SubmitUpdates()
 
 let removeIfExists employeeId startDate =
     let existing = query { for x in ctx.``[PUBLIC].[JOB_HISTORY]`` do
-                           where ((x.EMPLOYEE_ID = employeeId) && (x.START_DATE = startDate))
+                           where ((x.employee_id = employeeId) && (x.start_date = startDate))
                            headOrDefault }
     if existing <> null then
         existing.Delete()
         ctx.SubmitUpdates()
 
 removeIfExists 100 (DateTime(1993, 1, 13))
-ctx.Functions.ADD_JOB_HISTORY.Invoke(100, DateTime(1993, 1, 13), DateTime(1998, 7, 24), "IT_PROG", 60)
+ctx.Functions.add_job_history.Invoke(100, DateTime(1993, 1, 13), DateTime(1998, 7, 24), "IT_PROG", 60)
 
 //Support for sprocs that return ref cursors
 let employees =
     [
-      for e in ctx.Functions.GET_EMPLOYEES.Invoke().ReturnValue do
+      for e in ctx.Functions.get_employees.Invoke().ReturnValue do
         yield e.MapTo<Employee>()
     ]
 
@@ -165,7 +165,7 @@ type Region = {
 
 //Support for MARS procs
 let locations_and_regions =
-    let results = ctx.Functions.GET_LOCATIONS_AND_REGIONS.Invoke()
+    let results = ctx.Functions.get_locations_and_regions.Invoke()
     [
 //      for e in results.ReturnValue do
 //        yield e.ColumnValues |> Seq.toList |> box
@@ -177,7 +177,7 @@ let locations_and_regions =
 
 //Support for sprocs that return ref cursors and has in parameters
 let getemployees hireDate =
-    let results = (ctx.Functions.GET_EMPLOYEES_STARTING_AFTER.Invoke hireDate)
+    let results = (ctx.Functions.get_employees_starting_after.Invoke hireDate)
     [
       for e in results.ReturnValue do
         yield e.MapTo<Employee>()
@@ -187,4 +187,4 @@ getemployees (new System.DateTime(1999,4,1))
 
 //********************** Functions ***************************//
 
-let fullName = ctx.Functions.EMP_FULLNAME.Invoke(100).ReturnValue
+let fullName = ctx.Functions.emp_fullname.Invoke(100).ReturnValue


### PR DESCRIPTION
Npgsql 2.2 added many new types which were automatically picked up by type provider mappings, but since `Map.ofList` seems to select last occurring value when key value is same, the CLR mappings used Jsonb type as default type mapping for string type. That breaks type provider for postgresql almost completely.

This change makes postgres provider to prefer real string type instead of some other "weird" type the used version of Npgsql is offering.