### PR TITLE
Fix incorrect detection of array type in "IN" operator generation

### DIFF
--- a/src/SQLProvider/Providers.MSAccess.fs
+++ b/src/SQLProvider/Providers.MSAccess.fs
@@ -188,9 +188,9 @@ type internal MSAccessProvider() =
                         preds |> List.iteri( fun i (alias,col,operator,data) ->
                                 let extractData data = 
                                      match data with
-                                     | Some(x) when (box x :? string array) -> 
+                                     | Some(x) when (box x :? obj array) -> 
                                          // in and not in operators pass an array
-                                         let strings = box x :?> string array
+                                         let strings = box x :?> obj array
                                          strings |> Array.map createParam
                                      | Some(x) -> [|createParam (box x)|]
                                      | None ->    [|createParam DBNull.Value|]

--- a/src/SQLProvider/Providers.MsSqlServer.fs
+++ b/src/SQLProvider/Providers.MsSqlServer.fs
@@ -413,9 +413,9 @@ type internal MSSqlServerProvider() =
                         preds |> List.iteri( fun i (alias,col,operator,data) ->
                                 let extractData data = 
                                      match data with
-                                     | Some(x) when (box x :? System.Array) ->
+                                     | Some(x) when (box x :? obj array) ->
                                          // in and not in operators pass an array
-                                         let elements = box x :?> System.Array
+                                         let elements = box x :?> obj array
                                          Array.init (elements.Length) (fun i -> createParam (elements.GetValue(i)))
                                      | Some(x) -> [|createParam (box x)|]
                                      | None ->    [|createParam DBNull.Value|]

--- a/src/SQLProvider/Providers.MySql.fs
+++ b/src/SQLProvider/Providers.MySql.fs
@@ -429,9 +429,9 @@ type internal MySqlProvider(resolutionPath, owner, referencedAssemblies) as this
                         preds |> List.iteri( fun i (alias,col,operator,data) ->
                                 let extractData data = 
                                      match data with
-                                     | Some(x) when (box x :? System.Array) ->
+                                     | Some(x) when (box x :? obj array) ->
                                          // in and not in operators pass an array
-                                         let elements = box x :?> System.Array
+                                         let elements = box x :?> obj array
                                          Array.init (elements.Length) (fun i -> createParam (elements.GetValue(i)))
                                      | Some(x) -> [|createParam (box x)|]
                                      | None ->    [|createParam DBNull.Value|]

--- a/src/SQLProvider/Providers.Odbc.fs
+++ b/src/SQLProvider/Providers.Odbc.fs
@@ -158,9 +158,9 @@ type internal OdbcProvider(resolutionPath) =
                         preds |> List.iteri( fun i (alias,col,operator,data) ->
                                 let extractData data = 
                                      match data with
-                                     | Some(x) when (box x :? string array) -> 
+                                     | Some(x) when (box x :? obj array) -> 
                                          // in and not in operators pass an array
-                                         let strings = box x :?> string array
+                                         let strings = box x :?> obj array
                                          strings |> Array.map createParam
                                      | Some(x) -> [|createParam (box x)|]
                                      | None ->    [|createParam DBNull.Value|]

--- a/src/SQLProvider/Providers.Oracle.fs
+++ b/src/SQLProvider/Providers.Oracle.fs
@@ -445,9 +445,9 @@ type internal OracleProvider(resolutionPath, owner, referencedAssemblies) =
                         preds |> List.iteri( fun i (alias,col,operator,data) ->
                                 let extractData data = 
                                      match data with
-                                     | Some(x) when (box x :? System.Array) -> 
+                                     | Some(x) when (box x :? obj array) -> 
                                          // in and not in operators pass an array
-                                         let elements = box x :?> System.Array
+                                         let elements = box x :?> obj array
                                          Array.init (elements.Length) (fun i -> createParam (elements.GetValue(i)))
                                      | Some(x) -> [|createParam (box x)|]
                                      | None ->    [|createParam null|]

--- a/src/SQLProvider/Providers.Postgresql.fs
+++ b/src/SQLProvider/Providers.Postgresql.fs
@@ -526,7 +526,7 @@ type internal PostgresqlProvider(resolutionPath, owner, referencedAssemblies) as
                         preds |> List.iteri( fun i (alias,col,operator,data) ->
                                 let extractData data = 
                                      match data with
-                                     | Some(x) when box x :? string array || operator = FSharp.Data.Sql.In || operator = FSharp.Data.Sql.NotIn -> 
+                                     | Some(x) when box x :? obj array || operator = FSharp.Data.Sql.In || operator = FSharp.Data.Sql.NotIn -> 
                                          // in and not in operators pass an array
                                             (box x :?> obj []) |> Array.map createParam
                                      | Some(x) -> 

--- a/src/SQLProvider/Providers.SQLite.fs
+++ b/src/SQLProvider/Providers.SQLite.fs
@@ -222,9 +222,9 @@ type internal SQLiteProvider(resolutionPath, referencedAssemblies) as this =
                         preds |> List.iteri( fun i (alias,col,operator,data) ->
                                 let extractData data = 
                                      match data with
-                                     | Some(x) when (box x :? string array) -> 
+                                     | Some(x) when (box x :? obj array) -> 
                                          // in and not in operators pass an array
-                                         let strings = box x :?> string array
+                                         let strings = box x :?> obj array
                                          strings |> Array.map createParam
                                      | Some(x) -> [|createParam (box x)|]
                                      | None ->    [|createParam DBNull.Value|]


### PR DESCRIPTION
To detect arrays being passed to the IN and NOT IN operators, a runtime type check was performed against "string array", however what was probably changed in this [changeset](https://github.com/fsprojects/SQLProvider/commit/35df630919a662fe368b0768e1d93d78b4059a40) the array actually being passed is of type "obj array". This PR fixes this check for all supported databases (this has actually been fixed multiple times before for individual vendors, see [this](https://github.com/fsprojects/SQLProvider/commit/0f0e3a8a8a26567927b636d634e66e62d3e28ecc) and [this](https://github.com/fsprojects/SQLProvider/commit/f7d379bc2010dd431e7eff69b33406d8f7e9732b), but this PR fixes this in uniform way).