### PR TITLE
Documentation formatting

### DIFF
--- a/docs/content/core/composable.fsx
+++ b/docs/content/core/composable.fsx
@@ -1,0 +1,4 @@
+(**
+# Composable Query
+Documentation stub.
+*)

--- a/docs/content/core/constraints-relationships.fsx
+++ b/docs/content/core/constraints-relationships.fsx
@@ -3,7 +3,7 @@
 (*** hide ***)
 #I "../../../bin"
 
-(*
+(**
 
 # Constraints & Relationships
 

--- a/docs/content/core/crud.fsx
+++ b/docs/content/core/crud.fsx
@@ -1,0 +1,4 @@
+(**
+# CRUD
+Documentation stub.
+*)

--- a/docs/content/core/general.fsx
+++ b/docs/content/core/general.fsx
@@ -23,12 +23,13 @@ connect to a variety of database sources in the IDE and explore them in a
 type-safe manner, without the inconvenience of a code-generation step.
 
 SQL Provider supports the following database types:
-    * [`mssql.html` file] MSSQL
-    * [`oracle.html` file] Oracle
-    * [`sqlite.html` file] SQLite
-    * [`postgresql.html` file] PostgreSQL
-    * [`mysql.html` file] MySQL
-    * [`odbc.html` file] ODBC (_Experimental_, only supports SELECT & MAKE)
+
+* [MSSQL](mssql.html) 
+* [Oracle](oracle.html) 
+* [SQLite](sqlite.heml) 
+* [PostgreSQL](postgresql.html)
+* [MySQL](mysql.html)
+* [ODBC](odbc.html) (_Experimental_, only supports SELECT & MAKE)
 
 After you have installed the nuget package or built the type provider assembly 
 from source, you should reference the assembly either as a project reference 
@@ -58,7 +59,10 @@ more detail about the available static parameters in other areas of the
 documentation.
 *)
 
-type sql = SqlDataProvider<Common.DatabaseProviderTypes.SQLITE, connectionString, ResolutionPath = resolutionPath, CaseSensitivityChange = Common.CaseSensitivityChange.ORIGINAL>
+type sql = SqlDataProvider<Common.DatabaseProviderTypes.SQLITE,
+                           connectionString,
+                           ResolutionPath = resolutionPath,
+                           CaseSensitivityChange = Common.CaseSensitivityChange.ORIGINAL>
 
 (** 
 Now we have a type ``sql`` that represents the SQLite database provided in 
@@ -92,7 +96,7 @@ Each property is correctly typed depending on the database column
 definitions.  In this example, ``firstCustomer.ContactName`` is a string.
 *)
 
-(*
+(**
 ## Constraints and Relationships 
 
 A typical relational database will have many connected tables and views 

--- a/docs/content/core/individuals.fsx
+++ b/docs/content/core/individuals.fsx
@@ -1,1 +1,4 @@
-﻿
+﻿(**
+# Individuals
+Documentation stub.
+*)

--- a/docs/content/core/mssql.fsx
+++ b/docs/content/core/mssql.fsx
@@ -10,7 +10,7 @@ let connectionString = "Data Source=" + __SOURCE_DIRECTORY__ + @"\northwindEF.db
 let resolutionPath = __SOURCE_DIRECTORY__ + @"..\..\..\files\sqlite"
 #r "FSharp.Data.SqlProvider.dll"
 open FSharp.Data.Sql
-(*
+(**
 
 
 # MSSQL

--- a/docs/content/core/programmability.fsx
+++ b/docs/content/core/programmability.fsx
@@ -1,0 +1,4 @@
+(**
+# Programmability
+Documentation stub.
+*)

--- a/docs/tools/templates/template.cshtml
+++ b/docs/tools/templates/template.cshtml
@@ -40,7 +40,7 @@
             <li class="divider"></li>
             <li><a href="@Properties["project-nuget"]">Get Library via NuGet</a></li>
             <li><a href="@Properties["project-github"]">Source Code on GitHub</a></li>
-            <li><a href="@Properties["project-github"]/blob/master/LICENSE.md">License</a></li>
+            <li><a href="@Properties["project-github"]/blob/master/LICENSE.txt">License</a></li>
             <li><a href="@Properties["project-github"]/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
             
         

--- a/docs/tools/templates/template.cshtml
+++ b/docs/tools/templates/template.cshtml
@@ -47,7 +47,7 @@
             <li class="nav-header">Documentation</li>
               <li><a href="@Root/core/general.html">General</a></li>
               <li><a href="@Root/core/parameters.html">Static Parameters</a></li>
-              <li><a href="@Root/core/querying.html"></a>Querying</li>
+              <li><a href="@Root/core/querying.html">Querying</a></li>
               <li><a href="@Root/core/constraints-relationships.html">Constraints & Relationships</a></li>
               <li><a href="@Root/core/crud.html">CRUD</a></li>
               <li><a href="@Root/core/programmability.html">Programmability</a></li>


### PR DESCRIPTION
This PR will close #201 completely. Two notable problems it fixes are:

1. FSharp.Formatting cannot process empty pages (and we still have some - e.g. `composable.fsx`, `crud.fsx`), so I had to fill them with some stub content.
2. `generate.fsx` was passing `"."` as the root directory to `Literate.ProcessDirectory`. That option was applied to every documentation page and caused troubles for pages inside of `core` subdirectory. I wrote a simple implementation of `getRelativePath` to solve this; now it passes proper relative paths.

   On the other hand, ProjectScaffold uses different strategy: it [defines a `root` variable](https://github.com/fsprojects/ProjectScaffold/blob/ab1dcfb302ad47b6bfd164197ad30a4503d76f2a/docs/tools/generate.template#L40-L46) pointing to file system or to web address depending on `RELEASE` preprocessor constant.

   I am not aware whether SQLProvider build process defines this `RELEASE` constant or not, and whether such change will have an impact on the documentation publication process, so I've decided to use safer option: implement my little `getRelativePath` and don't mess with the preprocessor. After all, if we can have one portable copy of documentation that can be deployed locally or to the website - why not have it?