### PR TITLE
Fixed casing of the project page url

### DIFF
--- a/SQLProvider.nuspec
+++ b/SQLProvider.nuspec
@@ -6,7 +6,7 @@
     <authors>@authors@</authors>
     <owners>@authors@</owners>
     <licenseUrl>http://github.com/fsprojects/SQLProvider/blob/master/LICENSE.md</licenseUrl>
-    <projectUrl>http://fsprojects.github.io/SqlProvider</projectUrl>
+    <projectUrl>http://fsprojects.github.io/SQLProvider</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <summary>@summary@</summary>
     <description>@description@</description>


### PR DESCRIPTION
Old - Doesn't work: http://fsprojects.github.io/SqlProvider
New - Does work: http://fsprojects.github.io/SQLProvider