### PR TITLE
Use lowest matching for FSharp.Core

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -4,7 +4,7 @@ source https://nuget.org/api/v2
 nuget Nuget.CommandLine ~> 2
 nuget FAKE
 nuget FSharp.Formatting
-nuget FSharp.Core = 3.1.2.1
+nuget FSharp.Core >= 3.1.2.1 lowest_matching:true, redirects:force
 nuget RazorEngine
 nuget NUnit = 2.6.4
 nuget NUnit.Runners = 2.6.4


### PR DESCRIPTION
fixes NuGet dependencies in generated package and still tests against that version