### PR TITLE
Fix DateTime columns would loose the time part due to typemapping.

### DIFF
--- a/src/SQLProvider/Providers.Postgresql.fs
+++ b/src/SQLProvider/Providers.Postgresql.fs
@@ -161,7 +161,7 @@ module PostgreSQL =
             enumMappings @ [{ refCursor with ProviderTypeName = Some "SETOF refcursor" }]
 
         let adjustments =
-            [ (typeof<DateTime>.ToString(), DbType.Date)
+            [ (typeof<DateTime>.ToString(), DbType.DateTime)
               (typeof<string>.ToString(), DbType.String) ]
             |> List.map (fun (``type``,dbType) -> ``type``,mappings |> List.find (fun mp -> mp.ClrType = ``type`` && mp.DbType = dbType))
 


### PR DESCRIPTION
I'm not sure if this the correct way to fix it. At least for me it worked out quite well.

Since I have no idea why this type adjustment is present in the code it's hard to tell what it actually does. I think a comment at that line why it is present would put some light on the reader of the code.