### PR TITLE
Wrap reflection calls with error handling.

### DIFF
--- a/src/SQLProvider/Providers.Postgresql.fs
+++ b/src/SQLProvider/Providers.Postgresql.fs
@@ -177,10 +177,18 @@ module PostgreSQL =
         findDbType <- dbMappings.TryFind
 
     let createConnection connectionString = 
-        Activator.CreateInstance(connectionType.Value,[|box connectionString|]) :?> IDbConnection
+        try
+            Activator.CreateInstance(connectionType.Value,[|box connectionString|]) :?> IDbConnection
+        with 
+          | :? System.Reflection.TargetInvocationException as e ->
+            failwithf "Could not create the connection, most likely this means that the connectionString is wrong. See error from Npgsql to troubleshoot: %s" e.InnerException.Message
 
     let createCommand commandText connection = 
-        Activator.CreateInstance(commandType.Value,[|box commandText;box connection|]) :?> IDbCommand
+        try
+            Activator.CreateInstance(commandType.Value,[|box commandText;box connection|]) :?> IDbCommand
+        with 
+          | :? System.Reflection.TargetInvocationException as e ->
+            failwithf "Could not create the command, error from Npgsql %s" e.InnerException.Message
 
     let createCommandParameter sprocCommand (param:QueryParameter) value =
         let mapping = if value <> null && (not sprocCommand) then (findClrType (value.GetType().ToString())) else None


### PR DESCRIPTION
This was an extremely time consuming bug to fix, it boiled down to an error in a connection string, 'user' instead of 'user id' was used , however due to how type providers must be created, the error was masked with simply 'Exception has been thrown by the target of an invocation' and no additional info.

I add on this exception handling to help get the inner exception message, which is far more revealing: the error message from the InnerException is: 'Keyword not supported: user'

Edit:merge messages