### PR TITLE
Update to support seperating owner with comma.

### DIFF
--- a/src/SQLProvider/Providers.Postgresql.fs
+++ b/src/SQLProvider/Providers.Postgresql.fs
@@ -10,7 +10,7 @@ open FSharp.Data.Sql.Common
 
 module PostgreSQL =
     let mutable resolutionPath = String.Empty
-    let mutable owner = "public"
+    let mutable owner = [| "public" |]
     let mutable referencedAssemblies = [| |]
 
     let assemblyNames = [
@@ -355,11 +355,31 @@ type internal PostgresqlProvider(resolutionPath, owner, referencedAssemblies) as
         member __.CreateTypeMappings(_) = PostgreSQL.createTypeMappings()
 
         member __.GetTables(con,cs) =
-            use reader = executeSql con (sprintf "SELECT  table_schema,
-                                                          table_name,
-                                                          table_type
-                                                    FROM  information_schema.tables
-                                                   WHERE  table_schema = '%s'" PostgreSQL.owner)
+
+            // for a list xs, glue together boolean OR queries.
+            let ptr column (xs:string []) = 
+                // don't to all the way to the end, we dont want a dangling OR
+                [ for i = 0 to Array.length xs - 2 do
+                    yield sprintf "%s = @p%d OR" column i
+                  // add the last one.
+                  yield sprintf "%s = @p%d;" column (Array.length xs - 1)
+                ] |> String.concat " "
+
+            let baseQuery = 
+              sprintf "SELECT  table_schema,
+                               table_name,
+                               table_type
+                        FROM   information_schema.tables
+                        WHERE  %s" (ptr "table_schema" PostgreSQL.owner)
+            
+            use command = PostgreSQL.createCommand baseQuery con
+
+            for i = 0 to PostgreSQL.owner.Length-1 do
+                let c = QueryParameter.Create(sprintf "@p%d" i,i) 
+                command.Parameters.Add ( PostgreSQL.createCommandParameter false c PostgreSQL.owner.[i] )
+                |> ignore
+          
+            use reader = command.ExecuteReader()
             [ while reader.Read() do
                 let table = { Schema = Sql.dbUnbox<string> reader.["table_schema"]
                               Name = Sql.dbUnbox<string> reader.["table_name"]

--- a/src/SQLProvider/Providers.Postgresql.fs
+++ b/src/SQLProvider/Providers.Postgresql.fs
@@ -341,7 +341,7 @@ type internal PostgresqlProvider(resolutionPath, owner, referencedAssemblies) as
         PostgreSQL.referencedAssemblies <- referencedAssemblies
 
         if not(String.IsNullOrEmpty owner) then
-            PostgreSQL.owner <- owner
+            PostgreSQL.owner <- Array.append PostgreSQL.owner (owner.Split ',')
 
     let executeSql (con:IDbConnection) sql =
         use com = (this:>ISqlProvider).CreateCommand(con,sql)


### PR DESCRIPTION
I have made this change in relation to tackling problems in #183. Note that the Oracle type provider also uses string array to hold the 'owner', so there may be an opportunity to make this more robust accross the multiple providers.

The reason to keep it as string is two fold, first, it is unweidly to provide a string list into the TP type constructor, I tried and failed. Second, this shouldn't break existing implementation for MySQL and Oracle (as I don't know what to do there).

One short coming of this is that it introduces inconsistency into the handling of 'owners', this needs peer review.