### PR TITLE
Use OUTPUT clause instead of SCOPE_IDENTITY

### DIFF
--- a/src/SQLProvider/Providers.MsSqlServer.fs
+++ b/src/SQLProvider/Providers.MsSqlServer.fs
@@ -580,9 +580,10 @@ type internal MSSqlServerProvider() =
                     |> Array.unzip
                 
                 sb.Clear() |> ignore
-                ~~(sprintf "INSERT INTO %s (%s) VALUES (%s); SELECT SCOPE_IDENTITY();" 
+                ~~(sprintf "INSERT INTO %s (%s) OUTPUT inserted.%s VALUES (%s);" 
                     entity.Table.FullName
                     (String.Join(",",columnNames))
+                    pk
                     (String.Join(",",values |> Array.map(fun p -> p.ParameterName))))
                 cmd.Parameters.AddRange(values)
                 cmd.CommandText <- sb.ToString()


### PR DESCRIPTION
I have a table with a uniqueidentifier as the primary key, along with a default constraint of NEWID().  I wanted that value back from an insert statement, but only IDENTITY columns are currently supported.   Using the [OUTPUT clause](https://msdn.microsoft.com/en-us/library/ms177564.aspx), I was able to get the new guid back.  Identity columns still work as expected, too.

This SQL is supported back to SQL 2005.