### PR TITLE
force nuget to version 2 to allow tavis\appveyor builds to succ

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -1,6 +1,6 @@
 source https://nuget.org/api/v2
 
-nuget Nuget.CommandLine
+nuget Nuget.CommandLine ~> 2
 nuget Newtonsoft.Json
 nuget NUnit
 nuget FAKE


### PR DESCRIPTION
@7sharp9 suggested fix, as Fake doesn't support nuget 3, 'paket is downloading nunit 3' 

For more info see 
https://github.com/fsprojects/ProjectScaffold/pull/216