### PR TITLE
Minor documentation tweaks.

### DIFF
--- a/docs/content/core/general.fsx
+++ b/docs/content/core/general.fsx
@@ -184,9 +184,9 @@ let explicitJoinQuery =
     |> Seq.toArray
 
 (**
-Both of these queries have identical results, it's just one requires explicit 
-knowledge of which tables join where and how, and the other doesn't.
-You might have noticed the select expression has now changed to (customer,order). 
+Both of these queries have identical results, the only difference is that one 
+requires explicit knowledge of which tables join where and how, and the other doesn't.
+You might have noticed the select expression has now changed to (customer, order). 
 As you may expect, this will return an array of tuples where the first item 
 is a ``[Main].[Customers]Entity`` and the second a ``[Main].[Orders]Entity``.
 Often you will not be interested in selecting entire entities from the database.

--- a/docs/content/core/parameters.fsx
+++ b/docs/content/core/parameters.fsx
@@ -64,7 +64,7 @@ let resolutionPath =
 ### IndividualsAmount
 
 Number of instances to retrieve when using the [individuals](core/individuals.html) feature.
-Defaults to 1000.
+Default is 1000.
 *)
 
 let indivAmt = 500

--- a/docs/content/core/postgresql.fsx
+++ b/docs/content/core/postgresql.fsx
@@ -22,7 +22,7 @@ open FSharp.Data.Sql
 
 Basic connection string used to connect to PostgreSQL instance; typical 
 connection strings for the driver apply here. See
-(PostgreSQL Connecting Strings Documentation)[https://github.com/npgsql/Npgsql/wiki/User-Manual]
+[PostgreSQL Connecting Strings Documentation](https://github.com/npgsql/Npgsql/wiki/User-Manual)
 for a complete list of connection string options.
 
 *)
@@ -63,7 +63,7 @@ let [<Literal>] resPath = @"C:\Projects\Libs\Npgsql\"
 (**
 ### IndividualsAmount
 
-Sets the count to load for each individual. See (individuals)[individuals.html] 
+Sets the count to load for each individual. See [individuals](individuals.html)
 for further info.
 
 *)
@@ -74,7 +74,7 @@ let [<Literal>] indivAmount = 1000
 ### UseOptionTypes
 
 If true, F# option types will be used in place of nullable database columns.  
-If false, you will always receive the default value of the column's type even 
+If false, you will always receive the default value of the column's type, even 
 if it is null in the database.
 
 *)

--- a/docs/content/core/querying.fsx
+++ b/docs/content/core/querying.fsx
@@ -25,7 +25,7 @@ type sql  = SqlDataProvider<
 let ctx = sql.GetDataContext()
 
 
-
+(**
 SQLProvider leverages F#'s `query {}` expression syntax to perform queries 
 against the database.  Though many are supported, not all LINQ expressions are.
 *)

--- a/docs/content/index.fsx
+++ b/docs/content/index.fsx
@@ -39,14 +39,14 @@ PostgreSQL is based on the .NET drivers found [here](http://npgsql.projects.pgfo
 
 MySQL is based on the .NET drivers found [here](http://dev.mysql.com/downloads/connector/net/1.0.html). You will need the correct version for your specific architecture and setup. You also need to specify ResolutionPath, which points to the folder containing the dll files for the MySQL driver.
 
-Oracle is based on the current release (12.1.0.1.2) of the managed ODP.NET driver found [here](http://www.oracle.com/technetwork/topics/dotnet/downloads/index.html). However although the managed version is recommended it should also work with previous versions of the native driver.
+Oracle is based on the current release (12.1.0.1.2) of the managed ODP.NET driver found [here](http://www.oracle.com/technetwork/topics/dotnet/downloads/index.html). However, although the managed version is recommended, it should also work with previous versions of the native driver.
 
 <div class="row">
   <div class="span1"></div>
   <div class="span6">
     <div class="well well-small" id="nuget">
       The library can be <a href="https://nuget.org/packages/SQLProvider">installed from NuGet</a>:
-      <pre>PM> Install-Package SQLProvider</pre>
+      <pre>PM> Install-Package SQLProvider -Pre</pre>
     </div>
   </div>
   <div class="span1"></div>
@@ -60,8 +60,6 @@ This example demonstrates the use of the SQL type provider:
 *)
 // reference the type provider dll
 #r "FSharp.Data.SQLProvider.dll"
-open System
-open System.Linq
 open FSharp.Data.Sql
 
 let [<Literal>] resolutionPath = __SOURCE_DIRECTORY__ + @"..\..\files\sqlite" 
@@ -90,7 +88,7 @@ let mattisOrderDetails =
             join od in ctx.Main.OrderDetails on (o.OrderId = od.OrderId)
             //  the (!!) operator will perform an outer join on a relationship
             for prod in (!!) od.``main.Products by ProductID`` do 
-            // nullable columns can be represented as option types. The following generates IS NOT NULL
+            // nullable columns can be represented as option types; the following generates IS NOT NULL
             where o.ShipCountry.IsSome                
             // standard operators will work as expected; the following shows the like operator and IN operator
             where (c.ContactName =% ("Matti%") && c.CompanyName |=| [|"Squirrelcomapny";"DaveCompant"|] )
@@ -118,7 +116,7 @@ The library comes with comprehensible documentation.
  * [API Reference](reference/index.html) contains automatically generated documentation for all types, modules
    and functions in the library. 
 
-Database vendor specific issues and considerations are documented on their seperate pages. Please see the menu on the right.
+Database vendor specific issues and considerations are documented on their separate pages. Please see the menu on the right.
  
 Contributing and copyright
 --------------------------

--- a/src/SQLProvider/Providers.MSAccess.fs
+++ b/src/SQLProvider/Providers.MSAccess.fs
@@ -248,7 +248,7 @@ type internal MSAccessProvider() =
                 |> List.iter(fun (fromAlias, data, destAlias)  ->
                     let joinType = if data.OuterJoin then "LEFT JOIN " else "INNER JOIN "
                     let destTable = getTable destAlias
-                    ~~  (sprintf "%s [%s] as %s on [%s].[%s] = [%s].[%s]"
+                    ~~  (sprintf "%s [%s] as [%s] on [%s].[%s] = [%s].[%s]"
                         joinType destTable.Name destAlias 
                         (if data.RelDirection = RelationshipDirection.Parents then fromAlias else destAlias)
                         data.ForeignKey  
@@ -270,7 +270,7 @@ type internal MSAccessProvider() =
             // FROM
             //add in 'numLinks' open parens, after FROM, closing each after each JOIN statement
             let numLinks = sqlQuery.Links.Length
-            ~~(sprintf "FROM %s%s as %s " (new String('(',numLinks)) baseTable.Name baseAlias)
+            ~~(sprintf "FROM %s[%s] as [%s] " (new String('(',numLinks)) baseTable.Name baseAlias)
             fromBuilder(numLinks)
             // WHERE
             if sqlQuery.Filters.Length > 0 then


### PR DESCRIPTION
Fixed misspelling.
Fixed some incorrectly formatted hyperlinks.
Fixed Nuget install instructions (added " -Pre")
A few other very minor tweaks to wording or punctuation.