### PR TITLE
Ability to make asynchronous database operations. #163

### DIFF
--- a/docs/content/core/crud.fsx
+++ b/docs/content/core/crud.fsx
@@ -64,3 +64,9 @@ row.Delete()
 Submit updates to the database
 *)
 ctx.SubmitUpdates()
+
+(** 
+
+Support also async operations: ctx.SubmitUpdatesAsync() |> Async.StartAsTask
+
+*)

--- a/docs/content/core/general.fsx
+++ b/docs/content/core/general.fsx
@@ -134,6 +134,20 @@ let customersQuery =
     |> Seq.toArray
 
 (**
+
+Support also async queries
+
+ *)
+
+let customersQueryAsync = 
+    query { 
+        for customer in ctx.Main.Customers do
+            select customer
+    }
+    |> Seq.executeQueryAsync |> Async.StartAsTask
+
+
+(**
 The above example is identical to the query that was executed when 
 ``ctx.[main].[Customers] |> Seq.toArray`` was evaluated.
 

--- a/src/SQLProvider/Providers.MSAccess.fs
+++ b/src/SQLProvider/Providers.MSAccess.fs
@@ -60,6 +60,86 @@ type internal MSAccessProvider() =
         findDbType <- dbMappings.TryFind
         findDbTypeByEnum <- enumMappings.TryFind
     
+    let createInsertCommand (con:IDbConnection) (sb:Text.StringBuilder) (entity:SqlEntity) =     
+        let (~~) (t:string) = sb.Append t |> ignore
+        let cmd = new OleDbCommand()
+        cmd.Connection <- con :?> OleDbConnection
+        let pk = pkLookup.[entity.Table.FullName] 
+        let columnNames, values = 
+            (([],0),entity.ColumnValues)
+            ||> Seq.fold(fun (out,i) (k,v) ->
+                let name = sprintf "@param%i" i
+                let p = OleDbParameter(name,v)
+                (k,p)::out,i+1)
+            |> fun (x,_)-> x 
+            |> List.rev
+            |> List.toArray 
+            |> Array.unzip
+                
+        sb.Clear() |> ignore
+        ~~(sprintf "INSERT INTO [%s] (%s) VALUES (%s)"//; SELECT @@IDENTITY;" 
+            entity.Table.Name
+            (String.Join(",", columnNames))
+            (String.Join(",", values |> Array.map(fun p -> p.ParameterName))))
+        cmd.Parameters.AddRange(values)
+        cmd.CommandText <- sb.ToString()
+        cmd
+
+    let createUpdateCommand (con:IDbConnection) (sb:Text.StringBuilder) (entity:SqlEntity) changedColumns =
+        let (~~) (t:string) = sb.Append t |> ignore
+        let cmd = new OleDbCommand()
+        cmd.Connection <- con :?> OleDbConnection
+        let pk = pkLookup.[entity.Table.FullName] 
+        sb.Clear() |> ignore
+
+        if changedColumns |> List.exists ((=)pk) then failwith "Error - you cannot change the primary key of an entity."
+
+        let pkValue = 
+            match entity.GetColumnOption<obj> pk with
+            | Some v -> v
+            | None -> failwith "Error - you cannot update an entity that does not have a primary key."
+                
+        let data = 
+            (([],0),changedColumns)
+            ||> List.fold(fun (out,i) col ->                                                         
+                let name = sprintf "@param%i" i
+                let p = 
+                    match entity.GetColumnOption<obj> col with
+                    | Some v -> OleDbParameter(name,v)
+                    | None -> OleDbParameter(name,DBNull.Value)
+                (col,p)::out,i+1)
+            |> fun (x,_)-> x 
+            |> List.rev
+            |> List.toArray 
+                
+        let pkParam = OleDbParameter("@pk", pkValue)
+
+        ~~(sprintf "UPDATE [%s] SET %s WHERE %s = @pk;" 
+            entity.Table.Name
+            (String.Join(",", data |> Array.map(fun (c,p) -> sprintf "%s = %s" c p.ParameterName ) ))
+            pk)
+
+        cmd.Parameters.AddRange(data |> Array.map snd)
+        cmd.Parameters.Add pkParam |> ignore
+        cmd.CommandText <- sb.ToString()
+        cmd
+            
+    let createDeleteCommand (con:IDbConnection) (sb:Text.StringBuilder) (entity:SqlEntity) =
+        let (~~) (t:string) = sb.Append t |> ignore
+        let cmd = new OleDbCommand()
+        cmd.Connection <- con :?> OleDbConnection
+        sb.Clear() |> ignore
+        let pk = pkLookup.[entity.Table.FullName] 
+        sb.Clear() |> ignore
+        let pkValue = 
+            match entity.GetColumnOption<obj> pk with
+            | Some v -> v
+            | None -> failwith "Error - you cannot delete an entity that does not have a primary key."
+        cmd.Parameters.AddWithValue("@id",pkValue) |> ignore
+        ~~(sprintf "DELETE FROM [%s] WHERE %s = @id" entity.Table.Name pk )
+        cmd.CommandText <- sb.ToString()
+        cmd
+
     interface ISqlProvider with
         member __.CreateConnection(connectionString) = upcast new OleDbConnection(connectionString)
         member __.CreateCommand(connection,commandText) = upcast new OleDbCommand(commandText,connection:?>OleDbConnection)
@@ -292,7 +372,7 @@ type internal MSAccessProvider() =
     
         member this.ProcessUpdates(con, entities) =
             let sb = Text.StringBuilder()
-            let (~~) (t:string) = sb.Append t |> ignore
+
             entities |> List.iter (fun e -> printfn "entity - %A" e.ColumnValues)
             // ensure columns have been loaded
             entities |> List.map(fun e -> e.Table) 
@@ -301,82 +381,6 @@ type internal MSAccessProvider() =
 
             if con.State = ConnectionState.Closed then con.Open()
 
-            let createInsertCommand (entity:SqlEntity) =     
-                let cmd = new OleDbCommand()
-                cmd.Connection <- con :?> OleDbConnection
-                let pk = pkLookup.[entity.Table.FullName] 
-                let columnNames, values = 
-                    (([],0),entity.ColumnValues)
-                    ||> Seq.fold(fun (out,i) (k,v) ->
-                        let name = sprintf "@param%i" i
-                        let p = OleDbParameter(name,v)
-                        (k,p)::out,i+1)
-                    |> fun (x,_)-> x 
-                    |> List.rev
-                    |> List.toArray 
-                    |> Array.unzip
-                
-                sb.Clear() |> ignore
-                ~~(sprintf "INSERT INTO [%s] (%s) VALUES (%s)"//; SELECT @@IDENTITY;" 
-                    entity.Table.Name
-                    (String.Join(",", columnNames))
-                    (String.Join(",", values |> Array.map(fun p -> p.ParameterName))))
-                cmd.Parameters.AddRange(values)
-                cmd.CommandText <- sb.ToString()
-                cmd
-
-            let createUpdateCommand (entity:SqlEntity) changedColumns =
-                let cmd = new OleDbCommand()
-                cmd.Connection <- con :?> OleDbConnection
-                let pk = pkLookup.[entity.Table.FullName] 
-                sb.Clear() |> ignore
-
-                if changedColumns |> List.exists ((=)pk) then failwith "Error - you cannot change the primary key of an entity."
-
-                let pkValue = 
-                    match entity.GetColumnOption<obj> pk with
-                    | Some v -> v
-                    | None -> failwith "Error - you cannot update an entity that does not have a primary key."
-                
-                let data = 
-                    (([],0),changedColumns)
-                    ||> List.fold(fun (out,i) col ->                                                         
-                        let name = sprintf "@param%i" i
-                        let p = 
-                            match entity.GetColumnOption<obj> col with
-                            | Some v -> OleDbParameter(name,v)
-                            | None -> OleDbParameter(name,DBNull.Value)
-                        (col,p)::out,i+1)
-                    |> fun (x,_)-> x 
-                    |> List.rev
-                    |> List.toArray 
-                
-                let pkParam = OleDbParameter("@pk", pkValue)
-
-                ~~(sprintf "UPDATE [%s] SET %s WHERE %s = @pk;" 
-                    entity.Table.Name
-                    (String.Join(",", data |> Array.map(fun (c,p) -> sprintf "%s = %s" c p.ParameterName ) ))
-                    pk)
-
-                cmd.Parameters.AddRange(data |> Array.map snd)
-                cmd.Parameters.Add pkParam |> ignore
-                cmd.CommandText <- sb.ToString()
-                cmd
-            
-            let createDeleteCommand (entity:SqlEntity) =
-                let cmd = new OleDbCommand()
-                cmd.Connection <- con :?> OleDbConnection
-                sb.Clear() |> ignore
-                let pk = pkLookup.[entity.Table.FullName] 
-                sb.Clear() |> ignore
-                let pkValue = 
-                    match entity.GetColumnOption<obj> pk with
-                    | Some v -> v
-                    | None -> failwith "Error - you cannot delete an entity that does not have a primary key."
-                cmd.Parameters.AddWithValue("@id",pkValue) |> ignore
-                ~~(sprintf "DELETE FROM [%s] WHERE %s = @id" entity.Table.Name pk )
-                cmd.CommandText <- sb.ToString()
-                cmd
             try
                 // close the connection first otherwise it won't get enlisted into the transaction 
                 if con.State = ConnectionState.Open then con.Close()
@@ -388,7 +392,7 @@ type internal MSAccessProvider() =
                     |> List.iter(fun e -> 
                         match e._State with
                         | Created -> 
-                            let cmd = createInsertCommand e
+                            let cmd = createInsertCommand con sb e
                             cmd.Transaction <- trnsx :?> OleDbTransaction
                             Common.QueryEvents.PublishSqlQuery cmd.CommandText
                             let id = cmd.ExecuteScalar()
@@ -399,13 +403,13 @@ type internal MSAccessProvider() =
                             | None ->  e.SetColumnSilent(pkLookup.[e.Table.FullName], id)
                             e._State <- Unchanged
                         | Modified fields -> 
-                            let cmd = createUpdateCommand e fields
+                            let cmd = createUpdateCommand con sb e fields
                             cmd.Transaction <- trnsx :?> OleDbTransaction
                             Common.QueryEvents.PublishSqlQuery cmd.CommandText
                             cmd.ExecuteNonQuery() |> ignore
                             e._State <- Unchanged
                         | Deleted -> 
-                            let cmd = createDeleteCommand e
+                            let cmd = createDeleteCommand con sb e
                             cmd.Transaction <- trnsx :?> OleDbTransaction
                             Common.QueryEvents.PublishSqlQuery cmd.CommandText
                             cmd.ExecuteNonQuery() |> ignore
@@ -415,5 +419,72 @@ type internal MSAccessProvider() =
                     trnsx.Commit()
                 with 
                 |e -> trnsx.Rollback()
+            finally
+                con.Close()
+
+        member this.ProcessUpdatesAsync(con, entities) =
+            let sb = Text.StringBuilder()
+
+            entities |> List.iter (fun e -> printfn "entity - %A" e.ColumnValues)
+            // ensure columns have been loaded
+            entities |> List.map(fun e -> e.Table) 
+                     |> Seq.distinct 
+                     |> Seq.iter(fun t -> (this :> ISqlProvider).GetColumns(con,t) |> ignore )
+
+            if con.State = ConnectionState.Closed then con.Open()
+
+            use scope = new Transactions.TransactionScope(Transactions.TransactionScopeAsyncFlowOption.Enabled)
+            try
+                // close the connection first otherwise it won't get enlisted into the transaction 
+                if con.State = ConnectionState.Open then con.Close()
+                con.Open()
+                use trnsx = con.BeginTransaction()
+                try                
+                    // initially supporting update/create/delete of single entities, no hierarchies yet
+                    let handleEntity (e: SqlEntity) =
+                        match e._State with
+                        | Created -> 
+                            async {
+                                let cmd = createInsertCommand con sb e
+                                cmd.Transaction <- trnsx :?> OleDbTransaction
+                                Common.QueryEvents.PublishSqlQuery cmd.CommandText
+                                let id = cmd.ExecuteScalarAsync()
+                                match e.GetColumnOption pkLookup.[e.Table.FullName] with
+                                | Some v -> () // if the primary key exists, do nothing
+                                               // this is because non-identity columns will have been set 
+                                               // manually and in that case scope_identity would bring back 0 "" or whatever
+                                | None ->  e.SetColumnSilent(pkLookup.[e.Table.FullName], id)
+                                e._State <- Unchanged
+                            }
+                        | Modified fields -> 
+                            async {
+                                let cmd = createUpdateCommand con sb e fields
+                                cmd.Transaction <- trnsx :?> OleDbTransaction
+                                Common.QueryEvents.PublishSqlQuery cmd.CommandText
+                                cmd.ExecuteNonQuery() |> ignore
+                                e._State <- Unchanged
+                            }
+                        | Deleted -> 
+                            async {
+                                let cmd = createDeleteCommand con sb e
+                                cmd.Transaction <- trnsx :?> OleDbTransaction
+                                Common.QueryEvents.PublishSqlQuery cmd.CommandText
+                                cmd.ExecuteNonQuery() |> ignore
+                                // remove the pk to prevent this attempting to be used again
+                                e.SetColumnOptionSilent(pkLookup.[e.Table.FullName], None)
+                            }
+                        | Unchanged -> failwith "Unchanged entity encountered in update list - this should not be possible!"
+
+                    async { 
+                        do! Utilities.execiuteOneByOne handleEntity entities
+                        trnsx.Commit()
+                        scope.Complete()
+                    }
+
+                with 
+                |e -> 
+                    async {
+                        trnsx.Rollback()
+                    }
             finally
                 con.Close()

--- a/src/SQLProvider/Providers.MSAccess.fs
+++ b/src/SQLProvider/Providers.MSAccess.fs
@@ -431,7 +431,7 @@ type internal MSAccessProvider() =
                      |> Seq.distinct 
                      |> Seq.iter(fun t -> (this :> ISqlProvider).GetColumns(con,t) |> ignore )
 
-            use scope = new Transactions.TransactionScope(Transactions.TransactionScopeAsyncFlowOption.Enabled)
+            use scope = Utilities.ensureTransaction()
             try
                 // close the connection first otherwise it won't get enlisted into the transaction 
                 if con.State = ConnectionState.Open then con.Close()

--- a/src/SQLProvider/Providers.MsSqlServer.fs
+++ b/src/SQLProvider/Providers.MsSqlServer.fs
@@ -274,12 +274,96 @@ module MSSqlServer =
         | cols -> 
             use reader = com.ExecuteReader() :?> SqlDataReader
             Set(cols |> Array.map (processReturnColumn reader))
-                          
+   
 type internal MSSqlServerProvider() =
     let pkLookup =     Dictionary<string,string>()
     let tableLookup =  Dictionary<string,Table>()
     let columnLookup = Dictionary<string,Column list>()
     let relationshipLookup = Dictionary<string,Relationship list * Relationship list>()
+
+    let createInsertCommand (con:IDbConnection) (sb:Text.StringBuilder) (entity:SqlEntity) =     
+        let (~~) (t:string) = sb.Append t |> ignore
+
+        let cmd = new SqlCommand()
+        cmd.Connection <- con :?> SqlConnection
+        let pk = pkLookup.[entity.Table.FullName] 
+        let columnNames, values = 
+            (([],0),entity.ColumnValues)
+            ||> Seq.fold(fun (out,i) (k,v) ->
+                let name = sprintf "@param%i" i
+                let p = SqlParameter(name,v)
+                (k,p)::out,i+1)
+            |> fun (x,_)-> x 
+            |> List.rev
+            |> List.toArray 
+            |> Array.unzip
+                
+        sb.Clear() |> ignore
+        ~~(sprintf "INSERT INTO %s (%s) OUTPUT inserted.%s VALUES (%s);" 
+            entity.Table.FullName
+            (String.Join(",",columnNames))
+            pk
+            (String.Join(",",values |> Array.map(fun p -> p.ParameterName))))
+        cmd.Parameters.AddRange(values)
+        cmd.CommandText <- sb.ToString()
+        cmd
+
+    let createUpdateCommand (con:IDbConnection) (sb:Text.StringBuilder) (entity:SqlEntity) changedColumns =
+        let (~~) (t:string) = sb.Append t |> ignore
+
+        let cmd = new SqlCommand()
+        cmd.Connection <- con :?> SqlConnection
+        let pk = pkLookup.[entity.Table.FullName] 
+        sb.Clear() |> ignore
+
+        if changedColumns |> List.exists ((=)pk) then failwith "Error - you cannot change the primary key of an entity."
+
+        let pkValue = 
+            match entity.GetColumnOption<obj> pk with
+            | Some v -> v
+            | None -> failwith "Error - you cannot update an entity that does not have a primary key."
+                
+        let data = 
+            (([],0),changedColumns)
+            ||> List.fold(fun (out,i) col ->                                                         
+                let name = sprintf "@param%i" i
+                let p = 
+                    match entity.GetColumnOption<obj> col with
+                    | Some v -> SqlParameter(name,v)
+                    | None -> SqlParameter(name,DBNull.Value)
+                (col,p)::out,i+1)
+            |> fun (x,_)-> x 
+            |> List.rev
+            |> List.toArray 
+                
+        let pkParam = SqlParameter("@pk", pkValue)
+
+        ~~(sprintf "UPDATE %s SET %s WHERE %s = @pk;" 
+            entity.Table.FullName
+            (String.Join(",", data |> Array.map(fun (c,p) -> sprintf "%s = %s" c p.ParameterName ) ))
+            pk)
+
+        cmd.Parameters.AddRange(data |> Array.map snd)
+        cmd.Parameters.Add pkParam |> ignore
+        cmd.CommandText <- sb.ToString()
+        cmd
+            
+    let createDeleteCommand (con:IDbConnection) (sb:Text.StringBuilder) (entity:SqlEntity) =
+        let (~~) (t:string) = sb.Append t |> ignore
+
+        let cmd = new SqlCommand()
+        cmd.Connection <- con :?> SqlConnection
+        sb.Clear() |> ignore
+        let pk = pkLookup.[entity.Table.FullName] 
+        sb.Clear() |> ignore
+        let pkValue = 
+            match entity.GetColumnOption<obj> pk with
+            | Some v -> v
+            | None -> failwith "Error - you cannot delete an entity that does not have a primary key."
+        cmd.Parameters.AddWithValue("@id",pkValue) |> ignore
+        ~~(sprintf "DELETE FROM %s WHERE %s = @id" entity.Table.FullName pk )
+        cmd.CommandText <- sb.ToString()
+        cmd
 
     interface ISqlProvider with
         member __.CreateConnection(connectionString) = MSSqlServer.createConnection connectionString
@@ -553,96 +637,15 @@ type internal MSSqlServerProvider() =
             let sql = sb.ToString()
             (sql,parameters)
 
-        member this.ProcessUpdates(con, entities) =            
+        member this.ProcessUpdates(con, entities) =       
             let sb = Text.StringBuilder()
-            let (~~) (t:string) = sb.Append t |> ignore
-
+             
             // ensure columns have been loaded
             entities |> List.map(fun e -> e.Table) 
                      |> Seq.distinct 
                      |> Seq.iter(fun t -> (this :> ISqlProvider).GetColumns(con,t) |> ignore )
 
-            con.Open()
-
-            let createInsertCommand (entity:SqlEntity) =     
-                let cmd = new SqlCommand()
-                cmd.Connection <- con :?> SqlConnection
-                let pk = pkLookup.[entity.Table.FullName] 
-                let columnNames, values = 
-                    (([],0),entity.ColumnValues)
-                    ||> Seq.fold(fun (out,i) (k,v) ->
-                        let name = sprintf "@param%i" i
-                        let p = SqlParameter(name,v)
-                        (k,p)::out,i+1)
-                    |> fun (x,_)-> x 
-                    |> List.rev
-                    |> List.toArray 
-                    |> Array.unzip
-                
-                sb.Clear() |> ignore
-                ~~(sprintf "INSERT INTO %s (%s) OUTPUT inserted.%s VALUES (%s);" 
-                    entity.Table.FullName
-                    (String.Join(",",columnNames))
-                    pk
-                    (String.Join(",",values |> Array.map(fun p -> p.ParameterName))))
-                cmd.Parameters.AddRange(values)
-                cmd.CommandText <- sb.ToString()
-                cmd
-
-            let createUpdateCommand (entity:SqlEntity) changedColumns =
-                let cmd = new SqlCommand()
-                cmd.Connection <- con :?> SqlConnection
-                let pk = pkLookup.[entity.Table.FullName] 
-                sb.Clear() |> ignore
-
-                if changedColumns |> List.exists ((=)pk) then failwith "Error - you cannot change the primary key of an entity."
-
-                let pkValue = 
-                    match entity.GetColumnOption<obj> pk with
-                    | Some v -> v
-                    | None -> failwith "Error - you cannot update an entity that does not have a primary key."
-                
-                let data = 
-                    (([],0),changedColumns)
-                    ||> List.fold(fun (out,i) col ->                                                         
-                        let name = sprintf "@param%i" i
-                        let p = 
-                            match entity.GetColumnOption<obj> col with
-                            | Some v -> SqlParameter(name,v)
-                            | None -> SqlParameter(name,DBNull.Value)
-                        (col,p)::out,i+1)
-                    |> fun (x,_)-> x 
-                    |> List.rev
-                    |> List.toArray 
-                
-                let pkParam = SqlParameter("@pk", pkValue)
-
-                ~~(sprintf "UPDATE %s SET %s WHERE %s = @pk;" 
-                    entity.Table.FullName
-                    (String.Join(",", data |> Array.map(fun (c,p) -> sprintf "%s = %s" c p.ParameterName ) ))
-                    pk)
-
-                cmd.Parameters.AddRange(data |> Array.map snd)
-                cmd.Parameters.Add pkParam |> ignore
-                cmd.CommandText <- sb.ToString()
-                cmd
-            
-            let createDeleteCommand (entity:SqlEntity) =
-                let cmd = new SqlCommand()
-                cmd.Connection <- con :?> SqlConnection
-                sb.Clear() |> ignore
-                let pk = pkLookup.[entity.Table.FullName] 
-                sb.Clear() |> ignore
-                let pkValue = 
-                    match entity.GetColumnOption<obj> pk with
-                    | Some v -> v
-                    | None -> failwith "Error - you cannot delete an entity that does not have a primary key."
-                cmd.Parameters.AddWithValue("@id",pkValue) |> ignore
-                ~~(sprintf "DELETE FROM %s WHERE %s = @id" entity.Table.FullName pk )
-                cmd.CommandText <- sb.ToString()
-                cmd
-
-            use scope = new Transactions.TransactionScope()
+            use scope = new Transactions.TransactionScope(Transactions.TransactionScopeAsyncFlowOption.Enabled)
             try                
                 // close the connection first otherwise it won't get enlisted into the transaction 
                 if con.State = ConnectionState.Open then con.Close()
@@ -652,7 +655,7 @@ type internal MSSqlServerProvider() =
                 |> List.iter(fun e -> 
                     match e._State with
                     | Created -> 
-                        let cmd = createInsertCommand e
+                        let cmd = createInsertCommand con sb e
                         Common.QueryEvents.PublishSqlQuery cmd.CommandText
                         let id = cmd.ExecuteScalar()
                         match e.GetColumnOption pkLookup.[e.Table.FullName] with
@@ -662,12 +665,12 @@ type internal MSSqlServerProvider() =
                         | None ->  e.SetColumnSilent(pkLookup.[e.Table.FullName], id)
                         e._State <- Unchanged
                     | Modified fields -> 
-                        let cmd = createUpdateCommand e fields
+                        let cmd = createUpdateCommand con sb e fields
                         Common.QueryEvents.PublishSqlQuery cmd.CommandText
                         cmd.ExecuteNonQuery() |> ignore
                         e._State <- Unchanged
                     | Deleted -> 
-                        let cmd = createDeleteCommand e
+                        let cmd = createDeleteCommand con sb e
                         Common.QueryEvents.PublishSqlQuery cmd.CommandText
                         cmd.ExecuteNonQuery() |> ignore
                         // remove the pk to prevent this attempting to be used again
@@ -677,3 +680,58 @@ type internal MSSqlServerProvider() =
                 
             finally
                 con.Close()
+            
+
+        member this.ProcessUpdatesAsync(con, entities) = 
+            
+            let sb = Text.StringBuilder()
+             
+            // ensure columns have been loaded
+            entities |> List.map(fun e -> e.Table) 
+                     |> Seq.distinct 
+                     |> Seq.iter(fun t -> (this :> ISqlProvider).GetColumns(con,t) |> ignore )
+
+            use scope = new Transactions.TransactionScope(Transactions.TransactionScopeAsyncFlowOption.Enabled)
+            try                
+                // close the connection first otherwise it won't get enlisted into the transaction 
+                if con.State = ConnectionState.Open then con.Close()
+                con.Open()         
+                // initially supporting update/create/delete of single entities, no hierarchies yet
+                let handleEntity (e: SqlEntity) =
+                    match e._State with
+                    | Created -> 
+                        async {
+                            let cmd = createInsertCommand con sb e
+                            Common.QueryEvents.PublishSqlQuery cmd.CommandText
+                            let! id = cmd.ExecuteScalarAsync() |> Async.AwaitTask
+                            match e.GetColumnOption pkLookup.[e.Table.FullName] with
+                            | Some v -> () // if the primary key exists, do nothing
+                                           // this is because non-identity columns will have been set 
+                                           // manually and in that case scope_identity would bring back 0 "" or whatever
+                            | None ->  e.SetColumnSilent(pkLookup.[e.Table.FullName], id)
+                            e._State <- Unchanged
+                        }
+                    | Modified fields -> 
+                        async {
+                            let cmd = createUpdateCommand con sb e fields
+                            Common.QueryEvents.PublishSqlQuery cmd.CommandText
+                            do! cmd.ExecuteNonQueryAsync() |> Async.AwaitTask |> Async.Ignore
+                            e._State <- Unchanged
+                        }
+                    | Deleted -> 
+                        async {
+                            let cmd = createDeleteCommand con sb e
+                            Common.QueryEvents.PublishSqlQuery cmd.CommandText
+                            do! cmd.ExecuteNonQueryAsync() |> Async.AwaitTask |> Async.Ignore
+                            // remove the pk to prevent this attempting to be used again
+                            e.SetColumnOptionSilent(pkLookup.[e.Table.FullName], None)
+                        }
+                    | Unchanged -> failwith "Unchanged entity encountered in update list - this should not be possible!"
+
+                async { 
+                    do! Utilities.execiuteOneByOne handleEntity entities
+                    scope.Complete()
+                }
+            finally
+                con.Close()
+

--- a/src/SQLProvider/Providers.MsSqlServer.fs
+++ b/src/SQLProvider/Providers.MsSqlServer.fs
@@ -645,7 +645,7 @@ type internal MSSqlServerProvider() =
                      |> Seq.distinct 
                      |> Seq.iter(fun t -> (this :> ISqlProvider).GetColumns(con,t) |> ignore )
 
-            use scope = new Transactions.TransactionScope(Transactions.TransactionScopeAsyncFlowOption.Enabled)
+            use scope = Utilities.ensureTransaction()
             try                
                 // close the connection first otherwise it won't get enlisted into the transaction 
                 if con.State = ConnectionState.Open then con.Close()
@@ -693,7 +693,7 @@ type internal MSSqlServerProvider() =
 
             async { 
 
-                use scope = new Transactions.TransactionScope(Transactions.TransactionScopeAsyncFlowOption.Enabled)
+                use scope = Utilities.ensureTransaction()
                 try                
                     // close the connection first otherwise it won't get enlisted into the transaction 
                     if con.State = ConnectionState.Open then con.Close()

--- a/src/SQLProvider/Providers.MySql.fs
+++ b/src/SQLProvider/Providers.MySql.fs
@@ -238,6 +238,89 @@ type internal MySqlProvider(resolutionPath, owner, referencedAssemblies) as this
     let columnLookup = Dictionary<string,Column list>()
     let relationshipLookup = Dictionary<string,Relationship list * Relationship list>()
 
+    let createInsertCommand (con:IDbConnection) (sb:Text.StringBuilder) (entity:SqlEntity) =                 
+        let (~~) (t:string) = sb.Append t |> ignore
+        let cmd = (this :> ISqlProvider).CreateCommand(con,"")
+        cmd.Connection <- con 
+        let pk = pkLookup.[entity.Table.FullName] 
+        let columnNames, values = 
+            (([],0),entity.ColumnValues)
+            ||> Seq.fold(fun (out,i) (k,v) -> 
+                let name = sprintf "@param%i" i
+                let p = (this :> ISqlProvider).CreateCommandParameter(QueryParameter.Create(name, i),v)
+                (k,p)::out,i+1)
+            |> fun (x,_)-> x 
+            |> List.rev
+            |> List.toArray 
+            |> Array.unzip
+                
+        sb.Clear() |> ignore
+        ~~(sprintf "INSERT INTO %s (%s) VALUES (%s); SELECT LAST_INSERT_ID();" 
+            (entity.Table.FullName.Replace("[","`").Replace("]","`"))
+            (String.Join(",",columnNames))
+            (String.Join(",",values |> Array.map(fun p -> p.ParameterName))))
+                
+        values |> Array.iter (cmd.Parameters.Add >> ignore)
+        cmd.CommandText <- sb.ToString()
+        cmd
+
+    let createUpdateCommand (con:IDbConnection) (sb:Text.StringBuilder) (entity:SqlEntity) changedColumns =
+        let (~~) (t:string) = sb.Append t |> ignore
+        let cmd = (this :> ISqlProvider).CreateCommand(con,"")
+        cmd.Connection <- con 
+        let pk = pkLookup.[entity.Table.FullName] 
+        sb.Clear() |> ignore
+
+        if changedColumns |> List.exists ((=)pk) then failwith "Error - you cannot change the primary key of an entity."
+
+        let pkValue = 
+            match entity.GetColumnOption<obj> pk with
+            | Some v -> v
+            | None -> failwith "Error - you cannot update an entity that does not have a primary key."
+                
+        let data = 
+            (([],0),changedColumns)
+            ||> List.fold(fun (out,i) col ->                                                         
+                let name = sprintf "@param%i" i
+                let p = 
+                    match entity.GetColumnOption<obj> col with
+                    | Some v -> (this :> ISqlProvider).CreateCommandParameter(QueryParameter.Create(name, i),v)
+                    | None -> (this :> ISqlProvider).CreateCommandParameter(QueryParameter.Create(name, i), DBNull.Value)
+                (col,p)::out,i+1)
+            |> fun (x,_)-> x 
+            |> List.rev
+            |> List.toArray 
+                    
+                
+        let pkParam = (this :> ISqlProvider).CreateCommandParameter(QueryParameter.Create("@pk", 0),pkValue)
+
+        ~~(sprintf "UPDATE %s SET %s WHERE %s = @pk;" 
+            (entity.Table.FullName.Replace("[","`").Replace("]","`"))
+            (String.Join(",", data |> Array.map(fun (c,p) -> sprintf "%s = %s" c p.ParameterName ) ))
+            pk)
+
+        data |> Array.map snd |> Array.iter (cmd.Parameters.Add >> ignore)
+        cmd.Parameters.Add pkParam |> ignore
+        cmd.CommandText <- sb.ToString()
+        cmd
+            
+    let createDeleteCommand (con:IDbConnection) (sb:Text.StringBuilder) (entity:SqlEntity) =
+        let (~~) (t:string) = sb.Append t |> ignore
+        let cmd = (this :> ISqlProvider).CreateCommand(con,"")
+        cmd.Connection <- con 
+        sb.Clear() |> ignore
+        let pk = pkLookup.[entity.Table.FullName] 
+        sb.Clear() |> ignore
+        let pkValue = 
+            match entity.GetColumnOption<obj> pk with
+            | Some v -> v
+            | None -> failwith "Error - you cannot delete an entity that does not have a primary key."
+        let p = (this :> ISqlProvider).CreateCommandParameter(QueryParameter.Create("@id", 0),pkValue)
+        cmd.Parameters.Add(p) |> ignore
+        ~~(sprintf "DELETE FROM %s WHERE %s = @id" (entity.Table.FullName.Replace("[","`").Replace("]","`")) pk )
+        cmd.CommandText <- sb.ToString()
+        cmd
+
     do
         MySql.resolutionPath <- resolutionPath
         MySql.owner <- owner
@@ -508,6 +591,7 @@ type internal MySqlProvider(resolutionPath, owner, referencedAssemblies) as this
 
             let sql = sb.ToString()
             (sql,parameters)        
+
         member this.ProcessUpdates(con, entities) =
             let sb = Text.StringBuilder()
             let (~~) (t:string) = sb.Append t |> ignore
@@ -518,87 +602,8 @@ type internal MySqlProvider(resolutionPath, owner, referencedAssemblies) as this
                      |> Seq.iter(fun t -> (this :> ISqlProvider).GetColumns(con,t) |> ignore )
 
             con.Open()
-            let createInsertCommand (entity:SqlEntity) =                 
-                let cmd = (this :> ISqlProvider).CreateCommand(con,"")
-                cmd.Connection <- con 
-                let pk = pkLookup.[entity.Table.FullName] 
-                let columnNames, values = 
-                    (([],0),entity.ColumnValues)
-                    ||> Seq.fold(fun (out,i) (k,v) -> 
-                        let name = sprintf "@param%i" i
-                        let p = (this :> ISqlProvider).CreateCommandParameter(QueryParameter.Create(name, i),v)
-                        (k,p)::out,i+1)
-                    |> fun (x,_)-> x 
-                    |> List.rev
-                    |> List.toArray 
-                    |> Array.unzip
-                
-                sb.Clear() |> ignore
-                ~~(sprintf "INSERT INTO %s (%s) VALUES (%s); SELECT LAST_INSERT_ID();" 
-                    (entity.Table.FullName.Replace("[","`").Replace("]","`"))
-                    (String.Join(",",columnNames))
-                    (String.Join(",",values |> Array.map(fun p -> p.ParameterName))))
-                
-                values |> Array.iter (cmd.Parameters.Add >> ignore)
-                cmd.CommandText <- sb.ToString()
-                cmd
 
-            let createUpdateCommand (entity:SqlEntity) changedColumns =
-                let cmd = (this :> ISqlProvider).CreateCommand(con,"")
-                cmd.Connection <- con 
-                let pk = pkLookup.[entity.Table.FullName] 
-                sb.Clear() |> ignore
-
-                if changedColumns |> List.exists ((=)pk) then failwith "Error - you cannot change the primary key of an entity."
-
-                let pkValue = 
-                    match entity.GetColumnOption<obj> pk with
-                    | Some v -> v
-                    | None -> failwith "Error - you cannot update an entity that does not have a primary key."
-                
-                let data = 
-                    (([],0),changedColumns)
-                    ||> List.fold(fun (out,i) col ->                                                         
-                        let name = sprintf "@param%i" i
-                        let p = 
-                            match entity.GetColumnOption<obj> col with
-                            | Some v -> (this :> ISqlProvider).CreateCommandParameter(QueryParameter.Create(name, i),v)
-                            | None -> (this :> ISqlProvider).CreateCommandParameter(QueryParameter.Create(name, i), DBNull.Value)
-                        (col,p)::out,i+1)
-                    |> fun (x,_)-> x 
-                    |> List.rev
-                    |> List.toArray 
-                    
-                
-                let pkParam = (this :> ISqlProvider).CreateCommandParameter(QueryParameter.Create("@pk", 0),pkValue)
-
-                ~~(sprintf "UPDATE %s SET %s WHERE %s = @pk;" 
-                    (entity.Table.FullName.Replace("[","`").Replace("]","`"))
-                    (String.Join(",", data |> Array.map(fun (c,p) -> sprintf "%s = %s" c p.ParameterName ) ))
-                    pk)
-
-                data |> Array.map snd |> Array.iter (cmd.Parameters.Add >> ignore)
-                cmd.Parameters.Add pkParam |> ignore
-                cmd.CommandText <- sb.ToString()
-                cmd
-            
-            let createDeleteCommand (entity:SqlEntity) =
-                let cmd = (this :> ISqlProvider).CreateCommand(con,"")
-                cmd.Connection <- con 
-                sb.Clear() |> ignore
-                let pk = pkLookup.[entity.Table.FullName] 
-                sb.Clear() |> ignore
-                let pkValue = 
-                    match entity.GetColumnOption<obj> pk with
-                    | Some v -> v
-                    | None -> failwith "Error - you cannot delete an entity that does not have a primary key."
-                let p = (this :> ISqlProvider).CreateCommandParameter(QueryParameter.Create("@id", 0),pkValue)
-                cmd.Parameters.Add(p) |> ignore
-                ~~(sprintf "DELETE FROM %s WHERE %s = @id" (entity.Table.FullName.Replace("[","`").Replace("]","`")) pk )
-                cmd.CommandText <- sb.ToString()
-                cmd
-
-            use scope = new Transactions.TransactionScope()
+            use scope = new Transactions.TransactionScope(Transactions.TransactionScopeAsyncFlowOption.Enabled)
             try
                 // close the connection first otherwise it won't get enlisted into the transaction 
                 if con.State = ConnectionState.Open then con.Close()
@@ -609,7 +614,7 @@ type internal MySqlProvider(resolutionPath, owner, referencedAssemblies) as this
                 |> List.iter(fun e -> 
                     match e._State with
                     | Created -> 
-                        let cmd = createInsertCommand e
+                        let cmd = createInsertCommand con sb e
                         Common.QueryEvents.PublishSqlQuery cmd.CommandText
                         let id = cmd.ExecuteScalar()
                         match e.GetColumnOption pkLookup.[e.Table.FullName] with
@@ -619,17 +624,74 @@ type internal MySqlProvider(resolutionPath, owner, referencedAssemblies) as this
                         | None ->  e.SetColumnSilent(pkLookup.[e.Table.FullName], id)
                         e._State <- Unchanged
                     | Modified fields -> 
-                        let cmd = createUpdateCommand e fields
+                        let cmd = createUpdateCommand con sb e fields
                         Common.QueryEvents.PublishSqlQuery cmd.CommandText
                         cmd.ExecuteNonQuery() |> ignore
                         e._State <- Unchanged
                     | Deleted -> 
-                        let cmd = createDeleteCommand e
+                        let cmd = createDeleteCommand con sb e
                         Common.QueryEvents.PublishSqlQuery cmd.CommandText
                         cmd.ExecuteNonQuery() |> ignore
                         // remove the pk to prevent this attempting to be used again
                         e.SetColumnOptionSilent(pkLookup.[e.Table.FullName], None)
                     | Unchanged -> failwith "Unchanged entity encountered in update list - this should not be possible!")
+
                 scope.Complete()
+            finally
+                con.Close()
+
+        member this.ProcessUpdatesAsync(con, entities) =
+            let sb = Text.StringBuilder()
+            let (~~) (t:string) = sb.Append t |> ignore
+
+            // ensure columns have been loaded
+            entities |> List.map(fun e -> e.Table) 
+                     |> Seq.distinct 
+                     |> Seq.iter(fun t -> (this :> ISqlProvider).GetColumns(con,t) |> ignore )
+
+            con.Open()
+
+            use scope = new Transactions.TransactionScope(Transactions.TransactionScopeAsyncFlowOption.Enabled)
+            try
+                // close the connection first otherwise it won't get enlisted into the transaction 
+                if con.State = ConnectionState.Open then con.Close()
+                con.Open()         
+                
+                // initially supporting update/create/delete of single entities, no hierarchies yet
+                let handleEntity (e: SqlEntity) =
+                    match e._State with
+                    | Created -> 
+                        async {
+                            let cmd = createInsertCommand con sb e :?> System.Data.Common.DbCommand
+                            Common.QueryEvents.PublishSqlQuery cmd.CommandText
+                            let! id = cmd.ExecuteScalarAsync() |> Async.AwaitTask
+                            match e.GetColumnOption pkLookup.[e.Table.FullName] with
+                            | Some v -> () // if the primary key exists, do nothing
+                                           // this is because non-identity columns will have been set 
+                                           // manually and in that case scope_identity would bring back 0 "" or whatever
+                            | None ->  e.SetColumnSilent(pkLookup.[e.Table.FullName], id)
+                            e._State <- Unchanged
+                        }
+                    | Modified fields -> 
+                        async {
+                            let cmd = createUpdateCommand con sb e fields :?> System.Data.Common.DbCommand
+                            Common.QueryEvents.PublishSqlQuery cmd.CommandText
+                            do! cmd.ExecuteNonQueryAsync() |> Async.AwaitTask |> Async.Ignore
+                            e._State <- Unchanged
+                        }
+                    | Deleted -> 
+                        async {
+                            let cmd = createDeleteCommand con sb e :?> System.Data.Common.DbCommand
+                            Common.QueryEvents.PublishSqlQuery cmd.CommandText
+                            do! cmd.ExecuteNonQueryAsync() |> Async.AwaitTask |> Async.Ignore
+                            // remove the pk to prevent this attempting to be used again
+                            e.SetColumnOptionSilent(pkLookup.[e.Table.FullName], None)
+                        }
+                    | Unchanged -> failwith "Unchanged entity encountered in update list - this should not be possible!"
+
+                async { 
+                    do! Utilities.execiuteOneByOne handleEntity entities
+                    scope.Complete()
+                }
             finally
                 con.Close()

--- a/src/SQLProvider/Providers.MySql.fs
+++ b/src/SQLProvider/Providers.MySql.fs
@@ -603,7 +603,7 @@ type internal MySqlProvider(resolutionPath, owner, referencedAssemblies) as this
 
             con.Open()
 
-            use scope = new Transactions.TransactionScope(Transactions.TransactionScopeAsyncFlowOption.Enabled)
+            use scope = Utilities.ensureTransaction()
             try
                 // close the connection first otherwise it won't get enlisted into the transaction 
                 if con.State = ConnectionState.Open then con.Close()
@@ -651,7 +651,7 @@ type internal MySqlProvider(resolutionPath, owner, referencedAssemblies) as this
 
             async { 
 
-                use scope = new Transactions.TransactionScope(Transactions.TransactionScopeAsyncFlowOption.Enabled)
+                use scope = Utilities.ensureTransaction()
                 try
                     // close the connection first otherwise it won't get enlisted into the transaction 
                     if con.State = ConnectionState.Open then con.Close()

--- a/src/SQLProvider/Providers.MySql.fs
+++ b/src/SQLProvider/Providers.MySql.fs
@@ -649,49 +649,49 @@ type internal MySqlProvider(resolutionPath, owner, referencedAssemblies) as this
                      |> Seq.distinct 
                      |> Seq.iter(fun t -> (this :> ISqlProvider).GetColumns(con,t) |> ignore )
 
-            con.Open()
+            async { 
 
-            use scope = new Transactions.TransactionScope(Transactions.TransactionScopeAsyncFlowOption.Enabled)
-            try
-                // close the connection first otherwise it won't get enlisted into the transaction 
-                if con.State = ConnectionState.Open then con.Close()
-                con.Open()         
+                use scope = new Transactions.TransactionScope(Transactions.TransactionScopeAsyncFlowOption.Enabled)
+                try
+                    // close the connection first otherwise it won't get enlisted into the transaction 
+                    if con.State = ConnectionState.Open then con.Close()
+                    do! con.OpenAsync() |> Async.AwaitIAsyncResult |> Async.Ignore
                 
-                // initially supporting update/create/delete of single entities, no hierarchies yet
-                let handleEntity (e: SqlEntity) =
-                    match e._State with
-                    | Created -> 
-                        async {
-                            let cmd = createInsertCommand con sb e :?> System.Data.Common.DbCommand
-                            Common.QueryEvents.PublishSqlQuery cmd.CommandText
-                            let! id = cmd.ExecuteScalarAsync() |> Async.AwaitTask
-                            match e.GetColumnOption pkLookup.[e.Table.FullName] with
-                            | Some v -> () // if the primary key exists, do nothing
-                                           // this is because non-identity columns will have been set 
-                                           // manually and in that case scope_identity would bring back 0 "" or whatever
-                            | None ->  e.SetColumnSilent(pkLookup.[e.Table.FullName], id)
-                            e._State <- Unchanged
-                        }
-                    | Modified fields -> 
-                        async {
-                            let cmd = createUpdateCommand con sb e fields :?> System.Data.Common.DbCommand
-                            Common.QueryEvents.PublishSqlQuery cmd.CommandText
-                            do! cmd.ExecuteNonQueryAsync() |> Async.AwaitTask |> Async.Ignore
-                            e._State <- Unchanged
-                        }
-                    | Deleted -> 
-                        async {
-                            let cmd = createDeleteCommand con sb e :?> System.Data.Common.DbCommand
-                            Common.QueryEvents.PublishSqlQuery cmd.CommandText
-                            do! cmd.ExecuteNonQueryAsync() |> Async.AwaitTask |> Async.Ignore
-                            // remove the pk to prevent this attempting to be used again
-                            e.SetColumnOptionSilent(pkLookup.[e.Table.FullName], None)
-                        }
-                    | Unchanged -> failwith "Unchanged entity encountered in update list - this should not be possible!"
+                    // initially supporting update/create/delete of single entities, no hierarchies yet
+                    let handleEntity (e: SqlEntity) =
+                        match e._State with
+                        | Created -> 
+                            async {
+                                let cmd = createInsertCommand con sb e :?> System.Data.Common.DbCommand
+                                Common.QueryEvents.PublishSqlQuery cmd.CommandText
+                                let! id = cmd.ExecuteScalarAsync() |> Async.AwaitTask
+                                match e.GetColumnOption pkLookup.[e.Table.FullName] with
+                                | Some v -> () // if the primary key exists, do nothing
+                                               // this is because non-identity columns will have been set 
+                                               // manually and in that case scope_identity would bring back 0 "" or whatever
+                                | None ->  e.SetColumnSilent(pkLookup.[e.Table.FullName], id)
+                                e._State <- Unchanged
+                            }
+                        | Modified fields -> 
+                            async {
+                                let cmd = createUpdateCommand con sb e fields :?> System.Data.Common.DbCommand
+                                Common.QueryEvents.PublishSqlQuery cmd.CommandText
+                                do! cmd.ExecuteNonQueryAsync() |> Async.AwaitTask |> Async.Ignore
+                                e._State <- Unchanged
+                            }
+                        | Deleted -> 
+                            async {
+                                let cmd = createDeleteCommand con sb e :?> System.Data.Common.DbCommand
+                                Common.QueryEvents.PublishSqlQuery cmd.CommandText
+                                do! cmd.ExecuteNonQueryAsync() |> Async.AwaitTask |> Async.Ignore
+                                // remove the pk to prevent this attempting to be used again
+                                e.SetColumnOptionSilent(pkLookup.[e.Table.FullName], None)
+                            }
+                        | Unchanged -> failwith "Unchanged entity encountered in update list - this should not be possible!"
 
-                async { 
-                    do! Utilities.execiuteOneByOne handleEntity entities
+                    do! Utilities.executeOneByOne handleEntity entities
+                    
                     scope.Complete()
-                }
-            finally
-                con.Close()
+                finally
+                    con.Close()
+            }

--- a/src/SQLProvider/Providers.Odbc.fs
+++ b/src/SQLProvider/Providers.Odbc.fs
@@ -56,6 +56,91 @@ type internal OdbcProvider(resolutionPath) =
         use com = new OdbcCommand(sql,con:?>OdbcConnection)    
         com.ExecuteReader()
 
+    let createInsertCommand (con:IDbConnection) (sb:Text.StringBuilder) (entity:SqlEntity) =     
+        let (~~) (t:string) = sb.Append t |> ignore
+        let cmd = new OdbcCommand()
+        cmd.Connection <- con :?> OdbcConnection
+        let pk = pkLookup.[entity.Table.FullName] 
+        let columnNames, values = 
+            (([],0),entity.ColumnValues)
+            ||> Seq.fold(fun (out,i) (key,value) ->                         
+                let name = sprintf "@param%i" i
+                let p = OdbcParameter(name,value)
+                (key,p)::out,i+1)
+            |> fun (x,_)-> x 
+            |> List.rev
+            |> List.toArray 
+            |> Array.unzip
+                
+        sb.Clear() |> ignore
+        ~~(sprintf "INSERT INTO %s (%s) VALUES (%s);" 
+            entity.Table.Name
+            (String.Join(",",columnNames))
+            (String.Join(",",values |> Array.map(fun p -> "?"))))
+        cmd.Parameters.AddRange(values)
+        cmd.CommandText <- sb.ToString()
+        cmd
+
+    let lastInsertId (con:IDbConnection) =
+        let cmd = new OdbcCommand()
+        cmd.Connection <- con :?> OdbcConnection
+        cmd.CommandText <- "SELECT @@IDENTITY AS id;"
+        cmd
+
+    let createUpdateCommand (con:IDbConnection) (sb:Text.StringBuilder) (entity:SqlEntity) changedColumns =
+        let (~~) (t:string) = sb.Append t |> ignore
+        let cmd = new OdbcCommand()
+        cmd.Connection <- con :?> OdbcConnection
+        let pk = pkLookup.[entity.Table.FullName] 
+        sb.Clear() |> ignore
+
+        if changedColumns |> List.exists ((=)pk) then failwith "Error - you cannot change the primary key of an entity."
+
+        let pkValue = 
+            match entity.GetColumnOption<obj> pk with
+            | Some v -> v
+            | None -> failwith "Error - you cannot update an entity that does not have a primary key."
+                
+        let data = 
+            (([],0),changedColumns)
+            ||> List.fold(fun (out,i) col ->
+                let p = 
+                    match entity.GetColumnOption<obj> col with
+                    | Some v -> OdbcParameter(null,v)
+                    | None -> OdbcParameter(null,DBNull.Value)
+                (col,p)::out,i+1)
+            |> fun (x,_)-> x 
+            |> List.rev
+            |> List.toArray 
+                
+        let pkParam = OdbcParameter(null, pkValue)
+
+        ~~(sprintf "UPDATE %s SET %s WHERE %s = ?;" 
+            entity.Table.Name
+            (String.Join(",", data |> Array.map(fun (c,p) -> sprintf "%s = %s" c "?" ) ))
+            pk)
+
+        cmd.Parameters.AddRange(data |> Array.map snd)
+        cmd.Parameters.Add pkParam |> ignore
+        cmd.CommandText <- sb.ToString()
+        cmd
+            
+    let createDeleteCommand (con:IDbConnection) (sb:Text.StringBuilder) (entity:SqlEntity) =
+        let (~~) (t:string) = sb.Append t |> ignore
+        let cmd = new OdbcCommand()
+        cmd.Connection <- con :?> OdbcConnection
+        sb.Clear() |> ignore
+        let pk = pkLookup.[entity.Table.FullName] 
+        sb.Clear() |> ignore
+        let pkValue = 
+            match entity.GetColumnOption<obj> pk with
+            | Some v -> v
+            | None -> failwith "Error - you cannot delete an entity that does not have a primary key."
+        cmd.Parameters.AddWithValue("@id",pkValue) |> ignore
+        ~~(sprintf "DELETE FROM %s WHERE %s = ?" entity.Table.Name pk )
+        cmd.CommandText <- sb.ToString()
+        cmd
+
     interface ISqlProvider with
         member __.CreateConnection(connectionString) = upcast new OdbcConnection(connectionString)
         member __.CreateCommand(connection,commandText) = upcast new OdbcCommand(commandText, connection:?>OdbcConnection)
@@ -268,89 +353,7 @@ type internal OdbcProvider(resolutionPath) =
 
             if con.State <> ConnectionState.Open then con.Open()
 
-            let createInsertCommand (entity:SqlEntity) =     
-                let cmd = new OdbcCommand()
-                cmd.Connection <- con :?> OdbcConnection
-                let pk = pkLookup.[entity.Table.FullName] 
-                let columnNames, values = 
-                    (([],0),entity.ColumnValues)
-                    ||> Seq.fold(fun (out,i) (key,value) ->                         
-                        let name = sprintf "@param%i" i
-                        let p = OdbcParameter(name,value)
-                        (key,p)::out,i+1)
-                    |> fun (x,_)-> x 
-                    |> List.rev
-                    |> List.toArray 
-                    |> Array.unzip
-                
-                sb.Clear() |> ignore
-                ~~(sprintf "INSERT INTO %s (%s) VALUES (%s);" 
-                    entity.Table.Name
-                    (String.Join(",",columnNames))
-                    (String.Join(",",values |> Array.map(fun p -> "?"))))
-                cmd.Parameters.AddRange(values)
-                cmd.CommandText <- sb.ToString()
-                cmd
-
-            let lastInsertId () =
-                let cmd = new OdbcCommand()
-                cmd.Connection <- con :?> OdbcConnection
-                cmd.CommandText <- "SELECT @@IDENTITY AS id;"
-                cmd
-
-            let createUpdateCommand (entity:SqlEntity) changedColumns =
-                let cmd = new OdbcCommand()
-                cmd.Connection <- con :?> OdbcConnection
-                let pk = pkLookup.[entity.Table.FullName] 
-                sb.Clear() |> ignore
-
-                if changedColumns |> List.exists ((=)pk) then failwith "Error - you cannot change the primary key of an entity."
-
-                let pkValue = 
-                    match entity.GetColumnOption<obj> pk with
-                    | Some v -> v
-                    | None -> failwith "Error - you cannot update an entity that does not have a primary key."
-                
-                let data = 
-                    (([],0),changedColumns)
-                    ||> List.fold(fun (out,i) col ->
-                        let p = 
-                            match entity.GetColumnOption<obj> col with
-                            | Some v -> OdbcParameter(null,v)
-                            | None -> OdbcParameter(null,DBNull.Value)
-                        (col,p)::out,i+1)
-                    |> fun (x,_)-> x 
-                    |> List.rev
-                    |> List.toArray 
-                
-                let pkParam = OdbcParameter(null, pkValue)
-
-                ~~(sprintf "UPDATE %s SET %s WHERE %s = ?;" 
-                    entity.Table.Name
-                    (String.Join(",", data |> Array.map(fun (c,p) -> sprintf "%s = %s" c "?" ) ))
-                    pk)
-
-                cmd.Parameters.AddRange(data |> Array.map snd)
-                cmd.Parameters.Add pkParam |> ignore
-                cmd.CommandText <- sb.ToString()
-                cmd
-            
-            let createDeleteCommand (entity:SqlEntity) =
-                let cmd = new OdbcCommand()
-                cmd.Connection <- con :?> OdbcConnection
-                sb.Clear() |> ignore
-                let pk = pkLookup.[entity.Table.FullName] 
-                sb.Clear() |> ignore
-                let pkValue = 
-                    match entity.GetColumnOption<obj> pk with
-                    | Some v -> v
-                    | None -> failwith "Error - you cannot delete an entity that does not have a primary key."
-                cmd.Parameters.AddWithValue("@id",pkValue) |> ignore
-                ~~(sprintf "DELETE FROM %s WHERE %s = ?" entity.Table.Name pk )
-                cmd.CommandText <- sb.ToString()
-                cmd
-
-            use scope = new Transactions.TransactionScope()
+            use scope = new Transactions.TransactionScope(Transactions.TransactionScopeAsyncFlowOption.Enabled)
             try                
                 // close the connection first otherwise it won't get enlisted into the transaction 
                 if con.State = ConnectionState.Open then con.Close()
@@ -360,10 +363,10 @@ type internal OdbcProvider(resolutionPath) =
                 |> List.iter(fun e -> 
                     match e._State with
                     | Created -> 
-                        let cmd = createInsertCommand e
+                        let cmd = createInsertCommand con sb e
                         Common.QueryEvents.PublishSqlQuery cmd.CommandText
                         cmd.ExecuteNonQuery() |> ignore
-                        let id = (lastInsertId()).ExecuteScalar()
+                        let id = (lastInsertId con).ExecuteScalar()
                         match e.GetColumnOption pkLookup.[e.Table.FullName] with
                         | Some v -> () // if the primary key exists, do nothing
                                        // this is because non-identity columns will have been set 
@@ -371,17 +374,72 @@ type internal OdbcProvider(resolutionPath) =
                         | None ->  e.SetColumnSilent(pkLookup.[e.Table.FullName], id)
                         e._State <- Unchanged
                     | Modified fields -> 
-                        let cmd = createUpdateCommand e fields
+                        let cmd = createUpdateCommand con sb e fields
                         Common.QueryEvents.PublishSqlQuery cmd.CommandText
                         cmd.ExecuteNonQuery() |> ignore
                         e._State <- Unchanged
                     | Deleted -> 
-                        let cmd = createDeleteCommand e
+                        let cmd = createDeleteCommand con sb e
                         Common.QueryEvents.PublishSqlQuery cmd.CommandText
                         cmd.ExecuteNonQuery() |> ignore
                         // remove the pk to prevent this attempting to be used again
                         e.SetColumnOptionSilent(pkLookup.[e.Table.FullName], None)
                     | Unchanged -> failwith "Unchanged entity encountered in update list - this should not be possible!")
                 scope.Complete()
+            finally
+                con.Close()
+
+        member this.ProcessUpdatesAsync(con, entities) =
+            let sb = Text.StringBuilder()
+            let (~~) (t:string) = sb.Append t |> ignore
+
+            // ensure columns have been loaded
+            entities |> List.map(fun e -> e.Table) 
+                     |> Seq.distinct 
+                     |> Seq.iter(fun t -> (this :> ISqlProvider).GetColumns(con,t) |> ignore )
+
+            if con.State <> ConnectionState.Open then con.Open()
+
+            use scope = new Transactions.TransactionScope(Transactions.TransactionScopeAsyncFlowOption.Enabled)
+            try                
+                // close the connection first otherwise it won't get enlisted into the transaction 
+                if con.State = ConnectionState.Open then con.Close()
+                con.Open()         
+                // initially supporting update/create/delete of single entities, no hierarchies yet
+                let handleEntity (e: SqlEntity) =
+                    match e._State with
+                    | Created -> 
+                        async {
+                            let cmd = createInsertCommand con sb e
+                            Common.QueryEvents.PublishSqlQuery cmd.CommandText
+                            do! cmd.ExecuteNonQueryAsync() |> Async.AwaitTask |> Async.Ignore
+                            let id = (lastInsertId con).ExecuteScalar()
+                            match e.GetColumnOption pkLookup.[e.Table.FullName] with
+                            | Some v -> () // if the primary key exists, do nothing
+                                           // this is because non-identity columns will have been set 
+                                           // manually and in that case scope_identity would bring back 0 "" or whatever
+                            | None ->  e.SetColumnSilent(pkLookup.[e.Table.FullName], id)
+                            e._State <- Unchanged
+                        }
+                    | Modified fields -> 
+                        async {
+                            let cmd = createUpdateCommand con sb e fields
+                            Common.QueryEvents.PublishSqlQuery cmd.CommandText
+                            do! cmd.ExecuteNonQueryAsync() |> Async.AwaitTask |> Async.Ignore
+                            e._State <- Unchanged
+                        }
+                    | Deleted -> 
+                        async {
+                            let cmd = createDeleteCommand con sb e
+                            Common.QueryEvents.PublishSqlQuery cmd.CommandText
+                            do! cmd.ExecuteNonQueryAsync() |> Async.AwaitTask |> Async.Ignore
+                            // remove the pk to prevent this attempting to be used again
+                            e.SetColumnOptionSilent(pkLookup.[e.Table.FullName], None)
+                        }
+                    | Unchanged -> failwith "Unchanged entity encountered in update list - this should not be possible!"
+                async { 
+                    do! Utilities.execiuteOneByOne handleEntity entities
+                    scope.Complete()
+                }
             finally
                 con.Close()

--- a/src/SQLProvider/Providers.Odbc.fs
+++ b/src/SQLProvider/Providers.Odbc.fs
@@ -398,48 +398,47 @@ type internal OdbcProvider(resolutionPath) =
                      |> Seq.distinct 
                      |> Seq.iter(fun t -> (this :> ISqlProvider).GetColumns(con,t) |> ignore )
 
-            if con.State <> ConnectionState.Open then con.Open()
+            async { 
+                use scope = new Transactions.TransactionScope(Transactions.TransactionScopeAsyncFlowOption.Enabled)
+                try                
+                    // close the connection first otherwise it won't get enlisted into the transaction 
+                    if con.State = ConnectionState.Open then con.Close()
 
-            use scope = new Transactions.TransactionScope(Transactions.TransactionScopeAsyncFlowOption.Enabled)
-            try                
-                // close the connection first otherwise it won't get enlisted into the transaction 
-                if con.State = ConnectionState.Open then con.Close()
-                con.Open()         
-                // initially supporting update/create/delete of single entities, no hierarchies yet
-                let handleEntity (e: SqlEntity) =
-                    match e._State with
-                    | Created -> 
-                        async {
-                            let cmd = createInsertCommand con sb e
-                            Common.QueryEvents.PublishSqlQuery cmd.CommandText
-                            do! cmd.ExecuteNonQueryAsync() |> Async.AwaitTask |> Async.Ignore
-                            let id = (lastInsertId con).ExecuteScalar()
-                            match e.GetColumnOption pkLookup.[e.Table.FullName] with
-                            | Some v -> () // if the primary key exists, do nothing
-                                           // this is because non-identity columns will have been set 
-                                           // manually and in that case scope_identity would bring back 0 "" or whatever
-                            | None ->  e.SetColumnSilent(pkLookup.[e.Table.FullName], id)
-                            e._State <- Unchanged
-                        }
-                    | Modified fields -> 
-                        async {
-                            let cmd = createUpdateCommand con sb e fields
-                            Common.QueryEvents.PublishSqlQuery cmd.CommandText
-                            do! cmd.ExecuteNonQueryAsync() |> Async.AwaitTask |> Async.Ignore
-                            e._State <- Unchanged
-                        }
-                    | Deleted -> 
-                        async {
-                            let cmd = createDeleteCommand con sb e
-                            Common.QueryEvents.PublishSqlQuery cmd.CommandText
-                            do! cmd.ExecuteNonQueryAsync() |> Async.AwaitTask |> Async.Ignore
-                            // remove the pk to prevent this attempting to be used again
-                            e.SetColumnOptionSilent(pkLookup.[e.Table.FullName], None)
-                        }
-                    | Unchanged -> failwith "Unchanged entity encountered in update list - this should not be possible!"
-                async { 
-                    do! Utilities.execiuteOneByOne handleEntity entities
+                    do! con.OpenAsync() |> Async.AwaitIAsyncResult |> Async.Ignore
+                    // initially supporting update/create/delete of single entities, no hierarchies yet
+                    let handleEntity (e: SqlEntity) =
+                        match e._State with
+                        | Created -> 
+                            async {
+                                let cmd = createInsertCommand con sb e
+                                Common.QueryEvents.PublishSqlQuery cmd.CommandText
+                                do! cmd.ExecuteNonQueryAsync() |> Async.AwaitTask |> Async.Ignore
+                                let id = (lastInsertId con).ExecuteScalar()
+                                match e.GetColumnOption pkLookup.[e.Table.FullName] with
+                                | Some v -> () // if the primary key exists, do nothing
+                                               // this is because non-identity columns will have been set 
+                                               // manually and in that case scope_identity would bring back 0 "" or whatever
+                                | None ->  e.SetColumnSilent(pkLookup.[e.Table.FullName], id)
+                                e._State <- Unchanged
+                            }
+                        | Modified fields -> 
+                            async {
+                                let cmd = createUpdateCommand con sb e fields
+                                Common.QueryEvents.PublishSqlQuery cmd.CommandText
+                                do! cmd.ExecuteNonQueryAsync() |> Async.AwaitTask |> Async.Ignore
+                                e._State <- Unchanged
+                            }
+                        | Deleted -> 
+                            async {
+                                let cmd = createDeleteCommand con sb e
+                                Common.QueryEvents.PublishSqlQuery cmd.CommandText
+                                do! cmd.ExecuteNonQueryAsync() |> Async.AwaitTask |> Async.Ignore
+                                // remove the pk to prevent this attempting to be used again
+                                e.SetColumnOptionSilent(pkLookup.[e.Table.FullName], None)
+                            }
+                        | Unchanged -> failwith "Unchanged entity encountered in update list - this should not be possible!"
+                    do! Utilities.executeOneByOne handleEntity entities
                     scope.Complete()
-                }
-            finally
-                con.Close()
+                finally
+                    con.Close()
+            }

--- a/src/SQLProvider/Providers.Odbc.fs
+++ b/src/SQLProvider/Providers.Odbc.fs
@@ -353,7 +353,7 @@ type internal OdbcProvider(resolutionPath) =
 
             if con.State <> ConnectionState.Open then con.Open()
 
-            use scope = new Transactions.TransactionScope(Transactions.TransactionScopeAsyncFlowOption.Enabled)
+            use scope = Utilities.ensureTransaction()
             try                
                 // close the connection first otherwise it won't get enlisted into the transaction 
                 if con.State = ConnectionState.Open then con.Close()
@@ -399,7 +399,7 @@ type internal OdbcProvider(resolutionPath) =
                      |> Seq.iter(fun t -> (this :> ISqlProvider).GetColumns(con,t) |> ignore )
 
             async { 
-                use scope = new Transactions.TransactionScope(Transactions.TransactionScopeAsyncFlowOption.Enabled)
+                use scope = Utilities.ensureTransaction()
                 try                
                     // close the connection first otherwise it won't get enlisted into the transaction 
                     if con.State = ConnectionState.Open then con.Close()

--- a/src/SQLProvider/Providers.Oracle.fs
+++ b/src/SQLProvider/Providers.Oracle.fs
@@ -649,7 +649,7 @@ type internal OracleProvider(resolutionPath, owner, referencedAssemblies) =
 
             con.Open()
 
-            use scope = new Transactions.TransactionScope(Transactions.TransactionScopeAsyncFlowOption.Enabled)
+            use scope = Utilities.ensureTransaction()
             try                
                 // close the connection first otherwise it won't get enlisted into the transaction 
                 if con.State = ConnectionState.Open then con.Close()
@@ -695,7 +695,7 @@ type internal OracleProvider(resolutionPath, owner, referencedAssemblies) =
                      |> Seq.iter(fun t -> provider.GetColumns(con,t) |> ignore )
 
             async { 
-                use scope = new Transactions.TransactionScope(Transactions.TransactionScopeAsyncFlowOption.Enabled)
+                use scope = Utilities.ensureTransaction()
                 try                
                     // close the connection first otherwise it won't get enlisted into the transaction 
                     if con.State = ConnectionState.Open then con.Close()

--- a/src/SQLProvider/Providers.Postgresql.fs
+++ b/src/SQLProvider/Providers.Postgresql.fs
@@ -799,49 +799,50 @@ type internal PostgresqlProvider(resolutionPath, owner, referencedAssemblies) as
                      |> Seq.distinct 
                      |> Seq.iter(fun t -> (this :> ISqlProvider).GetColumns(con,t) |> ignore )
 
-            con.Open()
-
-            use scope = new Transactions.TransactionScope(Transactions.TransactionScopeAsyncFlowOption.Enabled)
-            try
+            async { 
+                use scope = new Transactions.TransactionScope(Transactions.TransactionScopeAsyncFlowOption.Enabled)
+                try
                 
-                // close the connection first otherwise it won't get enlisted into the transaction 
-                if con.State = ConnectionState.Open then con.Close()
-                con.Open()          
-                // initially supporting update/create/delete of single entities, no hierarchies yet
-                let handleEntity (e: SqlEntity) =
-                    match e._State with
-                    | Created -> 
-                        async {
-                            let cmd = createInsertCommand con sb e :?> System.Data.Common.DbCommand
-                            Common.QueryEvents.PublishSqlQuery cmd.CommandText
-                            let! id = cmd.ExecuteScalarAsync() |> Async.AwaitTask
-                            match e.GetColumnOption pkLookup.[e.Table.FullName] with
-                            | Some v -> () // if the primary key exists, do nothing
-                                           // this is because non-identity columns will have been set 
-                                           // manually and in that case scope_identity would bring back 0 "" or whatever
-                            | None ->  e.SetColumnSilent(pkLookup.[e.Table.FullName], id)
-                            e._State <- Unchanged
-                        }
-                    | Modified fields -> 
-                        async {
-                            let cmd = createUpdateCommand con sb e fields :?> System.Data.Common.DbCommand
-                            Common.QueryEvents.PublishSqlQuery cmd.CommandText
-                            do! cmd.ExecuteNonQueryAsync() |> Async.AwaitTask |> Async.Ignore
-                            e._State <- Unchanged
-                        }
-                    | Deleted -> 
-                        async {
-                            let cmd = createDeleteCommand con sb e :?> System.Data.Common.DbCommand
-                            Common.QueryEvents.PublishSqlQuery cmd.CommandText
-                            do! cmd.ExecuteNonQueryAsync() |> Async.AwaitTask |> Async.Ignore
-                            // remove the pk to prevent this attempting to be used again
-                            e.SetColumnOptionSilent(pkLookup.[e.Table.FullName], None)
-                        }
-                    | Unchanged -> failwith "Unchanged entity encountered in update list - this should not be possible!"
-                async { 
-                    do! Utilities.execiuteOneByOne handleEntity entities
-                    scope.Complete()
-                }
+                    // close the connection first otherwise it won't get enlisted into the transaction 
+                    if con.State = ConnectionState.Open then con.Close()
 
-            finally
-                con.Close()
+                    do! con.OpenAsync() |> Async.AwaitIAsyncResult |> Async.Ignore
+       
+                    // initially supporting update/create/delete of single entities, no hierarchies yet
+                    let handleEntity (e: SqlEntity) =
+                        match e._State with
+                        | Created -> 
+                            async {
+                                let cmd = createInsertCommand con sb e :?> System.Data.Common.DbCommand
+                                Common.QueryEvents.PublishSqlQuery cmd.CommandText
+                                let! id = cmd.ExecuteScalarAsync() |> Async.AwaitTask
+                                match e.GetColumnOption pkLookup.[e.Table.FullName] with
+                                | Some v -> () // if the primary key exists, do nothing
+                                               // this is because non-identity columns will have been set 
+                                               // manually and in that case scope_identity would bring back 0 "" or whatever
+                                | None ->  e.SetColumnSilent(pkLookup.[e.Table.FullName], id)
+                                e._State <- Unchanged
+                            }
+                        | Modified fields -> 
+                            async {
+                                let cmd = createUpdateCommand con sb e fields :?> System.Data.Common.DbCommand
+                                Common.QueryEvents.PublishSqlQuery cmd.CommandText
+                                do! cmd.ExecuteNonQueryAsync() |> Async.AwaitTask |> Async.Ignore
+                                e._State <- Unchanged
+                            }
+                        | Deleted -> 
+                            async {
+                                let cmd = createDeleteCommand con sb e :?> System.Data.Common.DbCommand
+                                Common.QueryEvents.PublishSqlQuery cmd.CommandText
+                                do! cmd.ExecuteNonQueryAsync() |> Async.AwaitTask |> Async.Ignore
+                                // remove the pk to prevent this attempting to be used again
+                                e.SetColumnOptionSilent(pkLookup.[e.Table.FullName], None)
+                            }
+                        | Unchanged -> failwith "Unchanged entity encountered in update list - this should not be possible!"
+
+                    do! Utilities.executeOneByOne handleEntity entities
+                    scope.Complete()
+                finally
+                    con.Close()
+            }
+

--- a/src/SQLProvider/Providers.Postgresql.fs
+++ b/src/SQLProvider/Providers.Postgresql.fs
@@ -754,7 +754,7 @@ type internal PostgresqlProvider(resolutionPath, owner, referencedAssemblies) as
 
             con.Open()
 
-            use scope = new Transactions.TransactionScope(Transactions.TransactionScopeAsyncFlowOption.Enabled)
+            use scope = Utilities.ensureTransaction()
             try
                 
                 // close the connection first otherwise it won't get enlisted into the transaction 
@@ -800,7 +800,7 @@ type internal PostgresqlProvider(resolutionPath, owner, referencedAssemblies) as
                      |> Seq.iter(fun t -> (this :> ISqlProvider).GetColumns(con,t) |> ignore )
 
             async { 
-                use scope = new Transactions.TransactionScope(Transactions.TransactionScopeAsyncFlowOption.Enabled)
+                use scope = Utilities.ensureTransaction()
                 try
                 
                     // close the connection first otherwise it won't get enlisted into the transaction 

--- a/src/SQLProvider/Providers.Postgresql.fs
+++ b/src/SQLProvider/Providers.Postgresql.fs
@@ -350,6 +350,95 @@ type internal PostgresqlProvider(resolutionPath, owner, referencedAssemblies) as
     let columnLookup = Dictionary<string,Column list>()
     let relationshipLookup = Dictionary<string,Relationship list * Relationship list>()
 
+    let createInsertCommand (con:IDbConnection) (sb:Text.StringBuilder) (entity:SqlEntity) =                 
+        let (~~) (t:string) = sb.Append t |> ignore
+        let cmd = (this :> ISqlProvider).CreateCommand(con,"")
+        cmd.Connection <- con 
+        let pk = pkLookup.[entity.Table.FullName] 
+        let columnNames, values = 
+            (([],0),entity.ColumnValues)
+            ||> Seq.fold(fun (out,i) (k,v) -> 
+                let name = sprintf "@param%i" i
+                let p = (this :> ISqlProvider).CreateCommandParameter(QueryParameter.Create(name,i),v)
+                (k,p)::out,i+1)
+            |> fun (x,_)-> x 
+            |> List.rev
+            |> List.toArray 
+            |> Array.unzip
+
+        sb.Clear() |> ignore
+        ~~(sprintf "INSERT INTO \"%s\".\"%s\" " entity.Table.Schema entity.Table.Name)
+
+        match columnNames with
+        | [||] -> ~~(sprintf "DEFAULT VALUES")
+        | _ -> ~~(sprintf "(%s) VALUES (%s)"
+                    (String.Join(",",columnNames |> Array.map (fun c -> sprintf "\"%s\"" c)))
+                    (String.Join(",",values |> Array.map(fun p -> p.ParameterName))))
+
+        ~~(sprintf " RETURNING \"%s\";" pk)
+
+        values |> Array.iter (cmd.Parameters.Add >> ignore)
+        cmd.CommandText <- sb.ToString()
+        cmd
+
+    let createUpdateCommand (con:IDbConnection) (sb:Text.StringBuilder) (entity:SqlEntity) changedColumns =
+        let (~~) (t:string) = sb.Append t |> ignore
+        let cmd = (this :> ISqlProvider).CreateCommand(con,"")
+        cmd.Connection <- con 
+        let pk = pkLookup.[entity.Table.FullName] 
+        sb.Clear() |> ignore
+
+        if changedColumns |> List.exists ((=)pk) then failwith "Error - you cannot change the primary key of an entity."
+
+        let pkValue = 
+            match entity.GetColumnOption<obj> pk with
+            | Some v -> v
+            | None -> failwith "Error - you cannot update an entity that does not have a primary key."
+                
+        let data = 
+            (([],0),changedColumns)
+            ||> List.fold(fun (out,i) col ->                                                         
+                let name = sprintf "@param%i" i
+                let p = 
+                    match entity.GetColumnOption<obj> col with
+                    | Some v -> (this :> ISqlProvider).CreateCommandParameter(QueryParameter.Create(name,i),v)
+                    | None -> (this :> ISqlProvider).CreateCommandParameter(QueryParameter.Create(name,i),DBNull.Value)
+                (col,p)::out,i+1)
+            |> fun (x,_)-> x 
+            |> List.rev
+            |> List.toArray 
+                    
+                
+        let pkParam = (this :> ISqlProvider).CreateCommandParameter(QueryParameter.Create("@pk",0),pkValue)
+
+        ~~(sprintf "UPDATE \"%s\".\"%s\" SET %s WHERE %s = @pk;" 
+            entity.Table.Schema entity.Table.Name
+            (String.Join(",", data |> Array.map(fun (c,p) -> sprintf "%s = %s" c p.ParameterName ) ))
+            pk)
+
+        data |> Array.map snd |> Array.iter (cmd.Parameters.Add >> ignore)
+        cmd.Parameters.Add pkParam |> ignore
+        cmd.CommandText <- sb.ToString()
+        cmd
+            
+    let createDeleteCommand (con:IDbConnection) (sb:Text.StringBuilder) (entity:SqlEntity) =
+        let (~~) (t:string) = sb.Append t |> ignore
+        let cmd = (this :> ISqlProvider).CreateCommand(con,"")
+        cmd.Connection <- con 
+        sb.Clear() |> ignore
+        let pk = pkLookup.[entity.Table.FullName] 
+        sb.Clear() |> ignore
+        let pkValue = 
+            match entity.GetColumnOption<obj> pk with
+            | Some v -> v
+            | None -> failwith "Error - you cannot delete an entity that does not have a primary key."
+        let p = (this :> ISqlProvider).CreateCommandParameter(QueryParameter.Create("@id",0),pkValue)
+
+        cmd.Parameters.Add(p) |> ignore
+        ~~(sprintf "DELETE FROM \"%s\".\"%s\" WHERE %s = @id" entity.Table.Schema entity.Table.Name pk )
+        cmd.CommandText <- sb.ToString()
+        cmd
+
     do
         PostgreSQL.resolutionPath <- resolutionPath
         PostgreSQL.referencedAssemblies <- referencedAssemblies
@@ -664,93 +753,8 @@ type internal PostgresqlProvider(resolutionPath, owner, referencedAssemblies) as
                      |> Seq.iter(fun t -> (this :> ISqlProvider).GetColumns(con,t) |> ignore )
 
             con.Open()
-            let createInsertCommand (entity:SqlEntity) =                 
-                let cmd = (this :> ISqlProvider).CreateCommand(con,"")
-                cmd.Connection <- con 
-                let pk = pkLookup.[entity.Table.FullName] 
-                let columnNames, values = 
-                    (([],0),entity.ColumnValues)
-                    ||> Seq.fold(fun (out,i) (k,v) -> 
-                        let name = sprintf "@param%i" i
-                        let p = (this :> ISqlProvider).CreateCommandParameter(QueryParameter.Create(name,i),v)
-                        (k,p)::out,i+1)
-                    |> fun (x,_)-> x 
-                    |> List.rev
-                    |> List.toArray 
-                    |> Array.unzip
 
-                sb.Clear() |> ignore
-                ~~(sprintf "INSERT INTO \"%s\".\"%s\" " entity.Table.Schema entity.Table.Name)
-
-                match columnNames with
-                | [||] -> ~~(sprintf "DEFAULT VALUES")
-                | _ -> ~~(sprintf "(%s) VALUES (%s)"
-                           (String.Join(",",columnNames |> Array.map (fun c -> sprintf "\"%s\"" c)))
-                           (String.Join(",",values |> Array.map(fun p -> p.ParameterName))))
-
-                ~~(sprintf " RETURNING \"%s\";" pk)
-
-                values |> Array.iter (cmd.Parameters.Add >> ignore)
-                cmd.CommandText <- sb.ToString()
-                cmd
-
-            let createUpdateCommand (entity:SqlEntity) changedColumns =
-                let cmd = (this :> ISqlProvider).CreateCommand(con,"")
-                cmd.Connection <- con 
-                let pk = pkLookup.[entity.Table.FullName] 
-                sb.Clear() |> ignore
-
-                if changedColumns |> List.exists ((=)pk) then failwith "Error - you cannot change the primary key of an entity."
-
-                let pkValue = 
-                    match entity.GetColumnOption<obj> pk with
-                    | Some v -> v
-                    | None -> failwith "Error - you cannot update an entity that does not have a primary key."
-                
-                let data = 
-                    (([],0),changedColumns)
-                    ||> List.fold(fun (out,i) col ->                                                         
-                        let name = sprintf "@param%i" i
-                        let p = 
-                            match entity.GetColumnOption<obj> col with
-                            | Some v -> (this :> ISqlProvider).CreateCommandParameter(QueryParameter.Create(name,i),v)
-                            | None -> (this :> ISqlProvider).CreateCommandParameter(QueryParameter.Create(name,i),DBNull.Value)
-                        (col,p)::out,i+1)
-                    |> fun (x,_)-> x 
-                    |> List.rev
-                    |> List.toArray 
-                    
-                
-                let pkParam = (this :> ISqlProvider).CreateCommandParameter(QueryParameter.Create("@pk",0),pkValue)
-
-                ~~(sprintf "UPDATE \"%s\".\"%s\" SET %s WHERE %s = @pk;" 
-                    entity.Table.Schema entity.Table.Name
-                    (String.Join(",", data |> Array.map(fun (c,p) -> sprintf "%s = %s" c p.ParameterName ) ))
-                    pk)
-
-                data |> Array.map snd |> Array.iter (cmd.Parameters.Add >> ignore)
-                cmd.Parameters.Add pkParam |> ignore
-                cmd.CommandText <- sb.ToString()
-                cmd
-            
-            let createDeleteCommand (entity:SqlEntity) =
-                let cmd = (this :> ISqlProvider).CreateCommand(con,"")
-                cmd.Connection <- con 
-                sb.Clear() |> ignore
-                let pk = pkLookup.[entity.Table.FullName] 
-                sb.Clear() |> ignore
-                let pkValue = 
-                    match entity.GetColumnOption<obj> pk with
-                    | Some v -> v
-                    | None -> failwith "Error - you cannot delete an entity that does not have a primary key."
-                let p = (this :> ISqlProvider).CreateCommandParameter(QueryParameter.Create("@id",0),pkValue)
-
-                cmd.Parameters.Add(p) |> ignore
-                ~~(sprintf "DELETE FROM \"%s\".\"%s\" WHERE %s = @id" entity.Table.Schema entity.Table.Name pk )
-                cmd.CommandText <- sb.ToString()
-                cmd
-
-            use scope = new Transactions.TransactionScope()
+            use scope = new Transactions.TransactionScope(Transactions.TransactionScopeAsyncFlowOption.Enabled)
             try
                 
                 // close the connection first otherwise it won't get enlisted into the transaction 
@@ -761,7 +765,7 @@ type internal PostgresqlProvider(resolutionPath, owner, referencedAssemblies) as
                 |> List.iter(fun e -> 
                     match e._State with
                     | Created -> 
-                        let cmd = createInsertCommand e
+                        let cmd = createInsertCommand con sb e
                         Common.QueryEvents.PublishSqlQuery cmd.CommandText
                         let id = cmd.ExecuteScalar()
                         match e.GetColumnOption pkLookup.[e.Table.FullName] with
@@ -771,17 +775,73 @@ type internal PostgresqlProvider(resolutionPath, owner, referencedAssemblies) as
                         | None ->  e.SetColumnSilent(pkLookup.[e.Table.FullName], id)
                         e._State <- Unchanged
                     | Modified fields -> 
-                        let cmd = createUpdateCommand e fields
+                        let cmd = createUpdateCommand con sb e fields
                         Common.QueryEvents.PublishSqlQuery cmd.CommandText
                         cmd.ExecuteNonQuery() |> ignore
                         e._State <- Unchanged
                     | Deleted -> 
-                        let cmd = createDeleteCommand e
+                        let cmd = createDeleteCommand con sb e
                         Common.QueryEvents.PublishSqlQuery cmd.CommandText
                         cmd.ExecuteNonQuery() |> ignore
                         // remove the pk to prevent this attempting to be used again
                         e.SetColumnOptionSilent(pkLookup.[e.Table.FullName], None)
                     | Unchanged -> failwith "Unchanged entity encountered in update list - this should not be possible!")
                 scope.Complete()
+            finally
+                con.Close()
+
+        member this.ProcessUpdatesAsync(con, entities) =
+            let sb = Text.StringBuilder()
+            let (~~) (t:string) = sb.Append t |> ignore
+
+            // ensure columns have been loaded
+            entities |> List.map(fun e -> e.Table) 
+                     |> Seq.distinct 
+                     |> Seq.iter(fun t -> (this :> ISqlProvider).GetColumns(con,t) |> ignore )
+
+            con.Open()
+
+            use scope = new Transactions.TransactionScope(Transactions.TransactionScopeAsyncFlowOption.Enabled)
+            try
+                
+                // close the connection first otherwise it won't get enlisted into the transaction 
+                if con.State = ConnectionState.Open then con.Close()
+                con.Open()          
+                // initially supporting update/create/delete of single entities, no hierarchies yet
+                let handleEntity (e: SqlEntity) =
+                    match e._State with
+                    | Created -> 
+                        async {
+                            let cmd = createInsertCommand con sb e :?> System.Data.Common.DbCommand
+                            Common.QueryEvents.PublishSqlQuery cmd.CommandText
+                            let! id = cmd.ExecuteScalarAsync() |> Async.AwaitTask
+                            match e.GetColumnOption pkLookup.[e.Table.FullName] with
+                            | Some v -> () // if the primary key exists, do nothing
+                                           // this is because non-identity columns will have been set 
+                                           // manually and in that case scope_identity would bring back 0 "" or whatever
+                            | None ->  e.SetColumnSilent(pkLookup.[e.Table.FullName], id)
+                            e._State <- Unchanged
+                        }
+                    | Modified fields -> 
+                        async {
+                            let cmd = createUpdateCommand con sb e fields :?> System.Data.Common.DbCommand
+                            Common.QueryEvents.PublishSqlQuery cmd.CommandText
+                            do! cmd.ExecuteNonQueryAsync() |> Async.AwaitTask |> Async.Ignore
+                            e._State <- Unchanged
+                        }
+                    | Deleted -> 
+                        async {
+                            let cmd = createDeleteCommand con sb e :?> System.Data.Common.DbCommand
+                            Common.QueryEvents.PublishSqlQuery cmd.CommandText
+                            do! cmd.ExecuteNonQueryAsync() |> Async.AwaitTask |> Async.Ignore
+                            // remove the pk to prevent this attempting to be used again
+                            e.SetColumnOptionSilent(pkLookup.[e.Table.FullName], None)
+                        }
+                    | Unchanged -> failwith "Unchanged entity encountered in update list - this should not be possible!"
+                async { 
+                    do! Utilities.execiuteOneByOne handleEntity entities
+                    scope.Complete()
+                }
+
             finally
                 con.Close()

--- a/src/SQLProvider/Providers.SQLite.fs
+++ b/src/SQLProvider/Providers.SQLite.fs
@@ -470,49 +470,48 @@ type internal SQLiteProvider(resolutionPath, referencedAssemblies, runtimeAssemb
                      |> Seq.distinct 
                      |> Seq.iter(fun t -> (this :> ISqlProvider).GetColumns(con,t) |> ignore )
 
-            con.Open()
-
-            use scope = new Transactions.TransactionScope(Transactions.TransactionScopeAsyncFlowOption.Enabled)
-            try
+            async { 
+                use scope = new Transactions.TransactionScope(Transactions.TransactionScopeAsyncFlowOption.Enabled)
+                try
                 
-                // close the connection first otherwise it won't get enlisted into the transaction 
-                if con.State = ConnectionState.Open then con.Close()
-                con.Open()         
-                // initially supporting update/create/delete of single entities, no hierarchies yet
-                let handleEntity (e: SqlEntity) =
-                    match e._State with
-                    | Created -> 
-                        async {
-                            use cmd = createInsertCommand con sb e :?> System.Data.Common.DbCommand
-                            Common.QueryEvents.PublishSqlQuery cmd.CommandText
-                            let! id = cmd.ExecuteScalarAsync() |> Async.AwaitTask
-                            match e.GetColumnOption pkLookup.[e.Table.FullName] with
-                            | Some v -> () // if the primary key exists, do nothing
-                                           // this is because non-identity columns will have been set 
-                                           // manually and in that case scope_identity would bring back 0 "" or whatever
-                            | None ->  e.SetColumnSilent(pkLookup.[e.Table.FullName], id)
-                            e._State <- Unchanged
-                        }
-                    | Modified fields -> 
-                        async {
-                            use cmd = createUpdateCommand con sb e fields :?> System.Data.Common.DbCommand
-                            Common.QueryEvents.PublishSqlQuery cmd.CommandText
-                            do! cmd.ExecuteNonQueryAsync() |> Async.AwaitTask |> Async.Ignore
-                            e._State <- Unchanged
-                        }
-                    | Deleted -> 
-                        async {
-                            use cmd = createDeleteCommand con sb e :?> System.Data.Common.DbCommand
-                            Common.QueryEvents.PublishSqlQuery cmd.CommandText
-                            do! cmd.ExecuteNonQueryAsync() |> Async.AwaitTask |> Async.Ignore
-                            // remove the pk to prevent this attempting to be used again
-                            e.SetColumnOptionSilent(pkLookup.[e.Table.FullName], None)
-                        }
-                    | Unchanged -> failwith "Unchanged entity encountered in update list - this should not be possible!"
-                async { 
-                    do! Utilities.execiuteOneByOne handleEntity entities
-                    scope.Complete()
-                }
+                    // close the connection first otherwise it won't get enlisted into the transaction 
+                    if con.State = ConnectionState.Open then con.Close()
+                    do! con.OpenAsync() |> Async.AwaitIAsyncResult |> Async.Ignore
+                    // initially supporting update/create/delete of single entities, no hierarchies yet
+                    let handleEntity (e: SqlEntity) =
+                        match e._State with
+                        | Created -> 
+                            async {
+                                use cmd = createInsertCommand con sb e :?> System.Data.Common.DbCommand
+                                Common.QueryEvents.PublishSqlQuery cmd.CommandText
+                                let! id = cmd.ExecuteScalarAsync() |> Async.AwaitTask
+                                match e.GetColumnOption pkLookup.[e.Table.FullName] with
+                                | Some v -> () // if the primary key exists, do nothing
+                                               // this is because non-identity columns will have been set 
+                                               // manually and in that case scope_identity would bring back 0 "" or whatever
+                                | None ->  e.SetColumnSilent(pkLookup.[e.Table.FullName], id)
+                                e._State <- Unchanged
+                            }
+                        | Modified fields -> 
+                            async {
+                                use cmd = createUpdateCommand con sb e fields :?> System.Data.Common.DbCommand
+                                Common.QueryEvents.PublishSqlQuery cmd.CommandText
+                                do! cmd.ExecuteNonQueryAsync() |> Async.AwaitTask |> Async.Ignore
+                                e._State <- Unchanged
+                            }
+                        | Deleted -> 
+                            async {
+                                use cmd = createDeleteCommand con sb e :?> System.Data.Common.DbCommand
+                                Common.QueryEvents.PublishSqlQuery cmd.CommandText
+                                do! cmd.ExecuteNonQueryAsync() |> Async.AwaitTask |> Async.Ignore
+                                // remove the pk to prevent this attempting to be used again
+                                e.SetColumnOptionSilent(pkLookup.[e.Table.FullName], None)
+                            }
+                        | Unchanged -> failwith "Unchanged entity encountered in update list - this should not be possible!"
 
-            finally
-                con.Close()
+                    do! Utilities.executeOneByOne handleEntity entities
+                    scope.Complete()
+                finally
+                    con.Close()
+            }
+

--- a/src/SQLProvider/Providers.SQLite.fs
+++ b/src/SQLProvider/Providers.SQLite.fs
@@ -425,7 +425,7 @@ type internal SQLiteProvider(resolutionPath, referencedAssemblies, runtimeAssemb
 
             con.Open()
 
-            use scope = new Transactions.TransactionScope(Transactions.TransactionScopeAsyncFlowOption.Enabled)
+            use scope = Utilities.ensureTransaction()
             try
                 
                 // close the connection first otherwise it won't get enlisted into the transaction 
@@ -471,7 +471,7 @@ type internal SQLiteProvider(resolutionPath, referencedAssemblies, runtimeAssemb
                      |> Seq.iter(fun t -> (this :> ISqlProvider).GetColumns(con,t) |> ignore )
 
             async { 
-                use scope = new Transactions.TransactionScope(Transactions.TransactionScopeAsyncFlowOption.Enabled)
+                use scope = Utilities.ensureTransaction()
                 try
                 
                     // close the connection first otherwise it won't get enlisted into the transaction 

--- a/src/SQLProvider/SqlDesignTime.fs
+++ b/src/SQLProvider/SqlDesignTime.fs
@@ -403,6 +403,7 @@ type SqlTypeProvider(config: TypeProviderConfig) as this =
 
               yield! containers |> Seq.map(fun p ->  ProvidedProperty(p.Name.Replace("Container",""), p, GetterCode = fun args -> <@@ ((%%args.[0] : obj) :?> ISqlDataContext) @@>)) |> Seq.cast<MemberInfo>
               yield ProvidedMethod("SubmitUpdates",[],typeof<unit>,     InvokeCode = fun args -> <@@ ((%%args.[0] : obj) :?> ISqlDataContext).SubmitPendingChanges() @@>)  :> MemberInfo
+              yield ProvidedMethod("SubmitUpdatesAsync",[],typeof<unit>,     InvokeCode = fun args -> <@@ ((%%args.[0] : obj) :?> ISqlDataContext).SubmitPendingChangesAsync() @@>)  :> MemberInfo
               yield ProvidedMethod("GetUpdates",[],typeof<SqlEntity list>, InvokeCode = fun args -> <@@ ((%%args.[0] : obj) :?> ISqlDataContext).GetPendingEntities() @@>)  :> MemberInfo
               yield ProvidedMethod("ClearUpdates",[],typeof<SqlEntity list>,InvokeCode = fun args -> <@@ ((%%args.[0] : obj) :?> ISqlDataContext).ClearPendingChanges() @@>)  :> MemberInfo
               yield ProvidedMethod("CreateConnection",[],typeof<IDbConnection>,InvokeCode = fun args -> <@@ ((%%args.[0] : obj) :?> ISqlDataContext).CreateConnection() @@>)  :> MemberInfo

--- a/src/SQLProvider/SqlDesignTime.fs
+++ b/src/SQLProvider/SqlDesignTime.fs
@@ -403,7 +403,7 @@ type SqlTypeProvider(config: TypeProviderConfig) as this =
 
               yield! containers |> Seq.map(fun p ->  ProvidedProperty(p.Name.Replace("Container",""), p, GetterCode = fun args -> <@@ ((%%args.[0] : obj) :?> ISqlDataContext) @@>)) |> Seq.cast<MemberInfo>
               yield ProvidedMethod("SubmitUpdates",[],typeof<unit>,     InvokeCode = fun args -> <@@ ((%%args.[0] : obj) :?> ISqlDataContext).SubmitPendingChanges() @@>)  :> MemberInfo
-              yield ProvidedMethod("SubmitUpdatesAsync",[],typeof<unit>,     InvokeCode = fun args -> <@@ ((%%args.[0] : obj) :?> ISqlDataContext).SubmitPendingChangesAsync() @@>)  :> MemberInfo
+              yield ProvidedMethod("SubmitUpdatesAsync",[],typeof<Async<unit>>,     InvokeCode = fun args -> <@@ ((%%args.[0] : obj) :?> ISqlDataContext).SubmitPendingChangesAsync() @@>)  :> MemberInfo
               yield ProvidedMethod("GetUpdates",[],typeof<SqlEntity list>, InvokeCode = fun args -> <@@ ((%%args.[0] : obj) :?> ISqlDataContext).GetPendingEntities() @@>)  :> MemberInfo
               yield ProvidedMethod("ClearUpdates",[],typeof<SqlEntity list>,InvokeCode = fun args -> <@@ ((%%args.[0] : obj) :?> ISqlDataContext).ClearPendingChanges() @@>)  :> MemberInfo
               yield ProvidedMethod("CreateConnection",[],typeof<IDbConnection>,InvokeCode = fun args -> <@@ ((%%args.[0] : obj) :?> ISqlDataContext).CreateConnection() @@>)  :> MemberInfo

--- a/src/SQLProvider/SqlProvider.fsproj
+++ b/src/SQLProvider/SqlProvider.fsproj
@@ -8,13 +8,14 @@
     <OutputType>Library</OutputType>
     <RootNamespace>SqlProvider</RootNamespace>
     <AssemblyName>FSharp.Data.SqlProvider</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <Name>FSharp.Data.SqlProvider</Name>
     <SccProjectName>SAK</SccProjectName>
     <SccProvider>SAK</SccProvider>
     <SccAuxPath>SAK</SccAuxPath>
     <SccLocalPath>SAK</SccLocalPath>
     <TargetFSharpCoreVersion>4.3.0.0</TargetFSharpCoreVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/SQLProvider/SqlRuntime.Common.fs
+++ b/src/SQLProvider/SqlRuntime.Common.fs
@@ -259,6 +259,7 @@ and ISqlDataContext =
     abstract GetIndividual              : string * obj -> SqlEntity
     abstract SubmitChangedEntity        : SqlEntity -> unit
     abstract SubmitPendingChanges       : unit -> unit
+    abstract SubmitPendingChangesAsync  : unit -> Async<unit>
     abstract ClearPendingChanges        : unit -> unit
     abstract GetPendingEntities         : unit -> SqlEntity list
     abstract GetPrimaryKeyDefinition    : string -> string
@@ -405,6 +406,7 @@ and internal ISqlProvider =
     abstract GetIndividualQueryText : Table * string -> string
 
     abstract ProcessUpdates : IDbConnection * SqlEntity list -> unit
+    abstract ProcessUpdatesAsync : IDbConnection * SqlEntity list -> Async<unit>
     /// Accepts a SqlQuery object and produces the SQL to execute on the server.
     /// the other parameters are the base table alias, the base table, and a dictionary containing 
     /// the columns from the various table aliases that are in the SELECT projection

--- a/src/SQLProvider/SqlRuntime.DataContext.fs
+++ b/src/SQLProvider/SqlRuntime.DataContext.fs
@@ -70,7 +70,7 @@ type public SqlDataContext (typeName,connectionString:string,providerType,resolu
             match providerCache.TryGetValue typeName with
             | true,provider -> 
                 async{
-                    use con = provider.CreateConnection(connectionString)
+                    use con = provider.CreateConnection(connectionString) :?> System.Data.Common.DbConnection
                     do! provider.ProcessUpdatesAsync(con, Seq.toList pendingChanges)
                     pendingChanges.Clear()
                 }

--- a/src/SQLProvider/SqlRuntime.Linq.fs
+++ b/src/SQLProvider/SqlRuntime.Linq.fs
@@ -418,14 +418,16 @@ module internal QueryImplementation =
                 yield en.Current
             }
         async{
-//            match s :> SqlQueryable<_>) with
-//            | true ->
-                let coll = s :?> SqlQueryable<_>
+            match s with
+            | :? SqlQueryable<'T> as coll -> 
                 let! en = coll.GetAsyncEnumerator()
                 return yieldseq en
-//            | false ->
-//                let en = s.GetEnumerator()
-//                return yieldseq en
+            | :? SqlOrderedQueryable<'T> as coll -> 
+                let! en = coll.GetAsyncEnumerator()
+                return yieldseq en
+            | c ->
+                let en = c.GetEnumerator()
+                return yieldseq en
         }
 namespace FSharp.Data.Sql
 open FSharp.Data.Sql.Runtime

--- a/src/SQLProvider/Utils.fs
+++ b/src/SQLProvider/Utils.fs
@@ -43,12 +43,12 @@ module internal Utilities =
 
     /// DB-connections are not usually supporting parallel SQL-query execution, so even when
     /// async thread is available, it can't be used to execute another SQL at the same time.
-    let rec execiuteOneByOne asyncFunc entityList =
+    let rec executeOneByOne asyncFunc entityList =
         match entityList with
         | h::t -> 
             async {
                 do! asyncFunc h
-                return! execiuteOneByOne asyncFunc t
+                return! executeOneByOne asyncFunc t
             }
         | [] -> async { () }
 

--- a/src/SQLProvider/Utils.fs
+++ b/src/SQLProvider/Utils.fs
@@ -52,6 +52,15 @@ module internal Utilities =
             }
         | [] -> async { () }
 
+    let ensureTransaction() =
+        #if __MonoCS__
+            // Todo: Take TransactionScopeAsyncFlowOption into use when implemented in Mono.
+            // Without it, transactions are not thread-safe over threads e.g. using async can be dangerous)
+            new Transactions.TransactionScope()
+        #else
+            new Transactions.TransactionScope(Transactions.TransactionScopeAsyncFlowOption.Enabled)
+        #endif
+
 module ConfigHelpers = 
     
     open System

--- a/tests/SqlProvider.Tests/scripts/MySqlTests.fsx
+++ b/tests/SqlProvider.Tests/scripts/MySqlTests.fsx
@@ -40,6 +40,13 @@ let employeesFirstName =
         select (emp.FirstName, emp.LastName)
     } |> Seq.toList
 
+let employeesFirstNameAsync = 
+    query {
+        for emp in ctx.Hr.Employees do
+        select (emp.FirstName, emp.LastName)
+    } |> Seq.executeQueryAsync |> Async.RunSynchronously
+
+
 let salesNamedDavid = 
     query {
             for emp in ctx.Hr.Employees do
@@ -120,7 +127,7 @@ antartica.RegionName <- "ant"
 ctx.SubmitUpdates()
 
 antartica.Delete()
-ctx.SubmitUpdates()
+ctx.SubmitUpdatesAsync() |> Async.RunSynchronously
 
 //********************** Procedures **************************//
 


### PR DESCRIPTION
#163 
Ability to make asynchronous database operations, for all the providers. 

SQL-Query operations for lists (`open FSharp.Data.Sql`):

            query {
                for x in dbContext.Mytable do
                where (x.Something.IsNone)
                select (x)
            } |> Seq.executeQueryAsync

Crud operations to update, insert & delete:
`dbContext.SubmitUpdatesAsync()`

The old sync-methods and ways are still in place, so you can still choose those if you want to use your web/BL-server CPU-resources for heating.

These new async-ones will return F# `Async` class. You have to deal with that. My suggestion is that you say `Async.AwaitTask` and return that out from your web-server (like SignalR / Owin / WebApi / whatever).

I recommend NOT to do Async.AsParallel (as 3rd party data-connection-providers are usually not very good in parallelism) and NOT to use Async.RunSynchronously (as then you loose the benefits of async, that method is for losers).

Some testing done with MySQL and MsSql.
