### PR TITLE
Fix generated SQL when query expression doesn't contain any entity projections.

### DIFF
--- a/src/SQLProvider/Providers.MSAccess.fs
+++ b/src/SQLProvider/Providers.MSAccess.fs
@@ -241,6 +241,7 @@ type internal MSAccessProvider() =
 
             // first build  the select statement, this is easy ...
             let columns =
+                if projectionColumns |> Seq.isEmpty then "1" else
                 String.Join(",",
                     [|for KeyValue(k,v) in projectionColumns do
                         if v.Count = 0 then   // if no columns exist in the projection then get everything

--- a/src/SQLProvider/Providers.MSAccess.fs
+++ b/src/SQLProvider/Providers.MSAccess.fs
@@ -11,11 +11,11 @@ open FSharp.Data.Sql.Schema
 open FSharp.Data.Sql.Common
 
 type internal MSAccessProvider() =
-    let pkLookup =     new Dictionary<string,string>()
-    let tableLookup =  new Dictionary<string,Table>()
+    let pkLookup = new Dictionary<string,string>()
+    let tableLookup = new Dictionary<string,Table>()
     let relationshipLookup = new Dictionary<string,Relationship list * Relationship list>()
     let columnLookup = new Dictionary<string,Column list>()
-     
+
     let mutable typeMappings = []
     let mutable findClrType : (string -> TypeMapping option)  = fun _ -> failwith "!"
     let mutable findDbType : (string -> TypeMapping option)  = fun _ -> failwith "!"
@@ -30,7 +30,7 @@ type internal MSAccessProvider() =
             p.DbType
 
         let getClrType (input:string) = Type.GetType(input).ToString()
-        let mappings =             
+        let mappings =
             [
                 for r in dt.Rows do
                     let clrType = getClrType (string r.["DataType"])
@@ -39,45 +39,46 @@ type internal MSAccessProvider() =
                     let dbType = getDbType providerType
                     yield { ProviderTypeName = Some oleDbType; ClrType = clrType; DbType = dbType; ProviderType = Some providerType; }
             ]
-        
+
         let clrMappings =
             mappings
             |> List.map (fun m -> m.ClrType, m)
             |> Map.ofList
 
-        let dbMappings = 
+        let dbMappings =
             mappings
             |> List.map (fun m -> m.ProviderTypeName.Value, m)
             |> Map.ofList
-        
+
         let enumMappings =
             mappings
-            |> List.map (fun m -> m.ProviderType.Value, m)            
+            |> List.map (fun m -> m.ProviderType.Value, m)
             |> Map.ofList
 
         typeMappings <- mappings
         findClrType <- clrMappings.TryFind
         findDbType <- dbMappings.TryFind
         findDbTypeByEnum <- enumMappings.TryFind
-    
-    let createInsertCommand (con:IDbConnection) (sb:Text.StringBuilder) (entity:SqlEntity) =     
+
+    let createInsertCommand (con:IDbConnection) (sb:Text.StringBuilder) (entity:SqlEntity) =
         let (~~) (t:string) = sb.Append t |> ignore
+
         let cmd = new OleDbCommand()
         cmd.Connection <- con :?> OleDbConnection
-        let pk = pkLookup.[entity.Table.FullName] 
-        let columnNames, values = 
+
+        let columnNames, values =
             (([],0),entity.ColumnValues)
             ||> Seq.fold(fun (out,i) (k,v) ->
                 let name = sprintf "@param%i" i
                 let p = OleDbParameter(name,v)
                 (k,p)::out,i+1)
-            |> fun (x,_)-> x 
+            |> fun (x,_)-> x
             |> List.rev
-            |> List.toArray 
+            |> List.toArray
             |> Array.unzip
-                
+
         sb.Clear() |> ignore
-        ~~(sprintf "INSERT INTO [%s] (%s) VALUES (%s)"//; SELECT @@IDENTITY;" 
+        ~~(sprintf "INSERT INTO [%s] (%s) VALUES (%s)"//; SELECT @@IDENTITY;"
             entity.Table.Name
             (String.Join(",", columnNames))
             (String.Join(",", values |> Array.map(fun p -> p.ParameterName))))
@@ -89,32 +90,32 @@ type internal MSAccessProvider() =
         let (~~) (t:string) = sb.Append t |> ignore
         let cmd = new OleDbCommand()
         cmd.Connection <- con :?> OleDbConnection
-        let pk = pkLookup.[entity.Table.FullName] 
+        let pk = pkLookup.[entity.Table.FullName]
         sb.Clear() |> ignore
 
         if changedColumns |> List.exists ((=)pk) then failwith "Error - you cannot change the primary key of an entity."
 
-        let pkValue = 
+        let pkValue =
             match entity.GetColumnOption<obj> pk with
             | Some v -> v
             | None -> failwith "Error - you cannot update an entity that does not have a primary key."
-                
-        let data = 
+
+        let data =
             (([],0),changedColumns)
-            ||> List.fold(fun (out,i) col ->                                                         
+            ||> List.fold(fun (out,i) col ->
                 let name = sprintf "@param%i" i
-                let p = 
+                let p =
                     match entity.GetColumnOption<obj> col with
                     | Some v -> OleDbParameter(name,v)
                     | None -> OleDbParameter(name,DBNull.Value)
                 (col,p)::out,i+1)
-            |> fun (x,_)-> x 
+            |> fun (x,_)-> x
             |> List.rev
-            |> List.toArray 
-                
+            |> List.toArray
+
         let pkParam = OleDbParameter("@pk", pkValue)
 
-        ~~(sprintf "UPDATE [%s] SET %s WHERE %s = @pk;" 
+        ~~(sprintf "UPDATE [%s] SET %s WHERE %s = @pk;"
             entity.Table.Name
             (String.Join(",", data |> Array.map(fun (c,p) -> sprintf "%s = %s" c p.ParameterName ) ))
             pk)
@@ -123,15 +124,15 @@ type internal MSAccessProvider() =
         cmd.Parameters.Add pkParam |> ignore
         cmd.CommandText <- sb.ToString()
         cmd
-            
+
     let createDeleteCommand (con:IDbConnection) (sb:Text.StringBuilder) (entity:SqlEntity) =
         let (~~) (t:string) = sb.Append t |> ignore
         let cmd = new OleDbCommand()
         cmd.Connection <- con :?> OleDbConnection
         sb.Clear() |> ignore
-        let pk = pkLookup.[entity.Table.FullName] 
+        let pk = pkLookup.[entity.Table.FullName]
         sb.Clear() |> ignore
-        let pkValue = 
+        let pkValue =
             match entity.GetColumnOption<obj> pk with
             | Some v -> v
             | None -> failwith "Error - you cannot delete an entity that does not have a primary key."
@@ -143,100 +144,103 @@ type internal MSAccessProvider() =
     interface ISqlProvider with
         member __.CreateConnection(connectionString) = upcast new OleDbConnection(connectionString)
         member __.CreateCommand(connection,commandText) = upcast new OleDbCommand(commandText,connection:?>OleDbConnection)
-        member __.CreateCommandParameter(param, value) = 
-            let p = OleDbParameter(param.Name,value)            
+
+        member __.CreateCommandParameter(param, value) =
+            let p = OleDbParameter(param.Name,value)
             p.DbType <- param.TypeMapping.DbType
             p.Direction <- param.Direction
             Option.iter (fun l -> p.Size <- l) param.Length
             upcast p
-        member __.ExecuteSprocCommand(com,definition,retCols,values) =  raise(NotImplementedException())
-        member __.CreateTypeMappings(con) = createTypeMappings (con:?>OleDbConnection)     
-        member __.GetTables(con,cs) =
+
+        member __.ExecuteSprocCommand(_,_,_,_) =  raise(NotImplementedException())
+        member __.CreateTypeMappings(con) = createTypeMappings (con:?>OleDbConnection)
+
+        member __.GetTables(con,_) =
             if con.State <> ConnectionState.Open then con.Open()
             let con = con:?>OleDbConnection
-            let tables = 
+            let tables =
                 con.GetSchema("Tables").AsEnumerable()
-                |> Seq.filter (fun row -> ["TABLE";"VIEW";"LINK"] |> List.exists (fun typ -> typ = row.["TABLE_TYPE"].ToString())) // = "TABLE" || row.["TABLE_TYPE"].ToString() = "VIEW" || row.["TABLE_TYPE"].ToString() = "LINK")  //The text file specification 'A Link Specification' does not exist. You cannot import, export, or link using the specification.                                                                                                                       
+                |> Seq.filter (fun row -> ["TABLE";"VIEW";"LINK"] |> List.exists (fun typ -> typ = row.["TABLE_TYPE"].ToString())) // = "TABLE" || row.["TABLE_TYPE"].ToString() = "VIEW" || row.["TABLE_TYPE"].ToString() = "LINK")  //The text file specification 'A Link Specification' does not exist. You cannot import, export, or link using the specification.
                 |> Seq.map (fun row -> let table ={ Schema = Path.GetFileNameWithoutExtension(con.DataSource); Name = row.["TABLE_NAME"].ToString() ; Type=row.["TABLE_TYPE"].ToString() }
                                        if tableLookup.ContainsKey table.FullName = false then tableLookup.Add(table.FullName,table)
                                        table)
                 |> List.ofSeq
             tables
 
-        member __.GetPrimaryKey(table) = 
+        member __.GetPrimaryKey(table) =
             match pkLookup.TryGetValue table.FullName with
             | true, v -> Some v
             | _ -> None
-        member __.GetColumns(con,table) = 
+
+        member __.GetColumns(con,table) =
             match columnLookup.TryGetValue table.FullName with
             | (true,data) -> data
-            | _ -> 
+            | _ ->
                if con.State <> ConnectionState.Open then con.Open()
-               let pks = 
+               let pks =
                     (con:?>OleDbConnection).GetSchema("Indexes",[|null;null;null;null;table.Name|]).AsEnumerable()
                     |> Seq.filter (fun idx ->  bool.Parse(idx.["PRIMARY_KEY"].ToString()))
                     |> Seq.map (fun idx -> idx.["COLUMN_NAME"].ToString())
                     |> Seq.toList
 
-               let columns = 
+               let columns =
                     (con:?>OleDbConnection).GetSchema("Columns",[|null;null;table.Name;null|]).AsEnumerable()
                     |> Seq.map (fun row -> let dt = row.["DATA_TYPE"].ToString()
                                            match findDbType dt with
                                            |Some(m) ->
-                                                 let col = 
+                                                 let col =
                                                     {Column.Name = row.["COLUMN_NAME"].ToString();
                                                      TypeMapping = m
                                                      IsPrimarKey = pks |> List.exists (fun idx -> idx = row.["COLUMN_NAME"].ToString())
                                                      IsNullable = bool.Parse(row.["IS_NULLABLE"].ToString()) }
                                                  col
                                            |_ -> failwith "failed to map datatypes") |> List.ofSeq
-              
+
               // only add to PK lookup if it's a single pk - no support for composite keys yet
                match pks with
-               | pk::[] -> pkLookup.Add(table.FullName, pk) 
+               | pk::[] -> pkLookup.Add(table.FullName, pk)
                | _ -> ()
 
                columnLookup.Add(table.FullName,columns)
                columns
+
         member __.GetRelationships(con,table) =
-            if con.State <> ConnectionState.Open then con.Open() 
-            let rels = 
+            if con.State <> ConnectionState.Open then con.Open()
+            let rels =
                 (con:?>OleDbConnection).GetOleDbSchemaTable(OleDbSchemaGuid.Foreign_Keys,[|null|]).AsEnumerable()
             let children = rels |> Seq.filter (fun r -> r.["PK_TABLE_NAME"].ToString() = table.Name)
                                 |> Seq.map    (fun r -> let pktableName = table.FullName
                                                         let fktableName = sprintf "[%s].[%s]" table.Schema  (r.["FK_TABLE_NAME"].ToString())
-                                                        let name = sprintf "FK_%s_%s" (r.["FK_TABLE_NAME"].ToString()) (r.["PK_TABLE_NAME"].ToString()) 
-                                                        {Name=name;PrimaryTable = pktableName;PrimaryKey=r.["PK_COLUMN_NAME"].ToString();ForeignTable=fktableName;ForeignKey=r.["FK_COLUMN_NAME"].ToString()})    
+                                                        let name = sprintf "FK_%s_%s" (r.["FK_TABLE_NAME"].ToString()) (r.["PK_TABLE_NAME"].ToString())
+                                                        {Name=name;PrimaryTable = pktableName;PrimaryKey=r.["PK_COLUMN_NAME"].ToString();ForeignTable=fktableName;ForeignKey=r.["FK_COLUMN_NAME"].ToString()})
                                 |> List.ofSeq
             let parents  = rels |> Seq.filter (fun r -> r.["FK_TABLE_NAME"].ToString() = table.Name)
                                 |> Seq.map    (fun r -> let pktableName = sprintf "[%s].[%s]" table.Schema  (r.["PK_TABLE_NAME"].ToString())
                                                         let fktableName = table.FullName
-                                                        let name = sprintf "FK_%s_%s" (r.["FK_TABLE_NAME"].ToString()) (r.["PK_TABLE_NAME"].ToString()) 
-                                                        {Name=name;PrimaryTable = pktableName;PrimaryKey=r.["PK_COLUMN_NAME"].ToString();ForeignTable=fktableName;ForeignKey=r.["FK_COLUMN_NAME"].ToString()})    
+                                                        let name = sprintf "FK_%s_%s" (r.["FK_TABLE_NAME"].ToString()) (r.["PK_TABLE_NAME"].ToString())
+                                                        {Name=name;PrimaryTable = pktableName;PrimaryKey=r.["PK_COLUMN_NAME"].ToString();ForeignTable=fktableName;ForeignKey=r.["FK_COLUMN_NAME"].ToString()})
                                 |> List.ofSeq
             relationshipLookup.Add(table.FullName,(children,parents))
             (children,parents)
-        member __.GetSprocs(con) = 
-            []
 
-        member this.GetIndividualsQueryText(table,amount) = sprintf "SELECT TOP %i * FROM [%s]" amount table.Name
-                                                            
-        member this.GetIndividualQueryText(table,column) = sprintf "SELECT * FROM [%s] WHERE [%s] = @id" table.Name column
-        
-        member this.GenerateQueryText(sqlQuery,baseAlias,baseTable,projectionColumns) = 
+        member __.GetSprocs(_) = []
+        member __.GetIndividualsQueryText(table,amount) = sprintf "SELECT TOP %i * FROM [%s]" amount table.Name
+        member __.GetIndividualQueryText(table,column) = sprintf "SELECT * FROM [%s] WHERE [%s] = @id" table.Name column
+
+        member __.GenerateQueryText(sqlQuery,baseAlias,baseTable,projectionColumns) =
             let sb = System.Text.StringBuilder()
             let parameters = ResizeArray<_>()
             let (~~) (t:string) = sb.Append t |> ignore
-    
+
             let getTable x =
                 match sqlQuery.Aliases.TryFind x with
                 | Some(a) -> a
                 | None -> baseTable
 
             let singleEntity = sqlQuery.Aliases.Count = 0
-            
+
             // first build  the select statement, this is easy ...
-            let columns = 
+            let columns =
                 String.Join(",",
                     [|for KeyValue(k,v) in projectionColumns do
                         if v.Count = 0 then   // if no columns exist in the projection then get everything
@@ -244,10 +248,10 @@ type internal MSAccessProvider() =
                                 if singleEntity then yield sprintf "[%s].[%s] as [%s]" k col col
                                 else yield sprintf "[%s].[%s] as [%s_%s]" k col k col
                         else
-                            for col in v do 
+                            for col in v do
                                 if singleEntity then yield sprintf "[%s].[%s] as [%s]" k col col
                                 else yield sprintf "[%s].[%s] as [%s_%s]" k col k col|]) // F# makes this so easy :)
-        
+
             // next up is the filter expressions
             // make this nicer later.. just try and get the damn thing to work properly (well, at all) for now :D
             // NOTE: really need to assign the parameters their correct SQL types
@@ -262,15 +266,15 @@ type internal MSAccessProvider() =
                            | :? DateTime as dt -> dt.ToOADate() |> box
                            | _           -> value
                 OleDbParameter(paramName,valu):> IDbDataParameter
-            let rec filterBuilder = function 
+            let rec filterBuilder = function
                 | [] -> ()
                 | (cond::conds) ->
                     let build op preds (rest:Condition list option) =
                         ~~ "("
                         preds |> List.iteri( fun i (alias,col,operator,data) ->
-                                let extractData data = 
+                                let extractData data =
                                      match data with
-                                     | Some(x) when (box x :? obj array) -> 
+                                     | Some(x) when (box x :? obj array) ->
                                          // in and not in operators pass an array
                                          let strings = box x :?> obj array
                                          strings |> Array.map createParam
@@ -281,19 +285,19 @@ type internal MSAccessProvider() =
                                 let paras = extractData data
                                 ~~(sprintf "%s%s" prefix <|
                                     match operator with
-                                    | FSharp.Data.Sql.IsNull -> (sprintf "[%s].[%s] IS NULL") alias col 
-                                    | FSharp.Data.Sql.NotNull -> (sprintf "[%s].[%s] IS NOT NULL") alias col 
-                                    | FSharp.Data.Sql.In ->                                     
+                                    | FSharp.Data.Sql.IsNull -> (sprintf "[%s].[%s] IS NULL") alias col
+                                    | FSharp.Data.Sql.NotNull -> (sprintf "[%s].[%s] IS NOT NULL") alias col
+                                    | FSharp.Data.Sql.In ->
                                         let text = String.Join(",",paras |> Array.map (fun p -> p.ParameterName))
                                         Array.iter parameters.Add paras
                                         (sprintf "[%s].[%s] IN (%s)") alias col text
-                                    | FSharp.Data.Sql.NotIn ->                                    
+                                    | FSharp.Data.Sql.NotIn ->
                                         let text = String.Join(",",paras |> Array.map (fun p -> p.ParameterName))
                                         Array.iter parameters.Add paras
-                                        (sprintf "[%s].[%s] NOT IN (%s)") alias col text 
-                                    | _ -> 
+                                        (sprintf "[%s].[%s] NOT IN (%s)") alias col text
+                                    | _ ->
                                         parameters.Add paras.[0]
-                                        (sprintf "[%s].[%s]%s %s") alias col 
+                                        (sprintf "[%s].[%s]%s %s") alias col
                                          (operator.ToString()) paras.[0].ParameterName)
                         )
                         // there's probably a nicer way to do this
@@ -306,40 +310,39 @@ type internal MSAccessProvider() =
                                 ~~ (sprintf " %s " op)
                                 filterBuilder [x]
                                 ~~ (sprintf " %s " op)
-                                aux xs 
+                                aux xs
                             | x::xs ->
                                 filterBuilder [x]
                                 ~~ (sprintf " %s " op)
                                 aux xs
                             | [] -> ()
-                    
+
                         Option.iter aux rest
                         ~~ ")"
-                
+
                     match cond with
                     | Or(preds,rest) -> build "OR" preds rest
-                    | And(preds,rest) ->  build "AND" preds rest 
-                
+                    | And(preds,rest) ->  build "AND" preds rest
+
                     filterBuilder conds
-                
-            // next up is the FROM statement which includes joins .. 
-            let fromBuilder(numLinks:int) = 
+
+            // next up is the FROM statement which includes joins ..
+            let fromBuilder(numLinks:int) =
                 sqlQuery.Links
                 |> List.iter(fun (fromAlias, data, destAlias)  ->
                     let joinType = if data.OuterJoin then "LEFT JOIN " else "INNER JOIN "
                     let destTable = getTable destAlias
                     ~~  (sprintf "%s [%s] as [%s] on [%s].[%s] = [%s].[%s]"
-                        joinType destTable.Name destAlias 
+                        joinType destTable.Name destAlias
                         (if data.RelDirection = RelationshipDirection.Parents then fromAlias else destAlias)
-                        data.ForeignKey  
-                        (if data.RelDirection = RelationshipDirection.Parents then destAlias else fromAlias) 
+                        data.ForeignKey
+                        (if data.RelDirection = RelationshipDirection.Parents then destAlias else fromAlias)
                         data.PrimaryKey)
                     if (numLinks > 0)  then ~~ ")")//append close paren after each JOIN, if necessary
-                        
 
             let orderByBuilder() =
                 sqlQuery.Ordering
-                |> List.iteri(fun i (alias,column,desc) -> 
+                |> List.iteri(fun i (alias,column,desc) ->
                     if i > 0 then ~~ ", "
                     ~~ (sprintf "[%s].[%s] %s" alias column (if not desc then "DESC" else "")))
 
@@ -358,57 +361,57 @@ type internal MSAccessProvider() =
             if sqlQuery.Filters.Length > 0 then
                 // each filter is effectively the entire contents of each where clause in the linq query,
                 // of which there can be many. Simply turn them all into one big AND expression as that is the
-                // only logical way to deal with them. 
+                // only logical way to deal with them.
                 let f = [And([],Some sqlQuery.Filters)]
-                ~~"WHERE " 
+                ~~"WHERE "
                 filterBuilder f
-        
+
             if sqlQuery.Ordering.Length > 0 then
                 ~~"ORDER BY "
                 orderByBuilder()
 
             let sql = sb.ToString()
             (sql,parameters)
-    
+
         member this.ProcessUpdates(con, entities) =
             let sb = Text.StringBuilder()
 
             entities |> List.iter (fun e -> printfn "entity - %A" e.ColumnValues)
             // ensure columns have been loaded
-            entities |> List.map(fun e -> e.Table) 
-                     |> Seq.distinct 
+            entities |> List.map(fun e -> e.Table)
+                     |> Seq.distinct
                      |> Seq.iter(fun t -> (this :> ISqlProvider).GetColumns(con,t) |> ignore )
 
             if con.State = ConnectionState.Closed then con.Open()
 
             try
-                // close the connection first otherwise it won't get enlisted into the transaction 
+                // close the connection first otherwise it won't get enlisted into the transaction
                 if con.State = ConnectionState.Open then con.Close()
                 con.Open()
                 use trnsx = con.BeginTransaction()
-                try                
+                try
                     // initially supporting update/create/delete of single entities, no hierarchies yet
                     entities
-                    |> List.iter(fun e -> 
+                    |> List.iter(fun e ->
                         match e._State with
-                        | Created -> 
+                        | Created ->
                             let cmd = createInsertCommand con sb e
                             cmd.Transaction <- trnsx :?> OleDbTransaction
                             Common.QueryEvents.PublishSqlQuery cmd.CommandText
                             let id = cmd.ExecuteScalar()
                             match e.GetColumnOption pkLookup.[e.Table.FullName] with
-                            | Some v -> () // if the primary key exists, do nothing
-                                           // this is because non-identity columns will have been set 
-                                           // manually and in that case scope_identity would bring back 0 "" or whatever
+                            | Some(_) -> () // if the primary key exists, do nothing
+                                            // this is because non-identity columns will have been set
+                                            // manually and in that case scope_identity would bring back 0 "" or whatever
                             | None ->  e.SetColumnSilent(pkLookup.[e.Table.FullName], id)
                             e._State <- Unchanged
-                        | Modified fields -> 
+                        | Modified fields ->
                             let cmd = createUpdateCommand con sb e fields
                             cmd.Transaction <- trnsx :?> OleDbTransaction
                             Common.QueryEvents.PublishSqlQuery cmd.CommandText
                             cmd.ExecuteNonQuery() |> ignore
                             e._State <- Unchanged
-                        | Deleted -> 
+                        | Deleted ->
                             let cmd = createDeleteCommand con sb e
                             cmd.Transaction <- trnsx :?> OleDbTransaction
                             Common.QueryEvents.PublishSqlQuery cmd.CommandText
@@ -417,8 +420,8 @@ type internal MSAccessProvider() =
                             e.SetColumnOptionSilent(pkLookup.[e.Table.FullName], None)
                         | Unchanged -> failwith "Unchanged entity encountered in update list - this should not be possible!")
                     trnsx.Commit()
-                with 
-                |e -> trnsx.Rollback()
+                with _ ->
+                    trnsx.Rollback()
             finally
                 con.Close()
 
@@ -427,36 +430,36 @@ type internal MSAccessProvider() =
 
             entities |> List.iter (fun e -> printfn "entity - %A" e.ColumnValues)
             // ensure columns have been loaded
-            entities |> List.map(fun e -> e.Table) 
-                     |> Seq.distinct 
+            entities |> List.map(fun e -> e.Table)
+                     |> Seq.distinct
                      |> Seq.iter(fun t -> (this :> ISqlProvider).GetColumns(con,t) |> ignore )
 
             use scope = Utilities.ensureTransaction()
             try
-                // close the connection first otherwise it won't get enlisted into the transaction 
+                // close the connection first otherwise it won't get enlisted into the transaction
                 if con.State = ConnectionState.Open then con.Close()
-                async { 
+                async {
 
                     do! con.OpenAsync() |> Async.AwaitIAsyncResult |> Async.Ignore
                     use trnsx = con.BeginTransaction()
-                    try                
+                    try
                         // initially supporting update/create/delete of single entities, no hierarchies yet
                         let handleEntity (e: SqlEntity) =
                             match e._State with
-                            | Created -> 
+                            | Created ->
                                 async {
                                     let cmd = createInsertCommand con sb e
                                     cmd.Transaction <- trnsx :?> OleDbTransaction
                                     Common.QueryEvents.PublishSqlQuery cmd.CommandText
                                     let id = cmd.ExecuteScalarAsync()
                                     match e.GetColumnOption pkLookup.[e.Table.FullName] with
-                                    | Some v -> () // if the primary key exists, do nothing
-                                                   // this is because non-identity columns will have been set 
-                                                   // manually and in that case scope_identity would bring back 0 "" or whatever
+                                    | Some(_) -> () // if the primary key exists, do nothing
+                                                    // this is because non-identity columns will have been set
+                                                    // manually and in that case scope_identity would bring back 0 "" or whatever
                                     | None ->  e.SetColumnSilent(pkLookup.[e.Table.FullName], id)
                                     e._State <- Unchanged
                                 }
-                            | Modified fields -> 
+                            | Modified fields ->
                                 async {
                                     let cmd = createUpdateCommand con sb e fields
                                     cmd.Transaction <- trnsx :?> OleDbTransaction
@@ -464,7 +467,7 @@ type internal MSAccessProvider() =
                                     cmd.ExecuteNonQuery() |> ignore
                                     e._State <- Unchanged
                                 }
-                            | Deleted -> 
+                            | Deleted ->
                                 async {
                                     let cmd = createDeleteCommand con sb e
                                     cmd.Transaction <- trnsx :?> OleDbTransaction
@@ -478,11 +481,8 @@ type internal MSAccessProvider() =
                         do! Utilities.executeOneByOne handleEntity entities
                         trnsx.Commit()
                         scope.Complete()
-
-                    with 
-                    |e -> 
+                    with _ ->
                         trnsx.Rollback()
                 }
-
             finally
                 con.Close()

--- a/src/SQLProvider/Providers.MsSqlServer.fs
+++ b/src/SQLProvider/Providers.MsSqlServer.fs
@@ -8,12 +8,11 @@ open FSharp.Data.Sql
 open FSharp.Data.Sql.Schema
 open FSharp.Data.Sql.Common
 
-module MSSqlServer = 
-
-    let getSchema name (args:string[]) (con:IDbConnection) = 
+module MSSqlServer =
+    let getSchema name (args:string[]) (con:IDbConnection) =
         let con = (con :?> SqlConnection)
         if con.State <> ConnectionState.Open then con.Open()
-        let res = con.GetSchema(name, args)    
+        let res = con.GetSchema(name, args)
         con.Close()
         res
 
@@ -29,15 +28,15 @@ module MSSqlServer =
             p.SqlDbType <- (Enum.ToObject(typeof<SqlDbType>, providerType) :?> SqlDbType)
             p.DbType
 
-        let getClrType (input:string) = 
+        let getClrType (input:string) =
             let t = Type.GetType input
             if t <> null then t.ToString() else typeof<String>.ToString()
 
-        let mappings =             
+        let mappings =
             [
                 for r in dt.Rows do
                     let oleDbType = string r.["TypeName"]
-                    let clrType = 
+                    let clrType =
                         if oleDbType = "tinyint"
                         then typeof<byte>.ToString()
                         else getClrType (string r.["DataType"])
@@ -52,43 +51,41 @@ module MSSqlServer =
             |> List.map (fun m -> m.ClrType, m)
             |> Map.ofList
 
-        let dbMappings = 
+        let dbMappings =
             mappings
             |> List.map (fun m -> m.ProviderTypeName.Value, m)
             |> Map.ofList
-            
+
         typeMappings <- mappings
         findClrType <- clrMappings.TryFind
         findDbType <- dbMappings.TryFind
-
 
     let createConnection connectionString = new SqlConnection(connectionString) :> IDbConnection
 
     let createCommand commandText (connection:IDbConnection) = new SqlCommand(commandText, downcast connection) :> IDbCommand
 
-    let dbUnbox<'a> (v:obj) : 'a = 
+    let dbUnbox<'a> (v:obj) : 'a =
         if Convert.IsDBNull(v) then Unchecked.defaultof<'a> else unbox v
-    
-    let dbUnboxWithDefault<'a> def (v:obj) : 'a = 
+
+    let dbUnboxWithDefault<'a> def (v:obj) : 'a =
         if Convert.IsDBNull(v) then def else unbox v
 
     let connect (con:IDbConnection) f =
         if con.State <> ConnectionState.Open then con.Open()
         let result = f con
         con.Close(); result
-        
+
     let executeSql sql (con:IDbConnection) =
-        use com = new SqlCommand(sql,con:?>SqlConnection)    
+        use com = new SqlCommand(sql,con:?>SqlConnection)
         com.ExecuteReader()
 
     let readParameter (parameter:IDbDataParameter) =
-        if parameter <> null 
-        then 
+        if parameter <> null then
             let par = parameter :?> SqlParameter
             par.Value
         else null
 
-    let isSQL2012Orlater (con:IDbConnection) =  
+    let isSQL2012Orlater (con:IDbConnection) =
         try
             let reader = executeSql "SELECT SERVERPROPERTY('productversion')" con
             let version = reader.GetSqlString(0)
@@ -97,8 +94,8 @@ module MSSqlServer =
             | _ -> false
         with _ -> false
 
-    let createCommandParameter (param:QueryParameter) (value:obj) = 
-        let p = SqlParameter(param.Name,value)            
+    let createCommandParameter (param:QueryParameter) (value:obj) =
+        let p = SqlParameter(param.Name,value)
         p.DbType <- param.TypeMapping.DbType
         Option.iter (fun (t:int) -> p.SqlDbType <- Enum.ToObject(typeof<SqlDbType>, t) :?> SqlDbType) param.TypeMapping.ProviderType
         p.Direction <- param.Direction
@@ -122,7 +119,7 @@ module MSSqlServer =
                     with
                     | ex ->
                         System.Diagnostics.Debug.WriteLine(sprintf "Failed to retrieve metadata for sproc %s\r\n : %s" sname.DbName (ex.ToString()))
-                        []) //Just assumes the proc / func returns something and let the caller process the result, for now.  
+                        []) //Just assumes the proc / func returns something and let the caller process the result, for now.
             initialSchemas
             |> List.mapi (fun i dt ->
                 match dt with
@@ -137,7 +134,7 @@ module MSSqlServer =
                           Length = None } |> Some
                     | None -> None)
             |> List.choose id
-        let retValueCols = 
+        let retValueCols =
             sparams
             |> List.filter (fun x -> x.Direction = ParameterDirection.ReturnValue)
             |> List.mapi (fun i p ->
@@ -146,22 +143,22 @@ module MSSqlServer =
                 else p)
         derivedCols @ retValueCols
 
-    let getSprocName (row:DataRow) = 
+    let getSprocName (row:DataRow) =
         let owner = dbUnbox row.["specific_catalog"]
         let (procName, packageName) = (dbUnbox row.["specific_name"], dbUnbox row.["specific_schema"])
         { ProcName = procName; Owner = owner; PackageName = packageName; }
 
-    let getSprocParameters (con : IDbConnection) (name : SprocName) = 
+    let getSprocParameters (con : IDbConnection) (name : SprocName) =
 
-        let createSprocParameters (row:DataRow) = 
+        let createSprocParameters (row:DataRow) =
             let dataType = dbUnbox row.["data_type"]
             let argumentName = dbUnbox row.["parameter_name"]
             let maxLength = Some(dbUnboxWithDefault<int> -1 row.["character_maximum_length"])
 
-            findDbType dataType 
+            findDbType dataType
             |> Option.map (fun m ->
                 let returnValue = dbUnbox<string> row.["is_result"] = "YES"
-                let direction = 
+                let direction =
                     match dbUnbox<string> row.["parameter_mode"] with
                     | "IN" -> ParameterDirection.Input
                     | "OUT" when returnValue -> ParameterDirection.ReturnValue
@@ -174,8 +171,8 @@ module MSSqlServer =
                   Length = maxLength
                   Ordinal = dbUnbox<int> row.["ordinal_position"] }
             )
-             
-        getSchema "ProcedureParameters" [||] con 
+
+        getSchema "ProcedureParameters" [||] con
         |> DataTable.groupBy (fun row -> getSprocName row, createSprocParameters row)
         |> Seq.filter (fun (n, _) -> n.ProcName = name.ProcName)
         |> Seq.collect (snd >> Seq.choose id)
@@ -185,10 +182,10 @@ module MSSqlServer =
     let getSprocs (con: IDbConnection) =
         let con = (con :?> SqlConnection)
 
-        let tableValued = 
-            Sql.executeSqlAsDataTable 
-                createCommand 
-                "SELECT DISTINCT ROUTINE_CATALOG, ROUTINE_SCHEMA, ROUTINE_NAME FROM [INFORMATION_SCHEMA].[ROUTINES] where [DATA_TYPE] = 'table'" 
+        let tableValued =
+            Sql.executeSqlAsDataTable
+                createCommand
+                "SELECT DISTINCT ROUTINE_CATALOG, ROUTINE_SCHEMA, ROUTINE_NAME FROM [INFORMATION_SCHEMA].[ROUTINES] where [DATA_TYPE] = 'table'"
                 con
             |> DataTable.map(fun row -> dbUnbox<string> row.["ROUTINE_CATALOG"], dbUnbox<string> row.["ROUTINE_SCHEMA"], dbUnbox<string> row.["ROUTINE_NAME"] )
 
@@ -205,22 +202,22 @@ module MSSqlServer =
         // table valued functions and stuff with user defined types are not currently supported.
         let toFilter = set(tableValued @ haveUDTs)
 
-        getSchema "Procedures" [||] con 
-        |> DataTable.filter(fun row -> 
+        getSchema "Procedures" [||] con
+        |> DataTable.filter(fun row ->
             let name = dbUnbox<string> row.["SPECIFIC_CATALOG"], dbUnbox<string> row.["SPECIFIC_SCHEMA"], dbUnbox<string> row.["SPECIFIC_NAME"]
             not <| Set.contains name toFilter)
         |> DataTable.map (fun row -> getSprocName row, dbUnbox<string> row.["routine_type"])
-        |> Seq.map (fun (name, routineType) -> 
+        |> Seq.map (fun (name, routineType) ->
              match routineType.ToUpper() with
              | "FUNCTION" -> Root("Functions",  Sproc({ Name = name; Params = (fun con -> getSprocParameters con name); ReturnColumns = (fun con sparams -> getSprocReturnCols con name sparams) }))
              | "PROCEDURE" ->  Root("Procedures", Sproc({ Name = name; Params = (fun con -> getSprocParameters con name); ReturnColumns = (fun con sparams -> getSprocReturnCols con name sparams) }))
              | _ -> Empty
-           ) 
+           )
         |> Seq.toList
 
-    let executeSprocCommand (com:IDbCommand) (inputParameters:QueryParameter []) (returnCols:QueryParameter[]) (values:obj[]) = 
+    let executeSprocCommand (com:IDbCommand) (inputParameters:QueryParameter []) (returnCols:QueryParameter[]) (values:obj[]) =
         let inputParameters = inputParameters |> Array.filter (fun p -> p.Direction = ParameterDirection.Input)
-        
+
         let outps =
              returnCols
              |> Array.map(fun ip ->
@@ -231,75 +228,74 @@ module MSSqlServer =
                     (-1, ip.Name, p)
                  else
                     (ip.Ordinal, ip.Name, p))
-        
+
         let inps =
              inputParameters
              |> Array.mapi(fun i ip ->
                  let p = createCommandParameter ip values.[i]
                  (ip.Ordinal, ip.Name, p))
-        
+
         let returnValues =
             outps |> Array.filter (fun (_,_,p) -> p.Direction = ParameterDirection.ReturnValue)
 
-        Array.append returnValues inps 
+        Array.append returnValues inps
         |> Array.sortBy (fun (x,_,_) -> x)
         |> Array.iter (fun (_,_,p) -> com.Parameters.Add(p) |> ignore)
 
         let processReturnColumn reader (retCol:QueryParameter) =
             match retCol.TypeMapping.ProviderTypeName with
-            | Some "cursor" -> 
+            | Some "cursor" ->
                 let result = ResultSet(retCol.Name, Sql.dataReaderToArray reader)
                 reader.NextResult() |> ignore
                 result
-            | _ -> 
+            | _ ->
                 match outps |> Array.tryFind (fun (_,_,p) -> p.ParameterName = retCol.Name) with
                 | Some(_,_,p) -> ScalarResultSet(p.ParameterName, readParameter p)
                 | None -> failwithf "Excepted return column %s but could not find it in the parameter set" retCol.Name
-        
-        
+
         match returnCols with
         | [||] -> com.ExecuteNonQuery() |> ignore; Unit
         | [|retCol|] ->
             match retCol.TypeMapping.ProviderTypeName with
-            | Some "cursor" -> 
+            | Some "cursor" ->
                 use reader = com.ExecuteReader() :?> SqlDataReader
                 let result = SingleResultSet(retCol.Name, Sql.dataReaderToArray reader)
                 reader.NextResult() |> ignore
                 result
-            | _ -> 
-                let result = com.ExecuteNonQuery()
+            | _ ->
+                com.ExecuteNonQuery() |> ignore
                 match outps |> Array.tryFind (fun (_,_,p) -> p.Direction = ParameterDirection.ReturnValue) with
                 | Some(_,name,p) -> Scalar(name, readParameter p)
                 | None -> failwithf "Excepted return column %s but could not find it in the parameter set" retCol.Name
-        | cols -> 
+        | cols ->
             use reader = com.ExecuteReader() :?> SqlDataReader
             Set(cols |> Array.map (processReturnColumn reader))
-   
+
 type internal MSSqlServerProvider() =
-    let pkLookup =     Dictionary<string,string>()
-    let tableLookup =  Dictionary<string,Table>()
+    let pkLookup = Dictionary<string,string>()
+    let tableLookup = Dictionary<string,Table>()
     let columnLookup = Dictionary<string,Column list>()
     let relationshipLookup = Dictionary<string,Relationship list * Relationship list>()
 
-    let createInsertCommand (con:IDbConnection) (sb:Text.StringBuilder) (entity:SqlEntity) =     
+    let createInsertCommand (con:IDbConnection) (sb:Text.StringBuilder) (entity:SqlEntity) =
         let (~~) (t:string) = sb.Append t |> ignore
 
         let cmd = new SqlCommand()
         cmd.Connection <- con :?> SqlConnection
-        let pk = pkLookup.[entity.Table.FullName] 
-        let columnNames, values = 
+        let pk = pkLookup.[entity.Table.FullName]
+        let columnNames, values =
             (([],0),entity.ColumnValues)
             ||> Seq.fold(fun (out,i) (k,v) ->
                 let name = sprintf "@param%i" i
                 let p = SqlParameter(name,v)
                 (k,p)::out,i+1)
-            |> fun (x,_)-> x 
+            |> fun (x,_)-> x
             |> List.rev
-            |> List.toArray 
+            |> List.toArray
             |> Array.unzip
-                
+
         sb.Clear() |> ignore
-        ~~(sprintf "INSERT INTO %s (%s) OUTPUT inserted.%s VALUES (%s);" 
+        ~~(sprintf "INSERT INTO %s (%s) OUTPUT inserted.%s VALUES (%s);"
             entity.Table.FullName
             (String.Join(",",columnNames))
             pk
@@ -313,32 +309,32 @@ type internal MSSqlServerProvider() =
 
         let cmd = new SqlCommand()
         cmd.Connection <- con :?> SqlConnection
-        let pk = pkLookup.[entity.Table.FullName] 
+        let pk = pkLookup.[entity.Table.FullName]
         sb.Clear() |> ignore
 
         if changedColumns |> List.exists ((=)pk) then failwith "Error - you cannot change the primary key of an entity."
 
-        let pkValue = 
+        let pkValue =
             match entity.GetColumnOption<obj> pk with
             | Some v -> v
             | None -> failwith "Error - you cannot update an entity that does not have a primary key."
-                
-        let data = 
+
+        let data =
             (([],0),changedColumns)
-            ||> List.fold(fun (out,i) col ->                                                         
+            ||> List.fold(fun (out,i) col ->
                 let name = sprintf "@param%i" i
-                let p = 
+                let p =
                     match entity.GetColumnOption<obj> col with
                     | Some v -> SqlParameter(name,v)
                     | None -> SqlParameter(name,DBNull.Value)
                 (col,p)::out,i+1)
-            |> fun (x,_)-> x 
+            |> fun (x,_)-> x
             |> List.rev
-            |> List.toArray 
-                
+            |> List.toArray
+
         let pkParam = SqlParameter("@pk", pkValue)
 
-        ~~(sprintf "UPDATE %s SET %s WHERE %s = @pk;" 
+        ~~(sprintf "UPDATE %s SET %s WHERE %s = @pk;"
             entity.Table.FullName
             (String.Join(",", data |> Array.map(fun (c,p) -> sprintf "%s = %s" c p.ParameterName ) ))
             pk)
@@ -347,16 +343,16 @@ type internal MSSqlServerProvider() =
         cmd.Parameters.Add pkParam |> ignore
         cmd.CommandText <- sb.ToString()
         cmd
-            
+
     let createDeleteCommand (con:IDbConnection) (sb:Text.StringBuilder) (entity:SqlEntity) =
         let (~~) (t:string) = sb.Append t |> ignore
 
         let cmd = new SqlCommand()
         cmd.Connection <- con :?> SqlConnection
         sb.Clear() |> ignore
-        let pk = pkLookup.[entity.Table.FullName] 
+        let pk = pkLookup.[entity.Table.FullName]
         sb.Clear() |> ignore
-        let pkValue = 
+        let pkValue =
             match entity.GetColumnOption<obj> pk with
             | Some v -> v
             | None -> failwith "Error - you cannot delete an entity that does not have a primary key."
@@ -370,24 +366,25 @@ type internal MSSqlServerProvider() =
         member __.CreateCommand(connection,commandText) = MSSqlServer.createCommand commandText connection
         member __.CreateCommandParameter(param, value) = MSSqlServer.createCommandParameter param value
         member __.ExecuteSprocCommand(con, inputParameters, returnCols, values:obj array) = MSSqlServer.executeSprocCommand con inputParameters returnCols values
+        member __.CreateTypeMappings(con) = MSSqlServer.createTypeMappings con
 
-        member __.CreateTypeMappings(con) = MSSqlServer.createTypeMappings con   
-        member __.GetTables(con, cs) =
-            MSSqlServer.connect con (fun con -> 
+        member __.GetTables(con,_) =
+            MSSqlServer.connect con (fun con ->
             use reader = MSSqlServer.executeSql "select TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE from INFORMATION_SCHEMA.TABLES" con
-            [ while reader.Read() do 
-                let table ={ Schema = reader.GetSqlString(0).Value ; Name = reader.GetSqlString(1).Value ; Type=reader.GetSqlString(2).Value.ToLower() } 
+            [ while reader.Read() do
+                let table ={ Schema = reader.GetSqlString(0).Value ; Name = reader.GetSqlString(1).Value ; Type=reader.GetSqlString(2).Value.ToLower() }
                 if tableLookup.ContainsKey table.FullName = false then tableLookup.Add(table.FullName,table)
                 yield table ])
 
-        member __.GetPrimaryKey(table) = 
-            match pkLookup.TryGetValue table.FullName with 
+        member __.GetPrimaryKey(table) =
+            match pkLookup.TryGetValue table.FullName with
             | true, v -> Some v
             | _ -> None
-        member __.GetColumns(con,table) = 
+
+        member __.GetColumns(con,table) =
             match columnLookup.TryGetValue table.FullName with
             | (true,data) -> data
-            | _ -> 
+            | _ ->
                // note this data can be obtained using con.GetSchema, and i didn't know at the time about the restrictions you can
                // pass in to filter by table name etc - we should probably swap this code to use that instead at some point
                // but hey, this works
@@ -398,9 +395,9 @@ type internal MSSqlServerProvider() =
                                              SELECT ku.TABLE_CATALOG,ku.TABLE_SCHEMA,ku.TABLE_NAME,ku.COLUMN_NAME
                                              FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc
                                              INNER JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS ku
-                                                 ON tc.CONSTRAINT_TYPE = 'PRIMARY KEY' 
+                                                 ON tc.CONSTRAINT_TYPE = 'PRIMARY KEY'
                                                  AND tc.CONSTRAINT_NAME = ku.CONSTRAINT_NAME
-                                          )   pk 
+                                          )   pk
                                  ON  c.TABLE_CATALOG = pk.TABLE_CATALOG
                                              AND c.TABLE_SCHEMA = pk.TABLE_SCHEMA
                                              AND c.TABLE_NAME = pk.TABLE_NAME
@@ -413,76 +410,76 @@ type internal MSSqlServerProvider() =
                if con.State <> ConnectionState.Open then con.Open()
                use reader = com.ExecuteReader()
                let columns =
-                  [ while reader.Read() do 
+                  [ while reader.Read() do
                       let dt = reader.GetSqlString(1).Value
                       match MSSqlServer.findDbType dt with
                       | Some(m) ->
                          let col =
-                            { Column.Name = reader.GetSqlString(0).Value; 
+                            { Column.Name = reader.GetSqlString(0).Value;
                               TypeMapping = m
                               IsNullable = let b = reader.GetString(4) in if b = "YES" then true else false
-                              IsPrimarKey = if reader.GetSqlString(5).Value = "PRIMARY KEY" then true else false } 
+                              IsPrimarKey = if reader.GetSqlString(5).Value = "PRIMARY KEY" then true else false }
                          if col.IsPrimarKey && pkLookup.ContainsKey table.FullName = false then pkLookup.Add(table.FullName,col.Name)
-                         yield col 
-                      | _ -> ()]  
+                         yield col
+                      | _ -> ()]
                columnLookup.Add(table.FullName,columns)
                con.Close()
                columns
-        member __.GetRelationships(con,table) = 
-            match relationshipLookup.TryGetValue table.FullName with 
+
+        member __.GetRelationships(con,table) =
+            match relationshipLookup.TryGetValue table.FullName with
             | true,v -> v
-            | _ -> 
+            | _ ->
             // mostly stolen from
             // http://msdn.microsoft.com/en-us/library/aa175805(SQL.80).aspx
-            let baseQuery = @"SELECT  
-                                 KCU1.CONSTRAINT_NAME AS FK_CONSTRAINT_NAME                                 
-                                ,KCU1.TABLE_NAME AS FK_TABLE_NAME 
-                                ,KCU1.COLUMN_NAME AS FK_COLUMN_NAME 
-                                ,KCU1.ORDINAL_POSITION AS FK_ORDINAL_POSITION 
-                                ,KCU2.CONSTRAINT_NAME AS REFERENCED_CONSTRAINT_NAME 
-                                ,KCU2.TABLE_NAME AS REFERENCED_TABLE_NAME 
-                                ,KCU2.COLUMN_NAME AS REFERENCED_COLUMN_NAME 
-                                ,KCU2.ORDINAL_POSITION AS REFERENCED_ORDINAL_POSITION 
+            let baseQuery = @"SELECT
+                                 KCU1.CONSTRAINT_NAME AS FK_CONSTRAINT_NAME
+                                ,KCU1.TABLE_NAME AS FK_TABLE_NAME
+                                ,KCU1.COLUMN_NAME AS FK_COLUMN_NAME
+                                ,KCU1.ORDINAL_POSITION AS FK_ORDINAL_POSITION
+                                ,KCU2.CONSTRAINT_NAME AS REFERENCED_CONSTRAINT_NAME
+                                ,KCU2.TABLE_NAME AS REFERENCED_TABLE_NAME
+                                ,KCU2.COLUMN_NAME AS REFERENCED_COLUMN_NAME
+                                ,KCU2.ORDINAL_POSITION AS REFERENCED_ORDINAL_POSITION
                                 ,KCU1.CONSTRAINT_SCHEMA AS FK_CONSTRAINT_SCHEMA
                                 ,KCU2.CONSTRAINT_SCHEMA AS PK_CONSTRAINT_SCHEMA
-                            FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS AS RC 
+                            FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS AS RC
 
-                            INNER JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS KCU1 
-                                ON KCU1.CONSTRAINT_CATALOG = RC.CONSTRAINT_CATALOG  
-                                AND KCU1.CONSTRAINT_SCHEMA = RC.CONSTRAINT_SCHEMA 
-                                AND KCU1.CONSTRAINT_NAME = RC.CONSTRAINT_NAME 
+                            INNER JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS KCU1
+                                ON KCU1.CONSTRAINT_CATALOG = RC.CONSTRAINT_CATALOG
+                                AND KCU1.CONSTRAINT_SCHEMA = RC.CONSTRAINT_SCHEMA
+                                AND KCU1.CONSTRAINT_NAME = RC.CONSTRAINT_NAME
 
-                            INNER JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS KCU2 
-                                ON KCU2.CONSTRAINT_CATALOG = RC.UNIQUE_CONSTRAINT_CATALOG  
-                                AND KCU2.CONSTRAINT_SCHEMA = RC.UNIQUE_CONSTRAINT_SCHEMA 
-                                AND KCU2.CONSTRAINT_NAME = RC.UNIQUE_CONSTRAINT_NAME 
+                            INNER JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS KCU2
+                                ON KCU2.CONSTRAINT_CATALOG = RC.UNIQUE_CONSTRAINT_CATALOG
+                                AND KCU2.CONSTRAINT_SCHEMA = RC.UNIQUE_CONSTRAINT_SCHEMA
+                                AND KCU2.CONSTRAINT_NAME = RC.UNIQUE_CONSTRAINT_NAME
                                 AND KCU2.ORDINAL_POSITION = KCU1.ORDINAL_POSITION "
 
             MSSqlServer.connect con (fun con ->
             use reader = MSSqlServer.executeSql (sprintf "%s WHERE KCU2.TABLE_NAME = '%s'" baseQuery table.Name ) con
             let children =
-                [ while reader.Read() do 
+                [ while reader.Read() do
                     yield { Name = reader.GetSqlString(0).Value; PrimaryTable=Table.CreateFullName(reader.GetSqlString(9).Value, reader.GetSqlString(5).Value); PrimaryKey=reader.GetSqlString(6).Value
-                            ForeignTable= Table.CreateFullName(reader.GetSqlString(8).Value, reader.GetSqlString(1).Value); ForeignKey=reader.GetSqlString(2).Value } ] 
+                            ForeignTable= Table.CreateFullName(reader.GetSqlString(8).Value, reader.GetSqlString(1).Value); ForeignKey=reader.GetSqlString(2).Value } ]
             reader.Dispose()
             use reader = MSSqlServer.executeSql (sprintf "%s WHERE KCU1.TABLE_NAME = '%s'" baseQuery table.Name ) con
             let parents =
-                [ while reader.Read() do 
+                [ while reader.Read() do
                     yield { Name = reader.GetSqlString(0).Value; PrimaryTable=Table.CreateFullName(reader.GetSqlString(9).Value, reader.GetSqlString(5).Value); PrimaryKey=reader.GetSqlString(6).Value
-                            ForeignTable=Table.CreateFullName(reader.GetSqlString(8).Value, reader.GetSqlString(1).Value); ForeignKey=reader.GetSqlString(2).Value } ] 
+                            ForeignTable=Table.CreateFullName(reader.GetSqlString(8).Value, reader.GetSqlString(1).Value); ForeignKey=reader.GetSqlString(2).Value } ]
             relationshipLookup.Add(table.FullName,(children,parents))
             (children,parents))
+
         member __.GetSprocs(con) = MSSqlServer.connect con MSSqlServer.getSprocs
+        member __.GetIndividualsQueryText(table,amount) = sprintf "SELECT TOP %i * FROM %s" amount table.FullName
+        member __.GetIndividualQueryText(table,column) = sprintf "SELECT * FROM [%s].[%s] WHERE [%s].[%s].[%s] = @id" table.Schema table.Name table.Schema table.Name column
 
-        member this.GetIndividualsQueryText(table,amount) = sprintf "SELECT TOP %i * FROM %s" amount table.FullName
-
-        member this.GetIndividualQueryText(table,column) = sprintf "SELECT * FROM [%s].[%s] WHERE [%s].[%s].[%s] = @id" table.Schema table.Name table.Schema table.Name column
-        
-        member this.GenerateQueryText(sqlQuery,baseAlias,baseTable,projectionColumns) = 
+        member __.GenerateQueryText(sqlQuery,baseAlias,baseTable,projectionColumns) =
             let sb = System.Text.StringBuilder()
             let parameters = ResizeArray<_>()
             let (~~) (t:string) = sb.Append t |> ignore
-            
+
             match sqlQuery.Take, sqlQuery.Skip, sqlQuery.Ordering with
             | Some _, Some _, [] -> failwith "skip and take paging requries an orderBy clause."
             | _ -> ()
@@ -493,22 +490,22 @@ type internal MSSqlServerProvider() =
                 | None -> baseTable
 
             let singleEntity = sqlQuery.Aliases.Count = 0
-            
+
             // first build  the select statement, this is easy ...
-            let columns = 
+            let columns =
                 String.Join(",",
                     [|for KeyValue(k,v) in projectionColumns do
                         if v.Count = 0 then   // if no columns exist in the projection then get everything
-                            for col in columnLookup.[(getTable k).FullName] |> List.map(fun c -> c.Name) do 
+                            for col in columnLookup.[(getTable k).FullName] |> List.map(fun c -> c.Name) do
                                 if singleEntity then yield sprintf "[%s].[%s] as '%s'" k col col
                                 else yield sprintf "[%s].[%s] as '[%s].[%s]'" k col k col
                         else
-                            for col in v do 
+                            for col in v do
                                 if singleEntity then yield sprintf "[%s].[%s] as '%s'" k col col
-                                else yield sprintf "[%s].[%s] as '[%s].[%s]'" k col k col|]) 
-        
+                                else yield sprintf "[%s].[%s] as '[%s].[%s]'" k col k col|])
+
             // next up is the filter expressions
-            // make this nicer later.. 
+            // make this nicer later..
             let param = ref 0
             let nextParam() =
                 incr param
@@ -518,13 +515,13 @@ type internal MSSqlServerProvider() =
                 let paramName = nextParam()
                 SqlParameter(paramName,value):> IDbDataParameter
 
-            let rec filterBuilder = function 
+            let rec filterBuilder = function
                 | [] -> ()
                 | (cond::conds) ->
                     let build op preds (rest:Condition list option) =
                         ~~ "("
                         preds |> List.iteri( fun i (alias,col,operator,data) ->
-                                let extractData data = 
+                                let extractData data =
                                      match data with
                                      | Some(x) when (box x :? obj array) ->
                                          // in and not in operators pass an array
@@ -551,13 +548,13 @@ type internal MSSqlServerProvider() =
                                 let paras = extractData data
                                 ~~(sprintf "%s%s" prefix <|
                                     match operator with
-                                    | FSharp.Data.Sql.IsNull -> (sprintf "[%s].[%s] IS NULL") alias col 
-                                    | FSharp.Data.Sql.NotNull -> (sprintf "[%s].[%s] IS NOT NULL") alias col 
+                                    | FSharp.Data.Sql.IsNull -> (sprintf "[%s].[%s] IS NULL") alias col
+                                    | FSharp.Data.Sql.NotNull -> (sprintf "[%s].[%s] IS NOT NULL") alias col
                                     | FSharp.Data.Sql.In -> operatorIn operator paras
                                     | FSharp.Data.Sql.NotIn -> operatorIn operator paras
-                                    | _ -> 
+                                    | _ ->
                                         parameters.Add paras.[0]
-                                        (sprintf "[%s].[%s]%s %s") alias col 
+                                        (sprintf "[%s].[%s]%s %s") alias col
                                          (operator.ToString()) paras.[0].ParameterName)
                         )
                         // there's probably a nicer way to do this
@@ -570,106 +567,106 @@ type internal MSSqlServerProvider() =
                                 ~~ (sprintf " %s " op)
                                 filterBuilder [x]
                                 ~~ (sprintf " %s " op)
-                                aux xs 
+                                aux xs
                             | x::xs ->
                                 filterBuilder [x]
                                 ~~ (sprintf " %s " op)
                                 aux xs
                             | [] -> ()
-                    
+
                         Option.iter aux rest
                         ~~ ")"
-                
+
                     match cond with
                     | Or(preds,rest) -> build "OR" preds rest
-                    | And(preds,rest) ->  build "AND" preds rest 
-                
+                    | And(preds,rest) ->  build "AND" preds rest
+
                     filterBuilder conds
-                
-            // next up is the FROM statement which includes joins .. 
-            let fromBuilder() = 
+
+            // next up is the FROM statement which includes joins ..
+            let fromBuilder() =
                 sqlQuery.Links
                 |> List.iter(fun (fromAlias, data, destAlias)  ->
                     let joinType = if data.OuterJoin then "LEFT OUTER JOIN " else "INNER JOIN "
                     let destTable = getTable destAlias
-                    ~~  (sprintf "%s [%s].[%s] as [%s] on [%s].[%s] = [%s].[%s] " 
-                            joinType destTable.Schema destTable.Name destAlias 
+                    ~~  (sprintf "%s [%s].[%s] as [%s] on [%s].[%s] = [%s].[%s] "
+                            joinType destTable.Schema destTable.Name destAlias
                             (if data.RelDirection = RelationshipDirection.Parents then fromAlias else destAlias)
-                            data.ForeignKey  
-                            (if data.RelDirection = RelationshipDirection.Parents then destAlias else fromAlias) 
+                            data.ForeignKey
+                            (if data.RelDirection = RelationshipDirection.Parents then destAlias else fromAlias)
                             data.PrimaryKey))
 
             let orderByBuilder() =
                 sqlQuery.Ordering
-                |> List.iteri(fun i (alias,column,desc) -> 
+                |> List.iteri(fun i (alias,column,desc) ->
                     if i > 0 then ~~ ", "
                     ~~ (sprintf "[%s].[%s]%s" alias column (if not desc then "DESC" else "")))
 
             // SELECT
             if sqlQuery.Distinct then ~~(sprintf "SELECT DISTINCT %s%s " (if sqlQuery.Take.IsSome then sprintf "TOP %i " sqlQuery.Take.Value else "")   columns)
             elif sqlQuery.Count then ~~("SELECT COUNT(1) ")
-            else  
+            else
                 match sqlQuery.Skip, sqlQuery.Take with
                 | None, Some take -> ~~(sprintf "SELECT TOP %i %s " take columns)
                 | _ -> ~~(sprintf "SELECT %s " columns)
             // FROM
-            ~~(sprintf "FROM [%s].[%s] as [%s] " baseTable.Schema baseTable.Name baseAlias)         
+            ~~(sprintf "FROM [%s].[%s] as [%s] " baseTable.Schema baseTable.Name baseAlias)
             fromBuilder()
             // WHERE
             if sqlQuery.Filters.Length > 0 then
                 // each filter is effectively the entire contents of each where clause in the LINQ query,
                 // of which there can be many. Simply turn them all into one big AND expression as that is the
-                // only logical way to deal with them. 
+                // only logical way to deal with them.
                 let f = [And([],Some sqlQuery.Filters)]
-                ~~"WHERE " 
+                ~~"WHERE "
                 filterBuilder f
-        
+
             if sqlQuery.Ordering.Length > 0 then
                 ~~"ORDER BY "
                 orderByBuilder()
 
-            match sqlQuery.Skip, sqlQuery.Take with 
-            | Some skip, Some take -> 
-                // Note: this only works in >=SQL2012 
+            match sqlQuery.Skip, sqlQuery.Take with
+            | Some skip, Some take ->
+                // Note: this only works in >=SQL2012
                 ~~ (sprintf "OFFSET %i ROWS FETCH NEXT %i ROWS ONLY" skip take)
             | _ -> ()
 
             let sql = sb.ToString()
             (sql,parameters)
 
-        member this.ProcessUpdates(con, entities) =       
+        member this.ProcessUpdates(con, entities) =
             let sb = Text.StringBuilder()
-             
+
             // ensure columns have been loaded
-            entities |> List.map(fun e -> e.Table) 
-                     |> Seq.distinct 
+            entities |> List.map(fun e -> e.Table)
+                     |> Seq.distinct
                      |> Seq.iter(fun t -> (this :> ISqlProvider).GetColumns(con,t) |> ignore )
 
             use scope = Utilities.ensureTransaction()
-            try                
-                // close the connection first otherwise it won't get enlisted into the transaction 
+            try
+                // close the connection first otherwise it won't get enlisted into the transaction
                 if con.State = ConnectionState.Open then con.Close()
-                con.Open()         
+                con.Open()
                 // initially supporting update/create/delete of single entities, no hierarchies yet
                 entities
-                |> List.iter(fun e -> 
+                |> List.iter(fun e ->
                     match e._State with
-                    | Created -> 
+                    | Created ->
                         let cmd = createInsertCommand con sb e
                         Common.QueryEvents.PublishSqlQuery cmd.CommandText
                         let id = cmd.ExecuteScalar()
                         match e.GetColumnOption pkLookup.[e.Table.FullName] with
-                        | Some v -> () // if the primary key exists, do nothing
-                                       // this is because non-identity columns will have been set 
-                                       // manually and in that case scope_identity would bring back 0 "" or whatever
+                        | Some(_) -> () // if the primary key exists, do nothing
+                                        // this is because non-identity columns will have been set
+                                        // manually and in that case scope_identity would bring back 0 "" or whatever
                         | None ->  e.SetColumnSilent(pkLookup.[e.Table.FullName], id)
                         e._State <- Unchanged
-                    | Modified fields -> 
+                    | Modified fields ->
                         let cmd = createUpdateCommand con sb e fields
                         Common.QueryEvents.PublishSqlQuery cmd.CommandText
                         cmd.ExecuteNonQuery() |> ignore
                         e._State <- Unchanged
-                    | Deleted -> 
+                    | Deleted ->
                         let cmd = createDeleteCommand con sb e
                         Common.QueryEvents.PublishSqlQuery cmd.CommandText
                         cmd.ExecuteNonQuery() |> ignore
@@ -677,50 +674,46 @@ type internal MSSqlServerProvider() =
                         e.SetColumnOptionSilent(pkLookup.[e.Table.FullName], None)
                     | Unchanged -> failwith "Unchanged entity encountered in update list - this should not be possible!")
                 scope.Complete()
-                
             finally
                 con.Close()
-            
 
-        member this.ProcessUpdatesAsync(con, entities) = 
-            
+        member this.ProcessUpdatesAsync(con, entities) =
             let sb = Text.StringBuilder()
-             
+
             // ensure columns have been loaded
-            entities |> List.map(fun e -> e.Table) 
-                     |> Seq.distinct 
+            entities |> List.map(fun e -> e.Table)
+                     |> Seq.distinct
                      |> Seq.iter(fun t -> (this :> ISqlProvider).GetColumns(con,t) |> ignore )
 
-            async { 
-
+            async {
                 use scope = Utilities.ensureTransaction()
-                try                
-                    // close the connection first otherwise it won't get enlisted into the transaction 
+                try
+                    // close the connection first otherwise it won't get enlisted into the transaction
                     if con.State = ConnectionState.Open then con.Close()
                     do! con.OpenAsync() |> Async.AwaitIAsyncResult |> Async.Ignore
                     // initially supporting update/create/delete of single entities, no hierarchies yet
                     let handleEntity (e: SqlEntity) =
                         match e._State with
-                        | Created -> 
+                        | Created ->
                             async {
                                 let cmd = createInsertCommand con sb e
                                 Common.QueryEvents.PublishSqlQuery cmd.CommandText
                                 let! id = cmd.ExecuteScalarAsync() |> Async.AwaitTask
                                 match e.GetColumnOption pkLookup.[e.Table.FullName] with
-                                | Some v -> () // if the primary key exists, do nothing
-                                               // this is because non-identity columns will have been set 
-                                               // manually and in that case scope_identity would bring back 0 "" or whatever
+                                | Some(_) -> () // if the primary key exists, do nothing
+                                                // this is because non-identity columns will have been set
+                                                // manually and in that case scope_identity would bring back 0 "" or whatever
                                 | None ->  e.SetColumnSilent(pkLookup.[e.Table.FullName], id)
                                 e._State <- Unchanged
                             }
-                        | Modified fields -> 
+                        | Modified fields ->
                             async {
                                 let cmd = createUpdateCommand con sb e fields
                                 Common.QueryEvents.PublishSqlQuery cmd.CommandText
                                 do! cmd.ExecuteNonQueryAsync() |> Async.AwaitTask |> Async.Ignore
                                 e._State <- Unchanged
                             }
-                        | Deleted -> 
+                        | Deleted ->
                             async {
                                 let cmd = createDeleteCommand con sb e
                                 Common.QueryEvents.PublishSqlQuery cmd.CommandText
@@ -735,4 +728,3 @@ type internal MSSqlServerProvider() =
                 finally
                     con.Close()
             }
-

--- a/src/SQLProvider/Providers.MsSqlServer.fs
+++ b/src/SQLProvider/Providers.MsSqlServer.fs
@@ -493,6 +493,7 @@ type internal MSSqlServerProvider() =
 
             // first build  the select statement, this is easy ...
             let columns =
+                if projectionColumns |> Seq.isEmpty then "1" else
                 String.Join(",",
                     [|for KeyValue(k,v) in projectionColumns do
                         if v.Count = 0 then   // if no columns exist in the projection then get everything

--- a/src/SQLProvider/Providers.MySql.fs
+++ b/src/SQLProvider/Providers.MySql.fs
@@ -8,8 +8,7 @@ open FSharp.Data.Sql
 open FSharp.Data.Sql.Schema
 open FSharp.Data.Sql.Common
 
-module MySql = 
-    
+module MySql =
     let mutable resolutionPath = String.Empty
     let mutable owner = String.Empty
     let mutable referencedAssemblies = [||]
@@ -21,16 +20,15 @@ module MySql =
     let assembly =
         lazy Reflection.tryLoadAssemblyFrom resolutionPath referencedAssemblies assemblyNames
 
-    let findType name = 
+    let findType name =
         match assembly.Value with
         | Choice1Of2(assembly) -> assembly.GetTypes() |> Array.find(fun t -> t.Name = name)
-        | Choice2Of2(paths) -> 
+        | Choice2Of2(paths) ->
            failwithf "Unable to resolve assemblies. One of %s must exist in the paths: %s %s"
-                (String.Join(", ", assemblyNames |> List.toArray)) 
+                (String.Join(", ", assemblyNames |> List.toArray))
                 Environment.NewLine
                 (String.Join(Environment.NewLine, paths))
 
-   
     let connectionType =  lazy (findType "MySqlConnection")
     let commandType =     lazy (findType "MySqlCommand")
     let parameterType =   lazy (findType "MySqlParameter")
@@ -39,7 +37,7 @@ module MySql =
     let paramEnumCtor   = lazy parameterType.Value.GetConstructor([|typeof<string>;enumType.Value|])
     let paramObjectCtor = lazy parameterType.Value.GetConstructor([|typeof<string>;typeof<obj>|])
 
-    let getSchema name (args:string[]) (conn:IDbConnection) = 
+    let getSchema name (args:string[]) (conn:IDbConnection) =
         getSchemaMethod.Value.Invoke(conn,[|name; args|]) :?> DataTable
 
     let mutable typeMappings = []
@@ -59,7 +57,7 @@ module MySql =
 
         let getClrType (input:string) = Type.GetType(input).ToString()
 
-        let mappings =             
+        let mappings =
             [
                 for r in dt.Rows do
                     let clrType = getClrType (string r.["DataType"])
@@ -75,45 +73,45 @@ module MySql =
             |> List.map (fun m -> m.ClrType, m)
             |> Map.ofList
 
-        let dbMappings = 
+        let dbMappings =
             mappings
             |> List.map (fun m -> m.ProviderTypeName.Value.ToLower(), m)
             |> Map.ofList
-            
+
         typeMappings <- mappings
         findClrType <- clrMappings.TryFind
-        findDbType <- dbMappings.TryFind 
-    
+        findDbType <- dbMappings.TryFind
+
     let createConnection connectionString =
         Activator.CreateInstance(connectionType.Value,[|box connectionString|]) :?> IDbConnection
 
-    let createCommand commandText connection = 
+    let createCommand commandText connection =
         Activator.CreateInstance(commandType.Value,[|box commandText;box connection|]) :?> IDbCommand
 
-    let createCommandParameter sprocCommand (param:QueryParameter) value = 
+    let createCommandParameter sprocCommand (param:QueryParameter) value =
         let mapping = if value <> null && (not sprocCommand) then (findClrType (value.GetType().ToString())) else None
         let value = if value = null then (box System.DBNull.Value) else value
-        
+
         let parameterType = parameterType.Value
-        let mySqlDbTypeSetter = 
+        let mySqlDbTypeSetter =
             parameterType.GetProperty("MySqlDbType").GetSetMethod()
-        
+
         let p = Activator.CreateInstance(parameterType,[|box param.Name;value|]) :?> IDbDataParameter
-        
-        p.Direction <-  param.Direction 
-        
+
+        p.Direction <-  param.Direction
+
         p.DbType <- (defaultArg mapping param.TypeMapping).DbType
         param.TypeMapping.ProviderType |> Option.iter (fun pt -> mySqlDbTypeSetter.Invoke(p, [|pt|]) |> ignore)
-        
-        Option.iter (fun l -> p.Size <- l) param.Length             
+
+        Option.iter (fun l -> p.Size <- l) param.Length
         p
-        
-    let getSprocReturnCols con (sparams: QueryParameter list) = 
+
+    let getSprocReturnCols (sparams: QueryParameter list) =
         match sparams |> List.filter (fun p -> p.Direction <> ParameterDirection.Input) with
         | [] ->
             match findDbType "cursor" with
             | None -> []
-            | Some m -> 
+            | Some m ->
                 [{
                     Name = "ResultSet"
                     TypeMapping = m
@@ -123,28 +121,28 @@ module MySql =
                  }]
         | a -> a
 
-    let getSprocName (row:DataRow) = 
-        let defaultValue = 
+    let getSprocName (row:DataRow) =
+        let defaultValue =
             if row.Table.Columns.Contains("specific_schema") then row.["specific_schema"]
             else row.["routine_schema"]
         let owner = Sql.dbUnboxWithDefault<string> owner defaultValue
         let procName = (Sql.dbUnboxWithDefault<string> (Guid.NewGuid().ToString()) row.["specific_name"])
         { ProcName = procName; Owner = owner; PackageName = String.Empty; }
 
-    let getSprocParameters (con:IDbConnection) (name:SprocName) = 
-        let createSprocParameters (row:DataRow) = 
+    let getSprocParameters (con:IDbConnection) (name:SprocName) =
+        let createSprocParameters (row:DataRow) =
             let dataType = Sql.dbUnbox row.["data_type"]
             let argumentName = Sql.dbUnbox row.["parameter_name"]
-            let maxLength = 
+            let maxLength =
                 let r = Sql.dbUnboxWithDefault<int> -1 row.["character_maximum_length"]
                 if r = -1 then None else Some r
 
-            findDbType dataType 
+            findDbType dataType
             |> Option.map (fun m ->
                 let ordinal_position = Sql.dbUnboxWithDefault<int> 0 row.["ORDINAL_POSITION"]
                 let parameter_mode = Sql.dbUnbox<string> row.["PARAMETER_MODE"]
                 let returnValue = argumentName = null && ordinal_position = 0
-                let direction = 
+                let direction =
                     match parameter_mode with
                     | "IN" -> ParameterDirection.Input
                     | "OUT" -> ParameterDirection.Output
@@ -161,7 +159,7 @@ module MySql =
         if String.IsNullOrEmpty owner then owner <- con.Database
 
         //This could filter the query using the Sproc name passed in
-        Sql.connect con (Sql.executeSqlAsDataTable createCommand (sprintf "SELECT * FROM information_schema.PARAMETERS where SPECIFIC_SCHEMA = '%s'" owner)) 
+        Sql.connect con (Sql.executeSqlAsDataTable createCommand (sprintf "SELECT * FROM information_schema.PARAMETERS where SPECIFIC_SCHEMA = '%s'" owner))
         |> DataTable.groupBy (fun row -> getSprocName row, createSprocParameters row)
         |> Seq.filter (fun (n, _) -> n.ProcName = name.ProcName)
         |> Seq.collect (snd >> Seq.choose id)
@@ -169,60 +167,58 @@ module MySql =
         |> Seq.toList
 
     let getSprocs (con:IDbConnection) =
-        getSchema "Procedures" [||] con 
-        |> DataTable.map (fun row -> 
+        getSchema "Procedures" [||] con
+        |> DataTable.map (fun row ->
                             let name = getSprocName row
                             match (Sql.dbUnbox<string> row.["routine_type"]).ToUpper() with
-                            | "FUNCTION" -> Root("Functions", Sproc({ Name = name; Params = (fun con -> getSprocParameters con name); ReturnColumns = (fun con name -> getSprocReturnCols con name) }))
-                            | "PROCEDURE" ->  Root("Procedures", Sproc({ Name = name; Params = (fun con -> getSprocParameters con name); ReturnColumns = (fun con name -> getSprocReturnCols con name) }))
+                            | "FUNCTION" -> Root("Functions", Sproc({ Name = name; Params = (fun con -> getSprocParameters con name); ReturnColumns = (fun _ name -> getSprocReturnCols name) }))
+                            | "PROCEDURE" ->  Root("Procedures", Sproc({ Name = name; Params = (fun con -> getSprocParameters con name); ReturnColumns = (fun _ name -> getSprocReturnCols name) }))
                             | _ -> Empty
                           )
         |> Seq.toList
 
     let readParameter (parameter:IDbDataParameter) =
-        if parameter <> null 
-        then 
+        if parameter <> null then
             let par = parameter
             par.Value
         else null
 
-    let executeSprocCommand (com:IDbCommand) (inputParams:QueryParameter[]) (retCols:QueryParameter[]) (values:obj[]) = 
+    let executeSprocCommand (com:IDbCommand) (inputParams:QueryParameter[]) (retCols:QueryParameter[]) (values:obj[]) =
         let inputParameters = inputParams |> Array.filter (fun p -> p.Direction = ParameterDirection.Input)
-        
+
         let outps =
              retCols
              |> Array.map(fun ip ->
                  let p = createCommandParameter true ip null
                  (ip.Ordinal, p))
-        
+
         let inps =
              inputParameters
              |> Array.mapi(fun i ip ->
                  let p = createCommandParameter true ip values.[i]
                  (ip.Ordinal,p))
-        
+
         Array.append outps inps
         |> Array.sortBy fst
         |> Array.iter (fun (_,p) -> com.Parameters.Add(p) |> ignore)
 
         let processReturnColumn reader (retCol:QueryParameter) =
             match retCol.TypeMapping.ProviderTypeName with
-            | Some "cursor" -> 
+            | Some "cursor" ->
                 let result = ResultSet(retCol.Name, Sql.dataReaderToArray reader)
                 reader.NextResult() |> ignore
                 result
-            | _ -> 
+            | _ ->
                 match outps |> Array.tryFind (fun (_,p) -> p.ParameterName = retCol.Name) with
                 | Some(_,p) -> ScalarResultSet(p.ParameterName, readParameter p)
                 | None -> failwithf "Excepted return column %s but could not find it in the parameter set" retCol.Name
-        
-        
+
         match retCols with
         | [||] -> com.ExecuteNonQuery() |> ignore; Unit
         | [|retCol|] ->
             use reader = com.ExecuteReader()
             match retCol.TypeMapping.ProviderTypeName with
-            | Some "cursor" -> 
+            | Some "cursor" ->
                 let result = SingleResultSet(retCol.Name, Sql.dataReaderToArray reader)
                 reader.NextResult() |> ignore
                 result
@@ -230,38 +226,39 @@ module MySql =
                 match outps |> Array.tryFind (fun (_,p) -> p.ParameterName = retCol.Name) with
                 | Some(_,p) -> Scalar(p.ParameterName, readParameter p)
                 | None -> failwithf "Excepted return column %s but could not find it in the parameter set" retCol.Name
-        | cols -> 
+        | cols ->
             use reader = com.ExecuteReader()
             Set(cols |> Array.map (processReturnColumn reader))
 
 type internal MySqlProvider(resolutionPath, owner, referencedAssemblies) as this =
-    let pkLookup =     Dictionary<string,string>()
-    let tableLookup =  Dictionary<string,Table>()
+    let pkLookup = Dictionary<string,string>()
+    let tableLookup = Dictionary<string,Table>()
     let columnLookup = Dictionary<string,Column list>()
     let relationshipLookup = Dictionary<string,Relationship list * Relationship list>()
 
-    let createInsertCommand (con:IDbConnection) (sb:Text.StringBuilder) (entity:SqlEntity) =                 
+    let createInsertCommand (con:IDbConnection) (sb:Text.StringBuilder) (entity:SqlEntity) =
         let (~~) (t:string) = sb.Append t |> ignore
+
         let cmd = (this :> ISqlProvider).CreateCommand(con,"")
-        cmd.Connection <- con 
-        let pk = pkLookup.[entity.Table.FullName] 
-        let columnNames, values = 
+        cmd.Connection <- con
+
+        let columnNames, values =
             (([],0),entity.ColumnValues)
-            ||> Seq.fold(fun (out,i) (k,v) -> 
+            ||> Seq.fold(fun (out,i) (k,v) ->
                 let name = sprintf "@param%i" i
                 let p = (this :> ISqlProvider).CreateCommandParameter(QueryParameter.Create(name, i),v)
                 (k,p)::out,i+1)
-            |> fun (x,_)-> x 
+            |> fun (x,_)-> x
             |> List.rev
-            |> List.toArray 
+            |> List.toArray
             |> Array.unzip
-                
+
         sb.Clear() |> ignore
-        ~~(sprintf "INSERT INTO %s (%s) VALUES (%s); SELECT LAST_INSERT_ID();" 
+        ~~(sprintf "INSERT INTO %s (%s) VALUES (%s); SELECT LAST_INSERT_ID();"
             (entity.Table.FullName.Replace("[","`").Replace("]","`"))
             (String.Join(",",columnNames))
             (String.Join(",",values |> Array.map(fun p -> p.ParameterName))))
-                
+
         values |> Array.iter (cmd.Parameters.Add >> ignore)
         cmd.CommandText <- sb.ToString()
         cmd
@@ -269,34 +266,33 @@ type internal MySqlProvider(resolutionPath, owner, referencedAssemblies) as this
     let createUpdateCommand (con:IDbConnection) (sb:Text.StringBuilder) (entity:SqlEntity) changedColumns =
         let (~~) (t:string) = sb.Append t |> ignore
         let cmd = (this :> ISqlProvider).CreateCommand(con,"")
-        cmd.Connection <- con 
-        let pk = pkLookup.[entity.Table.FullName] 
+        cmd.Connection <- con
+        let pk = pkLookup.[entity.Table.FullName]
         sb.Clear() |> ignore
 
         if changedColumns |> List.exists ((=)pk) then failwith "Error - you cannot change the primary key of an entity."
 
-        let pkValue = 
+        let pkValue =
             match entity.GetColumnOption<obj> pk with
             | Some v -> v
             | None -> failwith "Error - you cannot update an entity that does not have a primary key."
-                
-        let data = 
+
+        let data =
             (([],0),changedColumns)
-            ||> List.fold(fun (out,i) col ->                                                         
+            ||> List.fold(fun (out,i) col ->
                 let name = sprintf "@param%i" i
-                let p = 
+                let p =
                     match entity.GetColumnOption<obj> col with
                     | Some v -> (this :> ISqlProvider).CreateCommandParameter(QueryParameter.Create(name, i),v)
                     | None -> (this :> ISqlProvider).CreateCommandParameter(QueryParameter.Create(name, i), DBNull.Value)
                 (col,p)::out,i+1)
-            |> fun (x,_)-> x 
+            |> fun (x,_)-> x
             |> List.rev
-            |> List.toArray 
-                    
-                
+            |> List.toArray
+
         let pkParam = (this :> ISqlProvider).CreateCommandParameter(QueryParameter.Create("@pk", 0),pkValue)
 
-        ~~(sprintf "UPDATE %s SET %s WHERE %s = @pk;" 
+        ~~(sprintf "UPDATE %s SET %s WHERE %s = @pk;"
             (entity.Table.FullName.Replace("[","`").Replace("]","`"))
             (String.Join(",", data |> Array.map(fun (c,p) -> sprintf "%s = %s" c p.ParameterName ) ))
             pk)
@@ -305,15 +301,15 @@ type internal MySqlProvider(resolutionPath, owner, referencedAssemblies) as this
         cmd.Parameters.Add pkParam |> ignore
         cmd.CommandText <- sb.ToString()
         cmd
-            
+
     let createDeleteCommand (con:IDbConnection) (sb:Text.StringBuilder) (entity:SqlEntity) =
         let (~~) (t:string) = sb.Append t |> ignore
         let cmd = (this :> ISqlProvider).CreateCommand(con,"")
-        cmd.Connection <- con 
+        cmd.Connection <- con
         sb.Clear() |> ignore
-        let pk = pkLookup.[entity.Table.FullName] 
+        let pk = pkLookup.[entity.Table.FullName]
         sb.Clear() |> ignore
-        let pkValue = 
+        let pkValue =
             match entity.GetColumnOption<obj> pk with
             | Some v -> v
             | None -> failwith "Error - you cannot delete an entity that does not have a primary key."
@@ -336,27 +332,27 @@ type internal MySqlProvider(resolutionPath, owner, referencedAssemblies) as this
         member __.CreateTypeMappings(con) = Sql.connect con MySql.createTypeMappings
 
         member __.GetTables(con,cs) =
-            let caseChane = 
+            let caseChane =
                 match cs with
                 | Common.CaseSensitivityChange.TOUPPER -> "UPPER(TABLE_SCHEMA)"
                 | Common.CaseSensitivityChange.TOLOWER -> "LOWER(TABLE_SCHEMA)"
                 | _ -> "TABLE_SCHEMA"
             Sql.connect con (fun con ->
                 use reader = Sql.executeSql MySql.createCommand (sprintf "select TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE from INFORMATION_SCHEMA.TABLES where %s = '%s'" caseChane MySql.owner) con
-                [ while reader.Read() do 
-                    let table ={ Schema = reader.GetString(0); Name = reader.GetString(1); Type=reader.GetString(2) } 
+                [ while reader.Read() do
+                    let table ={ Schema = reader.GetString(0); Name = reader.GetString(1); Type=reader.GetString(2) }
                     if tableLookup.ContainsKey table.FullName = false then tableLookup.Add(table.FullName,table)
                     yield table ])
 
-        member __.GetPrimaryKey(table) = 
-            match pkLookup.TryGetValue table.FullName with 
+        member __.GetPrimaryKey(table) =
+            match pkLookup.TryGetValue table.FullName with
             | true, v -> Some v
             | _ -> None
 
-        member __.GetColumns(con,table) = 
+        member __.GetColumns(con,table) =
             match columnLookup.TryGetValue table.FullName with
             | (true,data) -> data
-            | _ -> 
+            | _ ->
                // note this data can be obtained using con.GetSchema, but with an epic schema we only want to get the data
                // we are interested in on demand
                let baseQuery = @"SELECT DISTINCTROW c.COLUMN_NAME,c.DATA_TYPE, c.character_maximum_length, c.numeric_precision, c.is_nullable
@@ -366,81 +362,80 @@ type internal MySqlProvider(resolutionPath, owner, referencedAssemblies) as this
                                              SELECT ku.TABLE_CATALOG,ku.TABLE_SCHEMA,ku.TABLE_NAME,ku.COLUMN_NAME
                                              FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc
                                              INNER JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS ku
-                                                 ON tc.CONSTRAINT_TYPE = 'PRIMARY KEY' 
+                                                 ON tc.CONSTRAINT_TYPE = 'PRIMARY KEY'
                                                  AND tc.CONSTRAINT_NAME = ku.CONSTRAINT_NAME
-                                          )   pk 
+                                          )   pk
                                  ON  c.TABLE_CATALOG = pk.TABLE_CATALOG
                                              AND c.TABLE_SCHEMA = pk.TABLE_SCHEMA
                                              AND c.TABLE_NAME = pk.TABLE_NAME
                                              AND c.COLUMN_NAME = pk.COLUMN_NAME
                                  WHERE c.TABLE_SCHEMA = @schema AND c.TABLE_NAME = @table"
-               use com = (this:>ISqlProvider).CreateCommand(con,baseQuery)               
+               use com = (this:>ISqlProvider).CreateCommand(con,baseQuery)
                com.Parameters.Add((this:>ISqlProvider).CreateCommandParameter(QueryParameter.Create("@schema", 0), table.Schema)) |> ignore
                com.Parameters.Add((this:>ISqlProvider).CreateCommandParameter(QueryParameter.Create("@table", 1), table.Name)) |> ignore
                if con.State <> ConnectionState.Open then con.Open()
                use reader = com.ExecuteReader()
                let columns =
-                  [ while reader.Read() do 
+                  [ while reader.Read() do
                       let dt = reader.GetString(1)
                       match MySql.findDbType dt with
                       | Some(m) ->
                          let col =
-                            { Column.Name = reader.GetString(0) 
+                            { Column.Name = reader.GetString(0)
                               TypeMapping = m
                               IsNullable = let b = reader.GetString(4) in if b = "YES" then true else false
-                              IsPrimarKey = if reader.GetString(5) = "PRIMARY KEY" then true else false } 
+                              IsPrimarKey = if reader.GetString(5) = "PRIMARY KEY" then true else false }
                          if col.IsPrimarKey && pkLookup.ContainsKey table.FullName = false then pkLookup.Add(table.FullName,col.Name)
-                         yield col 
-                      | _ -> ()]  
+                         yield col
+                      | _ -> ()]
                columnLookup.Add(table.FullName,columns)
                con.Close()
                columns
-        member __.GetRelationships(con,table) = 
-            match relationshipLookup.TryGetValue table.FullName with 
-            | true,v -> v
-            | _ -> 
-            let baseQuery = @"SELECT  
-                                 KCU1.CONSTRAINT_NAME AS FK_CONSTRAINT_NAME                                 
-                                ,RC.TABLE_NAME AS FK_TABLE_NAME 
-                                ,KCU1.TABLE_SCHEMA AS FK_SCHEMA_NAME 
-                                ,KCU1.COLUMN_NAME AS FK_COLUMN_NAME 
-                                ,RC.REFERENCED_TABLE_NAME AS REFERENCED_TABLE_NAME 
-                                ,KCU1.REFERENCED_TABLE_SCHEMA AS REFERENCED_SCHEMA_NAME 
-                                ,KCU1.REFERENCED_COLUMN_NAME AS FK_CONSTRAINT_SCHEMA
-                            FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS AS RC 
 
-                            INNER JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS KCU1 
-                                ON KCU1.CONSTRAINT_CATALOG = RC.CONSTRAINT_CATALOG  
-                                AND KCU1.CONSTRAINT_SCHEMA = RC.CONSTRAINT_SCHEMA 
+        member __.GetRelationships(con,table) =
+            match relationshipLookup.TryGetValue table.FullName with
+            | true,v -> v
+            | _ ->
+            let baseQuery = @"SELECT
+                                 KCU1.CONSTRAINT_NAME AS FK_CONSTRAINT_NAME
+                                ,RC.TABLE_NAME AS FK_TABLE_NAME
+                                ,KCU1.TABLE_SCHEMA AS FK_SCHEMA_NAME
+                                ,KCU1.COLUMN_NAME AS FK_COLUMN_NAME
+                                ,RC.REFERENCED_TABLE_NAME AS REFERENCED_TABLE_NAME
+                                ,KCU1.REFERENCED_TABLE_SCHEMA AS REFERENCED_SCHEMA_NAME
+                                ,KCU1.REFERENCED_COLUMN_NAME AS FK_CONSTRAINT_SCHEMA
+                            FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS AS RC
+
+                            INNER JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS KCU1
+                                ON KCU1.CONSTRAINT_CATALOG = RC.CONSTRAINT_CATALOG
+                                AND KCU1.CONSTRAINT_SCHEMA = RC.CONSTRAINT_SCHEMA
                                 AND KCU1.CONSTRAINT_NAME = RC.CONSTRAINT_NAME  "
 
             Sql.connect con (fun con ->
             use reader = (Sql.executeSql MySql.createCommand (sprintf "%s WHERE RC.TABLE_NAME = '%s'" baseQuery table.Name ) con)
             let children =
-                [ while reader.Read() do 
+                [ while reader.Read() do
                     yield { Name = reader.GetString(0); PrimaryTable=Table.CreateFullName(reader.GetString(2),reader.GetString(1)); PrimaryKey=reader.GetString(3)
-                            ForeignTable=Table.CreateFullName(reader.GetString(5),reader.GetString(4)); ForeignKey=reader.GetString(6) } ] 
+                            ForeignTable=Table.CreateFullName(reader.GetString(5),reader.GetString(4)); ForeignKey=reader.GetString(6) } ]
             reader.Dispose()
             use reader = Sql.executeSql MySql.createCommand (sprintf "%s WHERE RC.REFERENCED_TABLE_NAME = '%s'" baseQuery table.Name ) con
             let parents =
-                [ while reader.Read() do 
+                [ while reader.Read() do
                     yield { Name = reader.GetString(0); PrimaryTable=Table.CreateFullName(reader.GetString(2),reader.GetString(1)); PrimaryKey=reader.GetString(3)
-                            ForeignTable= Table.CreateFullName(reader.GetString(5),reader.GetString(4)); ForeignKey=reader.GetString(6) } ] 
+                            ForeignTable= Table.CreateFullName(reader.GetString(5),reader.GetString(4)); ForeignKey=reader.GetString(6) } ]
             relationshipLookup.Add(table.FullName,(children,parents))
-            
-            (children,parents))
-        
-        // todo
-        member __.GetSprocs(con) = Sql.connect con MySql.getSprocs
 
-        member this.GetIndividualsQueryText(table,amount) = sprintf "SELECT * FROM %s LIMIT %i;" (table.FullName.Replace("[","`").Replace("]","`")) amount 
-        member this.GetIndividualQueryText(table,column) = sprintf "SELECT * FROM `%s`.`%s` WHERE `%s`.`%s`.`%s` = @id" table.Schema table.Name table.Schema table.Name column
-        
-        member this.GenerateQueryText(sqlQuery,baseAlias,baseTable,projectionColumns) = 
+            (children,parents))
+
+        member __.GetSprocs(con) = Sql.connect con MySql.getSprocs
+        member __.GetIndividualsQueryText(table,amount) = sprintf "SELECT * FROM %s LIMIT %i;" (table.FullName.Replace("[","`").Replace("]","`")) amount
+        member __.GetIndividualQueryText(table,column) = sprintf "SELECT * FROM `%s`.`%s` WHERE `%s`.`%s`.`%s` = @id" table.Schema table.Name table.Schema table.Name column
+
+        member this.GenerateQueryText(sqlQuery,baseAlias,baseTable,projectionColumns) =
             let sb = System.Text.StringBuilder()
             let parameters = ResizeArray<_>()
             let (~~) (t:string) = sb.Append t |> ignore
-            
+
             // to simplfy (ha!) the processing, all tables should be aliased.
             // the LINQ infrastructure will cause this will happen by default if the query includes more than one table
             // if it does not, then we first need to create an alias for the single table
@@ -450,22 +445,22 @@ type internal MySqlProvider(resolutionPath, owner, referencedAssemblies) as this
                 | None -> baseTable
 
             let singleEntity = sqlQuery.Aliases.Count = 0
-            
+
             // build the sql query from the simplified abstract query expression
             // working on the basis that we will alias everything to make my life eaiser
             // first build  the select statment, this is easy ...
-            let columns = 
+            let columns =
                 String.Join(",",
                     [|for KeyValue(k,v) in projectionColumns do
                         if v.Count = 0 then   // if no columns exist in the projection then get everything
-                            for col in columnLookup.[(getTable k).FullName] |> List.map(fun c -> c.Name) do 
+                            for col in columnLookup.[(getTable k).FullName] |> List.map(fun c -> c.Name) do
                                 if singleEntity then yield sprintf "`%s`.`%s` as `%s`" k col col
                                 else yield sprintf "`%s`.`%s` as '`%s`.`%s`'" k col k col
                         else
-                            for col in v do 
+                            for col in v do
                                 if singleEntity then yield sprintf "`%s`.`%s` as `%s`" k col col
                                 else yield sprintf "`%s`.`%s` as '`%s`.`%s`'" k col k col|]) // F# makes this so easy :)
-        
+
             // next up is the filter expressions
             // make this nicer later.. just try and get the damn thing to work properly (well, at all) for now :D
             // NOTE: really need to assign the parameters their correct sql types
@@ -478,13 +473,13 @@ type internal MySqlProvider(resolutionPath, owner, referencedAssemblies) as this
                 let paramName = nextParam()
                 (this:>ISqlProvider).CreateCommandParameter(QueryParameter.Create(paramName, !param), value)
 
-            let rec filterBuilder = function 
+            let rec filterBuilder = function
                 | [] -> ()
                 | (cond::conds) ->
                     let build op preds (rest:Condition list option) =
                         ~~ "("
                         preds |> List.iteri( fun i (alias,col,operator,data) ->
-                                let extractData data = 
+                                let extractData data =
                                      match data with
                                      | Some(x) when (box x :? obj array) ->
                                          // in and not in operators pass an array
@@ -511,13 +506,13 @@ type internal MySqlProvider(resolutionPath, owner, referencedAssemblies) as this
                                 let paras = extractData data
                                 ~~(sprintf "%s%s" prefix <|
                                     match operator with
-                                    | FSharp.Data.Sql.IsNull -> (sprintf "`%s`.`%s` IS NULL") alias col 
-                                    | FSharp.Data.Sql.NotNull -> (sprintf "`%s`.`%s` IS NOT NULL") alias col 
+                                    | FSharp.Data.Sql.IsNull -> (sprintf "`%s`.`%s` IS NULL") alias col
+                                    | FSharp.Data.Sql.NotNull -> (sprintf "`%s`.`%s` IS NOT NULL") alias col
                                     | FSharp.Data.Sql.In -> operatorIn operator paras
                                     | FSharp.Data.Sql.NotIn -> operatorIn operator paras
-                                    | _ -> 
+                                    | _ ->
                                         parameters.Add paras.[0]
-                                        (sprintf "`%s`.`%s`%s %s") alias col 
+                                        (sprintf "`%s`.`%s`%s %s") alias col
                                          (operator.ToString()) paras.[0].ParameterName)
                         )
                         // there's probably a nicer way to do this
@@ -530,38 +525,38 @@ type internal MySqlProvider(resolutionPath, owner, referencedAssemblies) as this
                                 ~~ (sprintf " %s " op)
                                 filterBuilder [x]
                                 ~~ (sprintf " %s " op)
-                                aux xs 
+                                aux xs
                             | x::xs ->
                                 filterBuilder [x]
                                 ~~ (sprintf " %s " op)
                                 aux xs
                             | [] -> ()
-                    
+
                         Option.iter aux rest
                         ~~ ")"
-                
+
                     match cond with
                     | Or(preds,rest) -> build "OR" preds rest
-                    | And(preds,rest) ->  build "AND" preds rest 
-                
+                    | And(preds,rest) ->  build "AND" preds rest
+
                     filterBuilder conds
-                
-            // next up is the FROM statement which includes joins .. 
-            let fromBuilder() = 
+
+            // next up is the FROM statement which includes joins ..
+            let fromBuilder() =
                 sqlQuery.Links
                 |> List.iter(fun (fromAlias, data, destAlias)  ->
                     let joinType = if data.OuterJoin then "LEFT OUTER JOIN " else "INNER JOIN "
                     let destTable = getTable destAlias
-                    ~~  (sprintf "%s `%s`.`%s` as `%s` on `%s`.`%s` = `%s`.`%s` " 
-                            joinType destTable.Schema destTable.Name destAlias 
+                    ~~  (sprintf "%s `%s`.`%s` as `%s` on `%s`.`%s` = `%s`.`%s` "
+                            joinType destTable.Schema destTable.Name destAlias
                             (if data.RelDirection = RelationshipDirection.Parents then fromAlias else destAlias)
-                            data.ForeignKey  
-                            (if data.RelDirection = RelationshipDirection.Parents then destAlias else fromAlias) 
+                            data.ForeignKey
+                            (if data.RelDirection = RelationshipDirection.Parents then destAlias else fromAlias)
                             data.PrimaryKey))
 
             let orderByBuilder() =
                 sqlQuery.Ordering
-                |> List.iteri(fun i (alias,column,desc) -> 
+                |> List.iteri(fun i (alias,column,desc) ->
                     if i > 0 then ~~ ", "
                     ~~ (sprintf "`%s`.`%s` %s" alias column (if not desc then "DESC" else "")))
 
@@ -570,17 +565,17 @@ type internal MySqlProvider(resolutionPath, owner, referencedAssemblies) as this
             elif sqlQuery.Count then ~~("SELECT COUNT(1) ")
             else  ~~(sprintf "SELECT %s " columns)
             // FROM
-            ~~(sprintf "FROM %s as `%s` " (baseTable.FullName.Replace("[","`").Replace("]","`"))  baseAlias)         
+            ~~(sprintf "FROM %s as `%s` " (baseTable.FullName.Replace("[","`").Replace("]","`"))  baseAlias)
             fromBuilder()
             // WHERE
             if sqlQuery.Filters.Length > 0 then
                 // each filter is effectively the entire contents of each where clause in the linq query,
                 // of which there can be many. Simply turn them all into one big AND expression as that is the
-                // only logical way to deal with them. 
+                // only logical way to deal with them.
                 let f = [And([],Some sqlQuery.Filters)]
-                ~~"WHERE " 
+                ~~"WHERE "
                 filterBuilder f
-        
+
             if sqlQuery.Ordering.Length > 0 then
                 ~~"ORDER BY "
                 orderByBuilder()
@@ -592,45 +587,44 @@ type internal MySqlProvider(resolutionPath, owner, referencedAssemblies) as this
             | None, None -> ()
 
             let sql = sb.ToString()
-            (sql,parameters)        
+            (sql,parameters)
 
         member this.ProcessUpdates(con, entities) =
             let sb = Text.StringBuilder()
-            let (~~) (t:string) = sb.Append t |> ignore
 
             // ensure columns have been loaded
-            entities |> List.map(fun e -> e.Table) 
-                     |> Seq.distinct 
+            entities |> List.map(fun e -> e.Table)
+                     |> Seq.distinct
                      |> Seq.iter(fun t -> (this :> ISqlProvider).GetColumns(con,t) |> ignore )
 
             con.Open()
 
             use scope = Utilities.ensureTransaction()
             try
-                // close the connection first otherwise it won't get enlisted into the transaction 
+                // close the connection first otherwise it won't get enlisted into the transaction
                 if con.State = ConnectionState.Open then con.Close()
-                con.Open()         
-                
+                con.Open()
+
                 // initially supporting update/create/delete of single entities, no hierarchies yet
                 entities
-                |> List.iter(fun e -> 
+                |> List.iter(fun e ->
                     match e._State with
-                    | Created -> 
+                    | Created ->
                         let cmd = createInsertCommand con sb e
                         Common.QueryEvents.PublishSqlQuery cmd.CommandText
                         let id = cmd.ExecuteScalar()
                         match e.GetColumnOption pkLookup.[e.Table.FullName] with
-                        | Some v -> () // if the primary key exists, do nothing
-                                       // this is because non-identity columns will have been set 
-                                       // manually and in that case scope_identity would bring back 0 "" or whatever
+                        | Some(_) -> () // if the primary key exists, do nothing
+                                        // this is because non-identity columns will have been set
+                                        // manually and in that case scope_identity would bring back 0 "" or whatever
                         | None ->  e.SetColumnSilent(pkLookup.[e.Table.FullName], id)
                         e._State <- Unchanged
-                    | Modified fields -> 
+                    | Modified fields ->
                         let cmd = createUpdateCommand con sb e fields
                         Common.QueryEvents.PublishSqlQuery cmd.CommandText
                         cmd.ExecuteNonQuery() |> ignore
                         e._State <- Unchanged
-                    | Deleted -> 
+                    | Deleted ->
                         let cmd = createDeleteCommand con sb e
                         Common.QueryEvents.PublishSqlQuery cmd.CommandText
                         cmd.ExecuteNonQuery() |> ignore
@@ -644,44 +638,43 @@ type internal MySqlProvider(resolutionPath, owner, referencedAssemblies) as this
 
         member this.ProcessUpdatesAsync(con, entities) =
             let sb = Text.StringBuilder()
-            let (~~) (t:string) = sb.Append t |> ignore
 
             // ensure columns have been loaded
-            entities |> List.map(fun e -> e.Table) 
-                     |> Seq.distinct 
+            entities |> List.map(fun e -> e.Table)
+                     |> Seq.distinct
                      |> Seq.iter(fun t -> (this :> ISqlProvider).GetColumns(con,t) |> ignore )
 
-            async { 
+            async {
 
                 use scope = Utilities.ensureTransaction()
                 try
-                    // close the connection first otherwise it won't get enlisted into the transaction 
+                    // close the connection first otherwise it won't get enlisted into the transaction
                     if con.State = ConnectionState.Open then con.Close()
                     do! con.OpenAsync() |> Async.AwaitIAsyncResult |> Async.Ignore
-                
+
                     // initially supporting update/create/delete of single entities, no hierarchies yet
                     let handleEntity (e: SqlEntity) =
                         match e._State with
-                        | Created -> 
+                        | Created ->
                             async {
                                 let cmd = createInsertCommand con sb e :?> System.Data.Common.DbCommand
                                 Common.QueryEvents.PublishSqlQuery cmd.CommandText
                                 let! id = cmd.ExecuteScalarAsync() |> Async.AwaitTask
                                 match e.GetColumnOption pkLookup.[e.Table.FullName] with
-                                | Some v -> () // if the primary key exists, do nothing
-                                               // this is because non-identity columns will have been set 
-                                               // manually and in that case scope_identity would bring back 0 "" or whatever
+                                | Some(_) -> () // if the primary key exists, do nothing
+                                                // this is because non-identity columns will have been set
+                                                // manually and in that case scope_identity would bring back 0 "" or whatever
                                 | None ->  e.SetColumnSilent(pkLookup.[e.Table.FullName], id)
                                 e._State <- Unchanged
                             }
-                        | Modified fields -> 
+                        | Modified fields ->
                             async {
                                 let cmd = createUpdateCommand con sb e fields :?> System.Data.Common.DbCommand
                                 Common.QueryEvents.PublishSqlQuery cmd.CommandText
                                 do! cmd.ExecuteNonQueryAsync() |> Async.AwaitTask |> Async.Ignore
                                 e._State <- Unchanged
                             }
-                        | Deleted -> 
+                        | Deleted ->
                             async {
                                 let cmd = createDeleteCommand con sb e :?> System.Data.Common.DbCommand
                                 Common.QueryEvents.PublishSqlQuery cmd.CommandText
@@ -692,7 +685,7 @@ type internal MySqlProvider(resolutionPath, owner, referencedAssemblies) as this
                         | Unchanged -> failwith "Unchanged entity encountered in update list - this should not be possible!"
 
                     do! Utilities.executeOneByOne handleEntity entities
-                    
+
                     scope.Complete()
                 finally
                     con.Close()

--- a/src/SQLProvider/Providers.MySql.fs
+++ b/src/SQLProvider/Providers.MySql.fs
@@ -450,6 +450,7 @@ type internal MySqlProvider(resolutionPath, owner, referencedAssemblies) as this
             // working on the basis that we will alias everything to make my life eaiser
             // first build  the select statment, this is easy ...
             let columns =
+                if projectionColumns |> Seq.isEmpty then "1" else
                 String.Join(",",
                     [|for KeyValue(k,v) in projectionColumns do
                         if v.Count = 0 then   // if no columns exist in the projection then get everything

--- a/src/SQLProvider/Providers.Odbc.fs
+++ b/src/SQLProvider/Providers.Odbc.fs
@@ -212,6 +212,7 @@ type internal OdbcProvider() =
             let singleEntity = sqlQuery.Aliases.Count = 0
 
             let columns =
+                if projectionColumns |> Seq.isEmpty then "1" else
                 String.Join(",",
                     [|for KeyValue(k,v) in projectionColumns do
                         if v.Count = 0 then   // if no columns exist in the projection then get everything

--- a/src/SQLProvider/Providers.Odbc.fs
+++ b/src/SQLProvider/Providers.Odbc.fs
@@ -8,11 +8,10 @@ open FSharp.Data.Sql
 open FSharp.Data.Sql.Schema
 open FSharp.Data.Sql.Common
 
-type internal OdbcProvider(resolutionPath) =
-    let pkLookup =     Dictionary<string,string>()
-    let tableLookup =  Dictionary<string,Table>()
+type internal OdbcProvider() =
+    let pkLookup = Dictionary<string,string>()
+    let tableLookup = Dictionary<string,Table>()
     let columnLookup = Dictionary<string,Column list>()
-    let relationshipLookup = Dictionary<string,Relationship list * Relationship list>()
 
     let mutable typeMappings = []
     let mutable findClrType : (string -> TypeMapping option)  = fun _ -> failwith "!"
@@ -28,7 +27,7 @@ type internal OdbcProvider(resolutionPath) =
 
         let getClrType (input:string) = Type.GetType(input).ToString()
 
-        let mappings =             
+        let mappings =
             [
                 for r in dt.Rows do
                     let clrType = getClrType (string r.["DataType"])
@@ -43,40 +42,35 @@ type internal OdbcProvider(resolutionPath) =
             |> List.map (fun m -> m.ClrType, m)
             |> Map.ofList
 
-        let dbMappings = 
+        let dbMappings =
             mappings
             |> List.map (fun m -> m.ProviderTypeName.Value, m)
             |> Map.ofList
-            
+
         typeMappings <- mappings
         findClrType <- clrMappings.TryFind
-        findDbType <- dbMappings.TryFind 
-    
-    let executeSql (con:IDbConnection) sql =
-        use com = new OdbcCommand(sql,con:?>OdbcConnection)    
-        com.ExecuteReader()
+        findDbType <- dbMappings.TryFind
 
-    let createInsertCommand (con:IDbConnection) (sb:Text.StringBuilder) (entity:SqlEntity) =     
+    let createInsertCommand (con:IDbConnection) (sb:Text.StringBuilder) (entity:SqlEntity) =
         let (~~) (t:string) = sb.Append t |> ignore
         let cmd = new OdbcCommand()
         cmd.Connection <- con :?> OdbcConnection
-        let pk = pkLookup.[entity.Table.FullName] 
-        let columnNames, values = 
+        let columnNames, values =
             (([],0),entity.ColumnValues)
-            ||> Seq.fold(fun (out,i) (key,value) ->                         
+            ||> Seq.fold(fun (out,i) (key,value) ->
                 let name = sprintf "@param%i" i
                 let p = OdbcParameter(name,value)
                 (key,p)::out,i+1)
-            |> fun (x,_)-> x 
+            |> fun (x,_)-> x
             |> List.rev
-            |> List.toArray 
+            |> List.toArray
             |> Array.unzip
-                
+
         sb.Clear() |> ignore
-        ~~(sprintf "INSERT INTO %s (%s) VALUES (%s);" 
+        ~~(sprintf "INSERT INTO %s (%s) VALUES (%s);"
             entity.Table.Name
             (String.Join(",",columnNames))
-            (String.Join(",",values |> Array.map(fun p -> "?"))))
+            (String.Join(",",values |> Array.map(fun _ -> "?"))))
         cmd.Parameters.AddRange(values)
         cmd.CommandText <- sb.ToString()
         cmd
@@ -91,48 +85,48 @@ type internal OdbcProvider(resolutionPath) =
         let (~~) (t:string) = sb.Append t |> ignore
         let cmd = new OdbcCommand()
         cmd.Connection <- con :?> OdbcConnection
-        let pk = pkLookup.[entity.Table.FullName] 
+        let pk = pkLookup.[entity.Table.FullName]
         sb.Clear() |> ignore
 
         if changedColumns |> List.exists ((=)pk) then failwith "Error - you cannot change the primary key of an entity."
 
-        let pkValue = 
+        let pkValue =
             match entity.GetColumnOption<obj> pk with
             | Some v -> v
             | None -> failwith "Error - you cannot update an entity that does not have a primary key."
-                
-        let data = 
+
+        let data =
             (([],0),changedColumns)
             ||> List.fold(fun (out,i) col ->
-                let p = 
+                let p =
                     match entity.GetColumnOption<obj> col with
                     | Some v -> OdbcParameter(null,v)
                     | None -> OdbcParameter(null,DBNull.Value)
                 (col,p)::out,i+1)
-            |> fun (x,_)-> x 
+            |> fun (x,_)-> x
             |> List.rev
-            |> List.toArray 
-                
+            |> List.toArray
+
         let pkParam = OdbcParameter(null, pkValue)
 
-        ~~(sprintf "UPDATE %s SET %s WHERE %s = ?;" 
+        ~~(sprintf "UPDATE %s SET %s WHERE %s = ?;"
             entity.Table.Name
-            (String.Join(",", data |> Array.map(fun (c,p) -> sprintf "%s = %s" c "?" ) ))
+            (String.Join(",", data |> Array.map(fun (c,_) -> sprintf "%s = %s" c "?" ) ))
             pk)
 
         cmd.Parameters.AddRange(data |> Array.map snd)
         cmd.Parameters.Add pkParam |> ignore
         cmd.CommandText <- sb.ToString()
         cmd
-            
+
     let createDeleteCommand (con:IDbConnection) (sb:Text.StringBuilder) (entity:SqlEntity) =
         let (~~) (t:string) = sb.Append t |> ignore
         let cmd = new OdbcCommand()
         cmd.Connection <- con :?> OdbcConnection
         sb.Clear() |> ignore
-        let pk = pkLookup.[entity.Table.FullName] 
+        let pk = pkLookup.[entity.Table.FullName]
         sb.Clear() |> ignore
-        let pkValue = 
+        let pkValue =
             match entity.GetColumnOption<obj> pk with
             | Some v -> v
             | None -> failwith "Error - you cannot delete an entity that does not have a primary key."
@@ -144,30 +138,34 @@ type internal OdbcProvider(resolutionPath) =
     interface ISqlProvider with
         member __.CreateConnection(connectionString) = upcast new OdbcConnection(connectionString)
         member __.CreateCommand(connection,commandText) = upcast new OdbcCommand(commandText, connection:?>OdbcConnection)
-        member __.CreateCommandParameter(param, value) = 
-            let p = OdbcParameter()            
+
+        member __.CreateCommandParameter(param, value) =
+            let p = OdbcParameter()
             p.Value <- value
             p.ParameterName <- param.Name
             p.DbType <- param.TypeMapping.DbType
             p.Direction <- param.Direction
             Option.iter (fun l -> p.Size <- l) param.Length
             upcast p
-        member __.ExecuteSprocCommand(com,definition,retCols,values) = ReturnValueType.Unit //  raise(NotImplementedException())
 
-        member __.CreateTypeMappings(con) = createTypeMappings (con:?>OdbcConnection)     
-        member __.GetTables(con,cs) =
+        member __.ExecuteSprocCommand(_,_,_,_) = ReturnValueType.Unit
+        member __.CreateTypeMappings(con) = createTypeMappings (con:?>OdbcConnection)
+
+        member __.GetTables(con,_) =
             let con = con :?> OdbcConnection
             if con.State <> ConnectionState.Open then con.Open()
             let dataTables = con.GetSchema("Tables").Rows |> Seq.cast<DataRow> |> Seq.map (fun i -> i.ItemArray)
-            [ for dataTable in dataTables do 
-                let table ={ Schema = string dataTable.[1] ; Name = string dataTable.[2] ; Type=(string dataTable.[3]).ToLower() } 
+            [ for dataTable in dataTables do
+                let table ={ Schema = string dataTable.[1] ; Name = string dataTable.[2] ; Type=(string dataTable.[3]).ToLower() }
                 if tableLookup.ContainsKey table.FullName = false then tableLookup.Add(table.FullName,table)
                 yield table ]
-        member __.GetPrimaryKey(table) = 
-            match pkLookup.TryGetValue table.FullName with 
+
+        member __.GetPrimaryKey(table) =
+            match pkLookup.TryGetValue table.FullName with
             | true, v -> Some v
             | _ -> None
-        member __.GetColumns(con,table) = 
+
+        member __.GetColumns(con,table) =
             match columnLookup.TryGetValue table.FullName with
             | (true,data) -> data
             | _ ->
@@ -176,58 +174,55 @@ type internal OdbcProvider(resolutionPath) =
                let primaryKey = con.GetSchema("Indexes", [| null; null; table.Name |]).Rows |> Seq.cast<DataRow> |> Seq.map (fun i -> i.ItemArray) |> Array.ofSeq
                let dataTable = con.GetSchema("Columns", [| null; null; table.Name; null|]).Rows |> Seq.cast<DataRow> |> Seq.map (fun i -> i.ItemArray)
                let columns =
-                  [ for i in dataTable do 
+                  [ for i in dataTable do
                       let dt = i.[5] :?> string
                       match findDbType dt with
                       | Some(m) ->
                          let name = i.[3] :?> string
                          let col =
-                            { Column.Name = name 
+                            { Column.Name = name
                               TypeMapping = m
                               IsNullable = let b = i.[17] :?> string in if b = "YES" then true else false
-                              IsPrimarKey = if primaryKey.Length > 0 && primaryKey.[0].[8] = box name then true else false } 
+                              IsPrimarKey = if primaryKey.Length > 0 && primaryKey.[0].[8] = box name then true else false }
                          if col.IsPrimarKey && pkLookup.ContainsKey table.FullName = false then pkLookup.Add(table.FullName,col.Name)
-                         yield col 
-                      | _ -> ()]  
+                         yield col
+                      | _ -> ()]
                columnLookup.Add(table.FullName,columns)
                columns
 
-        member __.GetRelationships(con,table) =
-            // The ODBC type provider does not currently support GetRelationships operations.
-            ([],[])
+        member __.GetRelationships(_,_) = ([],[]) // The ODBC type provider does not currently support GetRelationships operations.
+        member __.GetSprocs(_) = []
 
-        member __.GetSprocs(con) = []
-
-        member this.GetIndividualsQueryText(table,amount) =
+        member __.GetIndividualsQueryText(table,_) =
             sprintf "SELECT * FROM `%s`" table.Name
 
-        member this.GetIndividualQueryText(table,column) =
+        member __.GetIndividualQueryText(table,column) =
             sprintf "SELECT * FROM `%s` WHERE `%s`.`%s` = ?" table.Name table.Name column
-        
-        member this.GenerateQueryText(sqlQuery,baseAlias,baseTable,projectionColumns) = 
+
+        member __.GenerateQueryText(sqlQuery,baseAlias,baseTable,projectionColumns) =
             let sb = System.Text.StringBuilder()
             let parameters = ResizeArray<_>()
             let (~~) (t:string) = sb.Append t |> ignore
-            
+
             let getTable x =
                 match sqlQuery.Aliases.TryFind x with
                 | Some(a) -> a
                 | None -> baseTable
 
             let singleEntity = sqlQuery.Aliases.Count = 0
-            
-            let columns = 
+
+            let columns =
                 String.Join(",",
                     [|for KeyValue(k,v) in projectionColumns do
                         if v.Count = 0 then   // if no columns exist in the projection then get everything
-                            for col in columnLookup.[(getTable k).FullName] |> List.map(fun c -> c.Name) do 
+                            for col in columnLookup.[(getTable k).FullName] |> List.map(fun c -> c.Name) do
                                 if singleEntity then yield sprintf "`%s`" col
                                 else yield sprintf "`%s`.`%s` as `%s_%s`" k col k col
                         else
-                            for col in v do 
+                            for col in v do
                                 if singleEntity then yield sprintf "`%s`" col
                                 else yield sprintf "`%s`.`%s` as `%s_%s`" k col k col |]) // F# makes this so easy :)
-        
+
             // make this nicer later.. just try and get the damn thing to work properly (well, at all) for now :D
             // NOTE: really need to assign the parameters their correct sql types
 
@@ -235,15 +230,15 @@ type internal OdbcProvider(resolutionPath) =
                 let paramName = "?"
                 OdbcParameter(paramName,value):> IDbDataParameter
 
-            let rec filterBuilder = function 
+            let rec filterBuilder = function
                 | [] -> ()
                 | (cond::conds) ->
                     let build op preds (rest:Condition list option) =
                         ~~ "("
                         preds |> List.iteri( fun i (alias,col,operator,data) ->
-                                let extractData data = 
+                                let extractData data =
                                      match data with
-                                     | Some(x) when (box x :? obj array) -> 
+                                     | Some(x) when (box x :? obj array) ->
                                          // in and not in operators pass an array
                                          let strings = box x :?> obj array
                                          strings |> Array.map createParam
@@ -254,19 +249,19 @@ type internal OdbcProvider(resolutionPath) =
                                 let paras = extractData data
                                 ~~(sprintf "%s%s" prefix <|
                                     match operator with
-                                    | FSharp.Data.Sql.IsNull -> (sprintf "`%s`.`%s` IS NULL") alias col 
-                                    | FSharp.Data.Sql.NotNull -> (sprintf "`%s`.`%s` IS NOT NULL") alias col 
-                                    | FSharp.Data.Sql.In ->                                     
+                                    | FSharp.Data.Sql.IsNull -> (sprintf "`%s`.`%s` IS NULL") alias col
+                                    | FSharp.Data.Sql.NotNull -> (sprintf "`%s`.`%s` IS NOT NULL") alias col
+                                    | FSharp.Data.Sql.In ->
                                         let text = String.Join(",",paras |> Array.map (fun p -> p.ParameterName))
                                         Array.iter parameters.Add paras
                                         (sprintf "`%s`.`%s` IN (%s)") alias col text
-                                    | FSharp.Data.Sql.NotIn ->                                    
+                                    | FSharp.Data.Sql.NotIn ->
                                         let text = String.Join(",",paras |> Array.map (fun p -> p.ParameterName))
                                         Array.iter parameters.Add paras
-                                        (sprintf "`%s`.`%s` NOT IN (%s)") alias col text 
-                                    | _ -> 
+                                        (sprintf "`%s`.`%s` NOT IN (%s)") alias col text
+                                    | _ ->
                                         parameters.Add paras.[0]
-                                        (sprintf "`%s`.%s %s %s") alias col 
+                                        (sprintf "`%s`.%s %s %s") alias col
                                          (operator.ToString()) paras.[0].ParameterName)
                         )
                         // there's probably a nicer way to do this
@@ -279,38 +274,38 @@ type internal OdbcProvider(resolutionPath) =
                                 ~~ (sprintf " %s " op)
                                 filterBuilder [x]
                                 ~~ (sprintf " %s " op)
-                                aux xs 
+                                aux xs
                             | x::xs ->
                                 filterBuilder [x]
                                 ~~ (sprintf " %s " op)
                                 aux xs
                             | [] -> ()
-                    
+
                         Option.iter aux rest
                         ~~ ")"
-                
+
                     match cond with
                     | Or(preds,rest) -> build "OR" preds rest
-                    | And(preds,rest) ->  build "AND" preds rest 
-                
+                    | And(preds,rest) ->  build "AND" preds rest
+
                     filterBuilder conds
-                
-            // next up is the FROM statement which includes joins .. 
-            let fromBuilder() = 
+
+            // next up is the FROM statement which includes joins ..
+            let fromBuilder() =
                 sqlQuery.Links
                 |> List.iter(fun (fromAlias, data, destAlias)  ->
                     let joinType = if data.OuterJoin then "LEFT OUTER JOIN " else "INNER JOIN "
                     let destTable = getTable destAlias
-                    ~~  (sprintf "%s `%s` as `%s` on `%s`.`%s` = `%s`.`%s` " 
-                            joinType destTable.Name destAlias 
+                    ~~  (sprintf "%s `%s` as `%s` on `%s`.`%s` = `%s`.`%s` "
+                            joinType destTable.Name destAlias
                             (if data.RelDirection = RelationshipDirection.Parents then fromAlias else destAlias)
-                            data.ForeignKey  
-                            (if data.RelDirection = RelationshipDirection.Parents then destAlias else fromAlias) 
+                            data.ForeignKey
+                            (if data.RelDirection = RelationshipDirection.Parents then destAlias else fromAlias)
                             data.PrimaryKey))
 
             let orderByBuilder() =
                 sqlQuery.Ordering
-                |> List.iteri(fun i (alias,column,desc) -> 
+                |> List.iteri(fun i (alias,column,desc) ->
                     if i > 0 then ~~ ", "
                     ~~ (sprintf "`%s`.`%s` %s" alias column (if not desc then "DESC" else "")))
 
@@ -330,11 +325,11 @@ type internal OdbcProvider(resolutionPath) =
             if sqlQuery.Filters.Length > 0 then
                 // each filter is effectively the entire contents of each where clause in the linq query,
                 // of which there can be many. Simply turn them all into one big AND expression as that is the
-                // only logical way to deal with them. 
+                // only logical way to deal with them.
                 let f = [And([],Some sqlQuery.Filters)]
-                ~~"WHERE " 
+                ~~"WHERE "
                 filterBuilder f
-        
+
             if sqlQuery.Ordering.Length > 0 then
                 ~~"ORDER BY "
                 orderByBuilder()
@@ -342,43 +337,42 @@ type internal OdbcProvider(resolutionPath) =
             let sql = sb.ToString()
             (sql,parameters)
 
-        member this.ProcessUpdates(con, entities) =            
+        member this.ProcessUpdates(con, entities) =
             let sb = Text.StringBuilder()
-            let (~~) (t:string) = sb.Append t |> ignore
 
             // ensure columns have been loaded
-            entities |> List.map(fun e -> e.Table) 
-                     |> Seq.distinct 
+            entities |> List.map(fun e -> e.Table)
+                     |> Seq.distinct
                      |> Seq.iter(fun t -> (this :> ISqlProvider).GetColumns(con,t) |> ignore )
 
             if con.State <> ConnectionState.Open then con.Open()
 
             use scope = Utilities.ensureTransaction()
-            try                
-                // close the connection first otherwise it won't get enlisted into the transaction 
+            try
+                // close the connection first otherwise it won't get enlisted into the transaction
                 if con.State = ConnectionState.Open then con.Close()
-                con.Open()         
+                con.Open()
                 // initially supporting update/create/delete of single entities, no hierarchies yet
                 entities
-                |> List.iter(fun e -> 
+                |> List.iter(fun e ->
                     match e._State with
-                    | Created -> 
+                    | Created ->
                         let cmd = createInsertCommand con sb e
                         Common.QueryEvents.PublishSqlQuery cmd.CommandText
                         cmd.ExecuteNonQuery() |> ignore
                         let id = (lastInsertId con).ExecuteScalar()
                         match e.GetColumnOption pkLookup.[e.Table.FullName] with
-                        | Some v -> () // if the primary key exists, do nothing
-                                       // this is because non-identity columns will have been set 
-                                       // manually and in that case scope_identity would bring back 0 "" or whatever
+                        | Some(_) -> () // if the primary key exists, do nothing
+                                        // this is because non-identity columns will have been set
+                                        // manually and in that case scope_identity would bring back 0 "" or whatever
                         | None ->  e.SetColumnSilent(pkLookup.[e.Table.FullName], id)
                         e._State <- Unchanged
-                    | Modified fields -> 
+                    | Modified fields ->
                         let cmd = createUpdateCommand con sb e fields
                         Common.QueryEvents.PublishSqlQuery cmd.CommandText
                         cmd.ExecuteNonQuery() |> ignore
                         e._State <- Unchanged
-                    | Deleted -> 
+                    | Deleted ->
                         let cmd = createDeleteCommand con sb e
                         Common.QueryEvents.PublishSqlQuery cmd.CommandText
                         cmd.ExecuteNonQuery() |> ignore
@@ -391,44 +385,43 @@ type internal OdbcProvider(resolutionPath) =
 
         member this.ProcessUpdatesAsync(con, entities) =
             let sb = Text.StringBuilder()
-            let (~~) (t:string) = sb.Append t |> ignore
 
             // ensure columns have been loaded
-            entities |> List.map(fun e -> e.Table) 
-                     |> Seq.distinct 
+            entities |> List.map(fun e -> e.Table)
+                     |> Seq.distinct
                      |> Seq.iter(fun t -> (this :> ISqlProvider).GetColumns(con,t) |> ignore )
 
-            async { 
+            async {
                 use scope = Utilities.ensureTransaction()
-                try                
-                    // close the connection first otherwise it won't get enlisted into the transaction 
+                try
+                    // close the connection first otherwise it won't get enlisted into the transaction
                     if con.State = ConnectionState.Open then con.Close()
 
                     do! con.OpenAsync() |> Async.AwaitIAsyncResult |> Async.Ignore
                     // initially supporting update/create/delete of single entities, no hierarchies yet
                     let handleEntity (e: SqlEntity) =
                         match e._State with
-                        | Created -> 
+                        | Created ->
                             async {
                                 let cmd = createInsertCommand con sb e
                                 Common.QueryEvents.PublishSqlQuery cmd.CommandText
                                 do! cmd.ExecuteNonQueryAsync() |> Async.AwaitTask |> Async.Ignore
                                 let id = (lastInsertId con).ExecuteScalar()
                                 match e.GetColumnOption pkLookup.[e.Table.FullName] with
-                                | Some v -> () // if the primary key exists, do nothing
-                                               // this is because non-identity columns will have been set 
-                                               // manually and in that case scope_identity would bring back 0 "" or whatever
+                                | Some(_) -> () // if the primary key exists, do nothing
+                                                // this is because non-identity columns will have been set
+                                                // manually and in that case scope_identity would bring back 0 "" or whatever
                                 | None ->  e.SetColumnSilent(pkLookup.[e.Table.FullName], id)
                                 e._State <- Unchanged
                             }
-                        | Modified fields -> 
+                        | Modified fields ->
                             async {
                                 let cmd = createUpdateCommand con sb e fields
                                 Common.QueryEvents.PublishSqlQuery cmd.CommandText
                                 do! cmd.ExecuteNonQueryAsync() |> Async.AwaitTask |> Async.Ignore
                                 e._State <- Unchanged
                             }
-                        | Deleted -> 
+                        | Deleted ->
                             async {
                                 let cmd = createDeleteCommand con sb e
                                 Common.QueryEvents.PublishSqlQuery cmd.CommandText

--- a/src/SQLProvider/Providers.Oracle.fs
+++ b/src/SQLProvider/Providers.Oracle.fs
@@ -3,19 +3,17 @@
 open System
 open System.Collections.Generic
 open System.Data
-open System.Reflection
 open FSharp.Data.Sql
 open FSharp.Data.Sql.Schema
 open FSharp.Data.Sql.Common
 open FSharp.Data.Sql.Common.Utilities
 
 module internal Oracle =
-    
     let mutable resolutionPath = String.Empty
     let mutable referencedAssemblies : string array = [||]
     let mutable owner = String.Empty
 
-    let assemblyNames = 
+    let assemblyNames =
         [
             "Oracle.ManagedDataAccess.dll"
             "Oracle.DataAccess.dll"
@@ -24,17 +22,16 @@ module internal Oracle =
     let assembly =
         lazy Reflection.tryLoadAssemblyFrom resolutionPath referencedAssemblies assemblyNames
 
-
-    let findType name = 
+    let findType name =
         match assembly.Value with
         | Choice1Of2(assembly) -> assembly.GetTypes() |> Array.find(fun t -> t.Name = name)
-        | Choice2Of2(paths) -> 
+        | Choice2Of2(paths) ->
            failwithf "Unable to resolve assemblies. One of %s must exist in the paths: %s %s"
-                (String.Join(", ", assemblyNames |> List.toArray)) 
+                (String.Join(", ", assemblyNames |> List.toArray))
                 Environment.NewLine
                 (String.Join(Environment.NewLine, paths))
 
-    let systemNames = 
+    let systemNames =
         [
             "SYSTEM"; "SYS"; "XDB"
         ]
@@ -48,7 +45,7 @@ module internal Oracle =
 
     let getSchemaMethod = lazy (connectionType.Value.GetMethod("GetSchema",[|typeof<string>; typeof<string[]>|]))
 
-    let getSchema name (args:string[]) conn = 
+    let getSchema name (args:string[]) conn =
         getSchemaMethod.Value.Invoke(conn,[|name; args|]) :?> DataTable
 
     let mutable typeMappings = []
@@ -70,7 +67,7 @@ module internal Oracle =
             | "system.long"  -> typeof<System.Int64>
             | _ -> Type.GetType(input)).ToString()
 
-        let mappings =             
+        let mappings =
             [
                 for r in dt.Rows do
                     let clrType = getClrType (string r.["DataType"])
@@ -86,38 +83,37 @@ module internal Oracle =
             |> List.map (fun m -> m.ClrType, m)
             |> Map.ofList
 
-        let oracleMappings = 
+        let oracleMappings =
             mappings
             |> List.map (fun m -> m.ProviderTypeName.Value, m)
             |> Map.ofList
-            
+
         typeMappings <- mappings
         findClrType <- clrMappings.TryFind
-        findDbType <- oracleMappings.TryFind 
- 
-    let tryReadValueProperty instance = 
+        findDbType <- oracleMappings.TryFind
+
+    let tryReadValueProperty instance =
         let typ = instance.GetType()
         let prop = typ.GetProperty("Value")
         if prop <> null
         then prop.GetGetMethod().Invoke(instance, [||]) |> Some
-        else None         
-            
-    let createConnection connectionString = 
+        else None
+
+    let createConnection connectionString =
         Activator.CreateInstance(connectionType.Value,[|box connectionString|]) :?> IDbConnection
 
-    let createCommand commandText connection = 
+    let createCommand commandText connection =
         Activator.CreateInstance(commandType.Value,[|box commandText;box connection|]) :?> IDbCommand
 
-    let createCommandParameter (param:QueryParameter) value = 
+    let createCommandParameter (param:QueryParameter) value =
         let value = if value = null then (box System.DBNull.Value) else value
         let parameterType = parameterType.Value
-        let oracleDbTypeSetter = 
+        let oracleDbTypeSetter =
             parameterType.GetProperty("OracleDbType").GetSetMethod()
-        
+
         let p = Activator.CreateInstance(parameterType,[|box param.Name; box value|]) :?> IDbDataParameter
-        
-        p.Direction <- param.Direction 
-        
+        p.Direction <- param.Direction
+
         match param.TypeMapping.ProviderTypeName with
         | Some _ ->
             p.DbType <- param.TypeMapping.DbType
@@ -126,41 +122,41 @@ module internal Oracle =
 
         match param.Length with
         | Some(length) when length >= 0 -> p.Size <- length
-        | _ -> 
+        | _ ->
                match param.TypeMapping.DbType with
                | DbType.String -> p.Size <- 32767
                | _ -> ()
-        p 
+        p
 
-    let readParameter (parameter:IDbDataParameter) = 
+    let readParameter (parameter:IDbDataParameter) =
         let parameterType = parameterType.Value
-        let oracleDbTypeGetter = 
+        let oracleDbTypeGetter =
             parameterType.GetProperty("OracleDbType").GetGetMethod()
-        
+
         match parameter.DbType, (oracleDbTypeGetter.Invoke(parameter, [||]) :?> int) with
         | DbType.Object, 121 ->
              if parameter.Value = null
              then null
              else
-                let data = 
-                    Sql.dataReaderToArray (getDataReaderForRefCursor.Value.Invoke(parameter.Value, [||]) :?> IDataReader) 
+                let data =
+                    Sql.dataReaderToArray (getDataReaderForRefCursor.Value.Invoke(parameter.Value, [||]) :?> IDataReader)
                     |> Seq.ofArray
                 data |> box
         | _, _ ->
             match tryReadValueProperty parameter.Value with
             | Some(obj) -> obj |> box
             | _ -> parameter.Value |> box
-    
+
     let getPrimaryKeys con =
-        let indexColumns = 
+        let indexColumns =
             getSchema "IndexColumns" [|owner|] con
-            |> DataTable.mapChoose (fun row -> 
+            |> DataTable.mapChoose (fun row ->
                 let tableOwner = Sql.dbUnbox<string> row.[2]
                 if List.exists ((=) tableOwner) systemNames
-                then None 
+                then None
                 else Some(Sql.dbUnbox row.[1], Sql.dbUnbox row.[4]))
             |> Map.ofList
-        
+
         getSchema "PrimaryKeys" [|owner|] con
         |> DataTable.mapChoose (fun row ->
             let indexName = Sql.dbUnbox row.[15]
@@ -169,31 +165,31 @@ module internal Oracle =
             then None
             else
                 match Map.tryFind indexName indexColumns with
-                | Some(column) -> 
+                | Some(column) ->
                     let pk = { Name = unbox row.[1]; Table = tableName; Column = column; IndexName = indexName }
                     Some(tableName, pk)
                 | None -> None)
 
-    let getTables con = 
+    let getTables con =
         getSchema "Tables" [|owner|] con
-        |> DataTable.mapChoose (fun row -> 
+        |> DataTable.mapChoose (fun row ->
               let name = Sql.dbUnbox row.[1]
               let typ = Sql.dbUnbox<string> row.[2]
               if typ = "System"
               then None
               else
-                Some { Schema = Sql.dbUnbox row.[0]; 
+                Some { Schema = Sql.dbUnbox row.[0];
                        Name = name;
                        Type = Sql.dbUnbox row.[2] })
 
-    let getColumns (primaryKeys:IDictionary<_,_>) table con = 
+    let getColumns (primaryKeys:IDictionary<_,_>) table con =
         getSchema "Columns" [|owner; table|] con
-        |> DataTable.mapChoose (fun row -> 
+        |> DataTable.mapChoose (fun row ->
                 let typ = Sql.dbUnbox row.[4]
                 let nullable = (Sql.dbUnbox row.[8]) = "Y"
                 let colName =  (Sql.dbUnbox row.[2])
                 match findDbType typ with
-                | Some(m) -> 
+                | Some(m) ->
                         { Name = colName
                           TypeMapping = m
                           IsPrimarKey = primaryKeys.Values |> Seq.exists (fun x -> x.Table = table && x.Column = colName)
@@ -201,30 +197,29 @@ module internal Oracle =
                 | _ -> None)
 
     let getRelationships (primaryKeys:IDictionary<_,_>) table con =
-        let foreignKeyCols = 
+        let foreignKeyCols =
             getSchema "ForeignKeyColumns" [|owner;table|] con
-            |> DataTable.map (fun row -> (Sql.dbUnbox row.[1], Sql.dbUnbox row.[3])) 
+            |> DataTable.map (fun row -> (Sql.dbUnbox row.[1], Sql.dbUnbox row.[3]))
             |> Map.ofList
-        let rels = 
+        let rels =
             getSchema "ForeignKeys" [|owner;table|] con
-            |> DataTable.mapChoose (fun row -> 
+            |> DataTable.mapChoose (fun row ->
                 let name = Sql.dbUnbox row.[4]
-                let pkName = Sql.dbUnbox row.[0]
                 match primaryKeys.TryGetValue(table) with
                 | true, pk ->
                     match foreignKeyCols.TryFind name with
                     | Some(fk) ->
-                         { Name = name 
-                           PrimaryTable = Table.CreateFullName(Sql.dbUnbox row.[1],Sql.dbUnbox row.[2]) 
+                         { Name = name
+                           PrimaryTable = Table.CreateFullName(Sql.dbUnbox row.[1],Sql.dbUnbox row.[2])
                            PrimaryKey = pk.Column
                            ForeignTable = Table.CreateFullName(Sql.dbUnbox row.[3],Sql.dbUnbox row.[5])
                            ForeignKey = fk } |> Some
                     | None -> None
                 | false, _ -> None
             )
-        let children = 
-            rels |> List.map (fun x -> 
-                { Name = x.Name 
+        let children =
+            rels |> List.map (fun x ->
+                { Name = x.Name
                   PrimaryTable = x.ForeignTable
                   PrimaryKey = x.ForeignKey
                   ForeignTable = x.PrimaryTable
@@ -232,14 +227,14 @@ module internal Oracle =
             )
         (children, rels)
 
-    let getIndivdualsQueryText amount (table:Table) = 
+    let getIndivdualsQueryText amount (table:Table) =
         sprintf "select * from ( select * from %s order by 1 desc) where ROWNUM <= %i" table.FullName amount
 
-    let getIndivdualQueryText (table:Table) column = 
+    let getIndivdualQueryText (table:Table) column =
         let tName = table.FullName
         sprintf "SELECT * FROM %s WHERE %s.%s = :id" tName tName (quoteWhiteSpace column)
 
-    let getSprocReturnColumns (con: IDbConnection) (sparams: QueryParameter list) =
+    let getSprocReturnColumns (sparams: QueryParameter list) =
         sparams
         |> List.filter (fun x -> x.Direction <> ParameterDirection.Input)
         |> List.mapi (fun i p -> { Name = (if (String.IsNullOrEmpty p.Name) && (i > 0)
@@ -253,20 +248,20 @@ module internal Oracle =
                                    Length = None
                                  })
 
-    let getSprocName (row:DataRow) = 
+    let getSprocName (row:DataRow) =
         let owner = Sql.dbUnbox row.["OWNER"]
         let (procName, packageName) = (Sql.dbUnbox row.["OBJECT_NAME"], Sql.dbUnbox row.["PACKAGE_NAME"])
         { ProcName = procName; Owner = owner; PackageName = packageName }
 
-    let getSprocParameters (con:IDbConnection) (name:SprocName) = 
-        let createSprocParameters (row:DataRow) = 
+    let getSprocParameters (con:IDbConnection) (name:SprocName) =
+        let createSprocParameters (row:DataRow) =
            let dataType = Sql.dbUnbox row.["DATA_TYPE"]
            let argumentName = Sql.dbUnbox row.["ARGUMENT_NAME"]
            let maxLength = Some(int(Sql.dbUnboxWithDefault<decimal> -1M row.["DATA_LENGTH"]))
 
-           findDbType dataType 
+           findDbType dataType
            |> Option.map (fun m ->
-               let direction = 
+               let direction =
                    match Sql.dbUnbox row.["IN_OUT"] with
                    | "IN" -> ParameterDirection.Input
                    | "OUT" when String.IsNullOrEmpty(argumentName) -> ParameterDirection.ReturnValue
@@ -279,7 +274,7 @@ module internal Oracle =
                  Length = maxLength
                  Ordinal = int(Sql.dbUnbox<decimal> row.["POSITION"]) }
            )
-        getSchema "ProcedureParameters" [|owner|] con 
+        getSchema "ProcedureParameters" [|owner|] con
         |> DataTable.groupBy (fun row -> getSprocName row, createSprocParameters row)
         |> Seq.filter (fun (n, _) -> n.ProcName = name.ProcName)
         |> Seq.collect (snd >> Seq.choose id)
@@ -288,55 +283,54 @@ module internal Oracle =
 
     let getSprocs con =
 
-        let buildDef classType row = 
+        let buildDef classType row =
             let name = getSprocName row
-            Root(classType, Sproc({ Name = name; Params = (fun con -> getSprocParameters con name); ReturnColumns = (fun con sparams -> getSprocReturnColumns con sparams) }))
+            Root(classType, Sproc({ Name = name; Params = (fun con -> getSprocParameters con name); ReturnColumns = (fun _ sparams -> getSprocReturnColumns sparams) }))
 
         let functions =
             (getSchema "Functions" [|owner|] con)
             |> DataTable.map (fun row -> buildDef "Functions" row)
 
-        let procs = 
-            (getSchema "Procedures" [|owner|] con) 
+        let procs =
+            (getSchema "Procedures" [|owner|] con)
             |> DataTable.map (fun row -> buildDef "Procedures" row)
 
         functions @ procs
 
-    let executeSprocCommand (com:IDbCommand) (inputParameters:QueryParameter[]) (retCols:QueryParameter[]) (values:obj[]) = 
+    let executeSprocCommand (com:IDbCommand) (inputParameters:QueryParameter[]) (retCols:QueryParameter[]) (values:obj[]) =
         let inputParameters = inputParameters |> Array.filter (fun p -> p.Direction = ParameterDirection.Input)
-        
+
         let outps =
              retCols
              |> Array.map(fun ip ->
                  let p = createCommandParameter ip null
                  (ip.Ordinal, p))
-        
+
         let inps =
              inputParameters
              |> Array.mapi(fun i ip ->
                  let p = createCommandParameter ip values.[i]
                  (ip.Ordinal,p))
-        
+
         Array.append outps inps
         |> Array.sortBy fst
         |> Array.iter (fun (_,p) -> com.Parameters.Add(p) |> ignore)
 
-        
-        let entities = 
+        let entities =
             match retCols with
             | [||] -> com.ExecuteNonQuery() |> ignore; Unit
             | [|col|] ->
                 use reader = com.ExecuteReader()
                 match col.TypeMapping.ProviderTypeName with
                 | Some "REF CURSOR" -> SingleResultSet(col.Name, Sql.dataReaderToArray reader)
-                | _ -> 
+                | _ ->
                     match outps |> Array.tryFind (fun (_,p) -> p.ParameterName = col.Name) with
                     | Some(_,p) -> Scalar(p.ParameterName, readParameter p)
                     | None -> failwithf "Excepted return column %s but could not find it in the parameter set" col.Name
-            | cols -> 
+            | cols ->
                 com.ExecuteNonQuery() |> ignore
-                let returnValues = 
-                    cols 
+                let returnValues =
+                    cols
                     |> Array.map (fun col ->
                         match outps |> Array.tryFind (fun (_,p) -> p.ParameterName = col.Name) with
                         | Some(_,p) ->
@@ -346,33 +340,30 @@ module internal Oracle =
                         | None -> failwithf "Excepted return column %s but could not find it in the parameter set" col.Name
                     )
                 Set(returnValues)
-          
-        entities                 
-
+        entities
 
 type internal OracleProvider(resolutionPath, owner, referencedAssemblies) =
-    
     let mutable primaryKeyCache : IDictionary<string,PrimaryKey> = null
     let relationshipCache = new Dictionary<string, Relationship list * Relationship list>()
     let columnCache = new Dictionary<string, Column list>()
     let mutable tableCache : Table list = []
 
-    let createInsertCommand (provider:ISqlProvider) (con:IDbConnection) (sb:Text.StringBuilder) (entity:SqlEntity) =     
+    let createInsertCommand (provider:ISqlProvider) (con:IDbConnection) (sb:Text.StringBuilder) (entity:SqlEntity) =
         let (~~) (t:string) = sb.Append t |> ignore
-        let pk = primaryKeyCache.[entity.Table.Name] 
-        let columnNames, values = 
+
+        let columnNames, values =
             (([],0),entity.ColumnValues)
             ||> Seq.fold(fun (out,i) (k,v) ->
                 let name = sprintf ":param%i" i
                 let p = provider.CreateCommandParameter(QueryParameter.Create(name,i), v)
                 (k,p)::out,i+1)
-            |> fun (x,_)-> x 
+            |> fun (x,_)-> x
             |> List.rev
-            |> List.toArray 
+            |> List.toArray
             |> Array.unzip
-                
+
         sb.Clear() |> ignore
-        ~~(sprintf "INSERT INTO %s (%s) VALUES (%s)" 
+        ~~(sprintf "INSERT INTO %s (%s) VALUES (%s)"
             (entity.Table.FullName)
             (String.Join(",",columnNames))
             (String.Join(",",values |> Array.map(fun p -> p.ParameterName))))
@@ -382,48 +373,48 @@ type internal OracleProvider(resolutionPath, owner, referencedAssemblies) =
 
     let createUpdateCommand (provider:ISqlProvider) (con:IDbConnection) (sb:Text.StringBuilder) (entity:SqlEntity) changedColumns =
         let (~~) (t:string) = sb.Append t |> ignore
-        let pk = primaryKeyCache.[entity.Table.Name] 
+        let pk = primaryKeyCache.[entity.Table.Name]
         sb.Clear() |> ignore
 
         if changedColumns |> List.exists ((=)pk.Column) then failwith "Error - you cannot change the primary key of an entity."
 
-        let pkValue = 
+        let pkValue =
             match entity.GetColumnOption<obj> pk.Column with
             | Some v -> v
             | None -> failwith "Error - you cannot update an entity that does not have a primary key."
-                
-        let columns, parameters = 
+
+        let columns, parameters =
             (([],0),changedColumns)
-            ||> List.fold(fun (out,i) col ->                                                         
+            ||> List.fold(fun (out,i) col ->
                 let name = sprintf ":param%i" i
-                let p = 
+                let p =
                     match entity.GetColumnOption<obj> col with
                     | Some v -> provider.CreateCommandParameter(QueryParameter.Create(name,i), v)
                     | None -> provider.CreateCommandParameter(QueryParameter.Create(name,i), DBNull.Value)
                 (col,p)::out,i+1)
-            |> fun (x,_)-> x 
+            |> fun (x,_)-> x
             |> List.rev
             |> List.toArray
             |> Array.unzip
-                
+
         let pkParam = provider.CreateCommandParameter(QueryParameter.Create(":pk",0), pkValue)
 
-        ~~(sprintf "UPDATE %s SET (%s) = (%s) WHERE %s = :pk" 
+        ~~(sprintf "UPDATE %s SET (%s) = (%s) WHERE %s = :pk"
             (entity.Table.FullName)
             (String.Join(",", columns))
             (String.Join(",", parameters |> Array.map (fun p -> p.ParameterName)))
             pk.Column)
-                
+
         let cmd = provider.CreateCommand(con, sb.ToString())
         parameters |> Array.iter (cmd.Parameters.Add >> ignore)
         cmd.Parameters.Add pkParam |> ignore
         cmd
-            
+
     let createDeleteCommand (provider:ISqlProvider) (con:IDbConnection) (sb:Text.StringBuilder) (entity:SqlEntity) =
         let (~~) (t:string) = sb.Append t |> ignore
-        let pk = primaryKeyCache.[entity.Table.Name] 
+        let pk = primaryKeyCache.[entity.Table.Name]
         sb.Clear() |> ignore
-        let pkValue = 
+        let pkValue =
             match entity.GetColumnOption<obj> pk.Column with
             | Some v -> v
             | None -> failwith "Error - you cannot delete an entity that does not have a primary key."
@@ -441,20 +432,19 @@ type internal OracleProvider(resolutionPath, owner, referencedAssemblies) =
         Oracle.owner <- owner
         Oracle.referencedAssemblies <- referencedAssemblies
         Oracle.resolutionPath <- resolutionPath
-    
+
     interface ISqlProvider with
         member __.CreateConnection(connectionString) = Oracle.createConnection connectionString
         member __.CreateCommand(connection,commandText) =  Oracle.createCommand commandText connection
         member __.CreateCommandParameter(param, value) = Oracle.createCommandParameter param value
-        member __.ExecuteSprocCommand(con, param ,retCols, values:obj array) = 
-            Oracle.executeSprocCommand con param retCols values
+        member __.ExecuteSprocCommand(con, param ,retCols, values:obj array) = Oracle.executeSprocCommand con param retCols values
 
-        member __.CreateTypeMappings(con) = 
-            Sql.connect con (fun con -> 
+        member __.CreateTypeMappings(con) =
+            Sql.connect con (fun con ->
                 Oracle.createTypeMappings con
                 primaryKeyCache <- ((Oracle.getPrimaryKeys con) |> dict))
 
-        member __.GetTables(con,cs) =
+        member __.GetTables(con,_) =
                match tableCache with
                | [] ->
                     let tables = Sql.connect con Oracle.getTables
@@ -462,12 +452,12 @@ type internal OracleProvider(resolutionPath, owner, referencedAssemblies) =
                     tables
                 | a -> a
 
-        member __.GetPrimaryKey(table) = 
-            match primaryKeyCache.TryGetValue table.Name with 
+        member __.GetPrimaryKey(table) =
+            match primaryKeyCache.TryGetValue table.Name with
             | true, v -> Some v.Column
             | _ -> None
 
-        member __.GetColumns(con,table) = 
+        member __.GetColumns(con,table) =
             match columnCache.TryGetValue table.FullName  with
             | true, cols -> cols
             | false, _ ->
@@ -482,18 +472,16 @@ type internal OracleProvider(resolutionPath, owner, referencedAssemblies) =
                     let rels = Sql.connect con (Oracle.getRelationships primaryKeyCache table.Name)
                     relationshipCache.Add(table.FullName, rels)
                     rels
-        
+
         member __.GetSprocs(con) = Sql.connect con Oracle.getSprocs
-
         member __.GetIndividualsQueryText(table,amount) = Oracle.getIndivdualsQueryText amount table
-
         member __.GetIndividualQueryText(table,column) = Oracle.getIndivdualQueryText table column
 
         member this.GenerateQueryText(sqlQuery,baseAlias,baseTable,projectionColumns) =
             let sb = System.Text.StringBuilder()
             let parameters = ResizeArray<_>()
             let (~~) (t:string) = sb.Append t |> ignore
-            
+
             let getTable x =
                 match sqlQuery.Aliases.TryFind x with
                 | Some(a) -> a
@@ -503,18 +491,18 @@ type internal OracleProvider(resolutionPath, owner, referencedAssemblies) =
             // now we can build the sql query that has been simplified by the above expression converter
             // working on the basis that we will alias everything to make my life eaiser
             // first build  the select statment, this is easy ...
-            let columns = 
+            let columns =
                 String.Join(",",
                     [|for KeyValue(k,v) in projectionColumns do
                         if v.Count = 0 then   // if no columns exist in the projection then get everything
-                            for col in columnCache.[baseTable.FullName] |> List.map(fun c -> c.Name) do 
+                            for col in columnCache.[baseTable.FullName] |> List.map(fun c -> c.Name) do
                                 if singleEntity then yield sprintf "%s.%s as \"%s\"" k col col
                                 else yield sprintf "%s.%s as \"%s.%s\"" k col k col
                         else
-                            for col in v do 
+                            for col in v do
                                 if singleEntity then yield sprintf "%s.%s as \"%s\"" k (quoteWhiteSpace col) col
                                 else yield sprintf "%s.%s as \"%s.%s\"" k (quoteWhiteSpace col) k col|]) // F# makes this so easy :)
-        
+
             // next up is the filter expressions
             // NOTE: really need to assign the parameters their correct db types
             let param = ref 0
@@ -527,15 +515,15 @@ type internal OracleProvider(resolutionPath, owner, referencedAssemblies) =
 
                 (this:>ISqlProvider).CreateCommandParameter(QueryParameter.Create(paramName, !param), value)
 
-            let rec filterBuilder = function 
+            let rec filterBuilder = function
                 | [] -> ()
                 | (cond::conds) ->
                     let build op preds (rest:Condition list option) =
                         ~~ "("
                         preds |> List.iteri( fun i (alias,col,operator,data) ->
-                                let extractData data = 
+                                let extractData data =
                                      match data with
-                                     | Some(x) when (box x :? obj array) -> 
+                                     | Some(x) when (box x :? obj array) ->
                                          // in and not in operators pass an array
                                          let elements = box x :?> obj array
                                          Array.init (elements.Length) (fun i -> createParam (elements.GetValue(i)))
@@ -546,19 +534,19 @@ type internal OracleProvider(resolutionPath, owner, referencedAssemblies) =
                                 let paras = extractData data
                                 ~~(sprintf "%s%s" prefix <|
                                     match operator with
-                                    | FSharp.Data.Sql.IsNull -> (sprintf "%s.%s IS NULL") alias (quoteWhiteSpace col) 
-                                    | FSharp.Data.Sql.NotNull -> (sprintf "%s.%s IS NOT NULL") alias (quoteWhiteSpace col) 
-                                    | FSharp.Data.Sql.In ->                                     
+                                    | FSharp.Data.Sql.IsNull -> (sprintf "%s.%s IS NULL") alias (quoteWhiteSpace col)
+                                    | FSharp.Data.Sql.NotNull -> (sprintf "%s.%s IS NOT NULL") alias (quoteWhiteSpace col)
+                                    | FSharp.Data.Sql.In ->
                                         let text = String.Join(",",paras |> Array.map (fun p -> p.ParameterName))
                                         Array.iter parameters.Add paras
                                         (sprintf "%s.%s IN (%s)") alias (quoteWhiteSpace col) text
-                                    | FSharp.Data.Sql.NotIn ->                                    
+                                    | FSharp.Data.Sql.NotIn ->
                                         let text = String.Join(",",paras |> Array.map (fun p -> p.ParameterName))
                                         Array.iter parameters.Add paras
-                                        (sprintf "%s.%s NOT IN (%s)") alias (quoteWhiteSpace col) text 
-                                    | _ -> 
+                                        (sprintf "%s.%s NOT IN (%s)") alias (quoteWhiteSpace col) text
+                                    | _ ->
                                         parameters.Add paras.[0]
-                                        (sprintf "%s.%s %s %s") alias (quoteWhiteSpace col) 
+                                        (sprintf "%s.%s %s %s") alias (quoteWhiteSpace col)
                                          (operator.ToString()) paras.[0].ParameterName)
                         )
                         // there's probably a nicer way to do this
@@ -571,38 +559,38 @@ type internal OracleProvider(resolutionPath, owner, referencedAssemblies) =
                                 ~~ (sprintf " %s " op)
                                 filterBuilder [x]
                                 ~~ (sprintf " %s " op)
-                                aux xs 
+                                aux xs
                             | x::xs ->
                                 filterBuilder [x]
                                 ~~ (sprintf " %s " op)
                                 aux xs
                             | [] -> ()
-                    
+
                         Option.iter aux rest
                         ~~ ")"
-                
+
                     match cond with
                     | Or(preds,rest) -> build "OR" preds rest
-                    | And(preds,rest) ->  build "AND" preds rest 
-                
+                    | And(preds,rest) ->  build "AND" preds rest
+
                     filterBuilder conds
-                
-            // next up is the FROM statement which includes joins .. 
-            let fromBuilder() = 
+
+            // next up is the FROM statement which includes joins ..
+            let fromBuilder() =
                 sqlQuery.Links
                 |> List.iter(fun (fromAlias, data, destAlias)  ->
                     let joinType = if data.OuterJoin then "LEFT OUTER JOIN " else "INNER JOIN "
                     let destTable = getTable destAlias
-                    ~~  (sprintf "%s %s %s on %s.%s = %s.%s " 
-                            joinType destTable.FullName destAlias 
+                    ~~  (sprintf "%s %s %s on %s.%s = %s.%s "
+                            joinType destTable.FullName destAlias
                             (if data.RelDirection = RelationshipDirection.Parents then fromAlias else destAlias)
-                            data.ForeignKey  
-                            (if data.RelDirection = RelationshipDirection.Parents then destAlias else fromAlias) 
+                            data.ForeignKey
+                            (if data.RelDirection = RelationshipDirection.Parents then destAlias else fromAlias)
                             data.PrimaryKey))
 
             let orderByBuilder() =
                 sqlQuery.Ordering
-                |> List.iteri(fun i (alias,column,desc) -> 
+                |> List.iteri(fun i (alias,column,desc) ->
                     if i > 0 then ~~ ", "
                     ~~ (sprintf "%s.%s%s" alias (quoteWhiteSpace column) (if not desc then " DESC NULLS LAST" else " ASC NULLS FIRST")))
 
@@ -611,26 +599,26 @@ type internal OracleProvider(resolutionPath, owner, referencedAssemblies) =
             elif sqlQuery.Count then ~~("SELECT COUNT(1) ")
             else  ~~(sprintf "SELECT %s " columns)
             // FROM
-            ~~(sprintf "FROM %s %s " baseTable.FullName baseAlias)         
+            ~~(sprintf "FROM %s %s " baseTable.FullName baseAlias)
             fromBuilder()
             // WHERE
             if sqlQuery.Filters.Length > 0 then
                 // each filter is effectively the entire contents of each where clause in the linq query,
                 // of which there can be many. Simply turn them all into one big AND expression as that is the
-                // only logical way to deal with them. 
+                // only logical way to deal with them.
                 let f = [And([],Some sqlQuery.Filters)]
-                ~~"WHERE " 
+                ~~"WHERE "
                 filterBuilder f
-        
+
             if sqlQuery.Ordering.Length > 0 then
                 ~~"ORDER BY "
                 orderByBuilder()
 
-            //I think on oracle this will potentially impact the ordering as the row num is generated before any 
-            //filters or ordering is applied hance why this produces a nested query. something like 
+            //I think on oracle this will potentially impact the ordering as the row num is generated before any
+            //filters or ordering is applied hance why this produces a nested query. something like
             //select * from (select ....) where ROWNUM <= 5.
-            if sqlQuery.Take.IsSome 
-            then 
+            if sqlQuery.Take.IsSome
+            then
                 let sql = sprintf "select * from (%s) where ROWNUM <= %i" (sb.ToString()) sqlQuery.Take.Value
                 (sql, parameters)
             else
@@ -640,40 +628,39 @@ type internal OracleProvider(resolutionPath, owner, referencedAssemblies) =
         member this.ProcessUpdates(con, entities) =
             let sb = Text.StringBuilder()
             let provider = this :> ISqlProvider
-            let (~~) (t:string) = sb.Append t |> ignore
 
             // ensure columns have been loaded
-            entities |> List.map(fun e -> e.Table) 
-                     |> Seq.distinct 
+            entities |> List.map(fun e -> e.Table)
+                     |> Seq.distinct
                      |> Seq.iter(fun t -> provider.GetColumns(con,t) |> ignore )
 
             con.Open()
 
             use scope = Utilities.ensureTransaction()
-            try                
-                // close the connection first otherwise it won't get enlisted into the transaction 
+            try
+                // close the connection first otherwise it won't get enlisted into the transaction
                 if con.State = ConnectionState.Open then con.Close()
-                con.Open()         
+                con.Open()
                 // initially supporting update/create/delete of single entities, no hierarchies yet
                 entities
-                |> List.iter(fun e -> 
+                |> List.iter(fun e ->
                     match e._State with
-                    | Created -> 
+                    | Created ->
                         let cmd = createInsertCommand provider con sb e
                         Common.QueryEvents.PublishSqlQuery cmd.CommandText
                         let id = cmd.ExecuteScalar()
                         match e.GetColumnOption primaryKeyCache.[e.Table.Name].Column with
-                        | Some v -> () // if the primary key exists, do nothing
-                                       // this is because non-identity columns will have been set 
-                                       // manually and in that case scope_identity would bring back 0 "" or whatever
+                        | Some(_) -> () // if the primary key exists, do nothing
+                                        // this is because non-identity columns will have been set
+                                        // manually and in that case scope_identity would bring back 0 "" or whatever
                         | None ->  e.SetColumnSilent(primaryKeyCache.[e.Table.Name].Column, id)
                         e._State <- Unchanged
-                    | Modified fields -> 
+                    | Modified fields ->
                         let cmd = createUpdateCommand provider con sb e fields
                         Common.QueryEvents.PublishSqlQuery cmd.CommandText
                         cmd.ExecuteNonQuery() |> ignore
                         e._State <- Unchanged
-                    | Deleted -> 
+                    | Deleted ->
                         let cmd = createDeleteCommand provider con sb e
                         Common.QueryEvents.PublishSqlQuery cmd.CommandText
                         cmd.ExecuteNonQuery() |> ignore
@@ -687,17 +674,16 @@ type internal OracleProvider(resolutionPath, owner, referencedAssemblies) =
         member this.ProcessUpdatesAsync(con, entities) =
             let sb = Text.StringBuilder()
             let provider = this :> ISqlProvider
-            let (~~) (t:string) = sb.Append t |> ignore
 
             // ensure columns have been loaded
-            entities |> List.map(fun e -> e.Table) 
-                     |> Seq.distinct 
+            entities |> List.map(fun e -> e.Table)
+                     |> Seq.distinct
                      |> Seq.iter(fun t -> provider.GetColumns(con,t) |> ignore )
 
-            async { 
+            async {
                 use scope = Utilities.ensureTransaction()
-                try                
-                    // close the connection first otherwise it won't get enlisted into the transaction 
+                try
+                    // close the connection first otherwise it won't get enlisted into the transaction
                     if con.State = ConnectionState.Open then con.Close()
 
                     do! con.OpenAsync() |> Async.AwaitIAsyncResult |> Async.Ignore
@@ -705,26 +691,26 @@ type internal OracleProvider(resolutionPath, owner, referencedAssemblies) =
                     // initially supporting update/create/delete of single entities, no hierarchies yet
                     let handleEntity (e: SqlEntity) =
                         match e._State with
-                        | Created -> 
+                        | Created ->
                             async {
                                 let cmd = createInsertCommand provider con sb e :?> System.Data.Common.DbCommand
                                 Common.QueryEvents.PublishSqlQuery cmd.CommandText
                                 let! id = cmd.ExecuteScalarAsync() |> Async.AwaitTask
                                 match e.GetColumnOption primaryKeyCache.[e.Table.Name].Column with
-                                | Some v -> () // if the primary key exists, do nothing
-                                               // this is because non-identity columns will have been set 
-                                               // manually and in that case scope_identity would bring back 0 "" or whatever
+                                | Some(_) -> () // if the primary key exists, do nothing
+                                                // this is because non-identity columns will have been set
+                                                // manually and in that case scope_identity would bring back 0 "" or whatever
                                 | None ->  e.SetColumnSilent(primaryKeyCache.[e.Table.Name].Column, id)
                                 e._State <- Unchanged
                             }
-                        | Modified fields -> 
+                        | Modified fields ->
                             async {
                                 let cmd = createUpdateCommand provider con sb e fields :?> System.Data.Common.DbCommand
                                 Common.QueryEvents.PublishSqlQuery cmd.CommandText
                                 do! cmd.ExecuteNonQueryAsync() |> Async.AwaitTask |> Async.Ignore
                                 e._State <- Unchanged
                             }
-                        | Deleted -> 
+                        | Deleted ->
                             async {
                                 let cmd = createDeleteCommand provider con sb e :?> System.Data.Common.DbCommand
                                 Common.QueryEvents.PublishSqlQuery cmd.CommandText

--- a/src/SQLProvider/Providers.Oracle.fs
+++ b/src/SQLProvider/Providers.Oracle.fs
@@ -492,6 +492,7 @@ type internal OracleProvider(resolutionPath, owner, referencedAssemblies) =
             // working on the basis that we will alias everything to make my life eaiser
             // first build  the select statment, this is easy ...
             let columns =
+                if projectionColumns |> Seq.isEmpty then "1" else
                 String.Join(",",
                     [|for KeyValue(k,v) in projectionColumns do
                         if v.Count = 0 then   // if no columns exist in the projection then get everything

--- a/src/SQLProvider/Providers.Postgresql.fs
+++ b/src/SQLProvider/Providers.Postgresql.fs
@@ -605,6 +605,7 @@ type internal PostgresqlProvider(resolutionPath, owner, referencedAssemblies) as
             // working on the basis that we will alias everything to make my life eaiser
             // first build  the select statment, this is easy ...
             let columns =
+                if projectionColumns |> Seq.isEmpty then "1" else
                 String.Join(",",
                     [|for KeyValue(k,v) in projectionColumns do
                         if v.Count = 0 then   // if no columns exist in the projection then get everything

--- a/src/SQLProvider/Providers.SQLite.fs
+++ b/src/SQLProvider/Providers.SQLite.fs
@@ -11,15 +11,15 @@ open FSharp.Data.Sql.Common
 
 type internal SQLiteProvider(resolutionPath, referencedAssemblies, runtimeAssembly) as this =
     // note we intentionally do not hang onto a connection object at any time,
-    // as the type provider will dicate the connection lifecycles 
-    let pkLookup =     Dictionary<string,string>()
-    let tableLookup =  Dictionary<string,Table>()
-    let columnLookup = Dictionary<string,Column list>()    
+    // as the type provider will dicate the connection lifecycles
+    let pkLookup = Dictionary<string,string>()
+    let tableLookup = Dictionary<string,Table>()
+    let columnLookup = Dictionary<string,Column list>()
     let relationshipLookup = Dictionary<string,Relationship list * Relationship list>()
     let isMono = Type.GetType ("Mono.Runtime") <> null
 
     // Dynamically load the SQLite assembly so we don't have a dependency on it in the project
-    let assemblyNames =  
+    let assemblyNames =
         [
            (if isMono then "Mono" else "System") + ".Data.SQLite.dll"
            (if isMono then "Mono" else "System") + ".Data.Sqlite.dll"
@@ -28,12 +28,12 @@ type internal SQLiteProvider(resolutionPath, referencedAssemblies, runtimeAssemb
     let assembly =
         lazy Reflection.tryLoadAssemblyFrom resolutionPath (Array.append [|runtimeAssembly|] referencedAssemblies) assemblyNames
 
-    let findType f = 
+    let findType f =
         match assembly.Value with
         | Choice1Of2(assembly) -> assembly.GetTypes() |> Array.find f
-        | Choice2Of2(paths) -> 
+        | Choice2Of2(paths) ->
            failwithf "Unable to resolve assemblies. One of %s must exist in the paths: %s %s"
-                (String.Join(", ", assemblyNames |> List.toArray)) 
+                (String.Join(", ", assemblyNames |> List.toArray))
                 Environment.NewLine
                 (String.Join(Environment.NewLine, paths))
 
@@ -43,7 +43,7 @@ type internal SQLiteProvider(resolutionPath, referencedAssemblies, runtimeAssemb
     let getSchemaMethod = (connectionType.GetMethod("GetSchema",[|typeof<string>|]))
 
 
-    let getSchema name conn = 
+    let getSchema name conn =
         getSchemaMethod.Invoke(conn,[|name|]) :?> DataTable
 
     let mutable typeMappings = []
@@ -53,7 +53,7 @@ type internal SQLiteProvider(resolutionPath, referencedAssemblies, runtimeAssemb
     let createTypeMappings con =
         let dt = getSchema "DataTypes" con
 
-        let mappings =             
+        let mappings =
             [
                 for r in dt.Rows do
                     let clrType = string r.["DataType"]
@@ -68,41 +68,38 @@ type internal SQLiteProvider(resolutionPath, referencedAssemblies, runtimeAssemb
             |> List.map (fun m -> m.ClrType, m)
             |> Map.ofList
 
-        let dbMappings = 
+        let dbMappings =
             mappings
             |> List.map (fun m -> m.ProviderTypeName.Value, m)
             |> Map.ofList
-            
+
         typeMappings <- mappings
         findClrType <- clrMappings.TryFind
-        findDbType <- dbMappings.TryFind 
-    
-    let executeSql (con:IDbConnection) sql =        
-        use com = (this:>ISqlProvider).CreateCommand(con,sql)    
-        com.ExecuteReader()
+        findDbType <- dbMappings.TryFind
 
-    let createInsertCommand (con:IDbConnection) (sb:Text.StringBuilder) (entity:SqlEntity) =                 
+    let createInsertCommand (con:IDbConnection) (sb:Text.StringBuilder) (entity:SqlEntity) =
         let (~~) (t:string) = sb.Append t |> ignore
+
         let cmd = (this :> ISqlProvider).CreateCommand(con,"")
-        cmd.Connection <- con 
-        let pk = pkLookup.[entity.Table.FullName] 
-        let columnNames, values = 
+        cmd.Connection <- con
+
+        let columnNames, values =
             (([],0),entity.ColumnValues)
-            ||> Seq.fold(fun (out,i) (k,v) -> 
+            ||> Seq.fold(fun (out,i) (k,v) ->
                 let name = sprintf "@param%i" i
                 let p = (this :> ISqlProvider).CreateCommandParameter(QueryParameter.Create(name,i),v)
                 (k,p)::out,i+1)
-            |> fun (x,_)-> x 
+            |> fun (x,_)-> x
             |> List.rev
-            |> List.toArray 
+            |> List.toArray
             |> Array.unzip
-                
+
         sb.Clear() |> ignore
-        ~~(sprintf "INSERT INTO %s (%s) VALUES (%s); SELECT last_insert_rowid();" 
+        ~~(sprintf "INSERT INTO %s (%s) VALUES (%s); SELECT last_insert_rowid();"
             entity.Table.FullName
             (String.Join(",",columnNames))
             (String.Join(",",values |> Array.map(fun p -> p.ParameterName))))
-                
+
         values |> Array.iter (cmd.Parameters.Add >> ignore)
         cmd.CommandText <- sb.ToString()
         cmd
@@ -110,34 +107,33 @@ type internal SQLiteProvider(resolutionPath, referencedAssemblies, runtimeAssemb
     let createUpdateCommand (con:IDbConnection) (sb:Text.StringBuilder) (entity:SqlEntity) changedColumns =
         let (~~) (t:string) = sb.Append t |> ignore
         let cmd = (this :> ISqlProvider).CreateCommand(con,"")
-        cmd.Connection <- con 
-        let pk = pkLookup.[entity.Table.FullName] 
+        cmd.Connection <- con
+        let pk = pkLookup.[entity.Table.FullName]
         sb.Clear() |> ignore
 
         if changedColumns |> List.exists ((=)pk) then failwith "Error - you cannot change the primary key of an entity."
 
-        let pkValue = 
+        let pkValue =
             match entity.GetColumnOption<obj> pk with
             | Some v -> v
             | None -> failwith "Error - you cannot update an entity that does not have a primary key."
-                
-        let data = 
+
+        let data =
             (([],0),changedColumns)
-            ||> List.fold(fun (out,i) col ->                                                         
+            ||> List.fold(fun (out,i) col ->
                 let name = sprintf "@param%i" i
-                let p = 
+                let p =
                     match entity.GetColumnOption<obj> col with
                     | Some v -> (this :> ISqlProvider).CreateCommandParameter(QueryParameter.Create(name,i),v)
                     | None -> (this :> ISqlProvider).CreateCommandParameter(QueryParameter.Create(name,i),DBNull.Value)
                 (col,p)::out,i+1)
-            |> fun (x,_)-> x 
+            |> fun (x,_)-> x
             |> List.rev
-            |> List.toArray 
-                    
-                
+            |> List.toArray
+
         let pkParam = (this :> ISqlProvider).CreateCommandParameter(QueryParameter.Create("@pk",0),pkValue)
 
-        ~~(sprintf "UPDATE %s SET %s WHERE %s = @pk;" 
+        ~~(sprintf "UPDATE %s SET %s WHERE %s = @pk;"
             entity.Table.FullName
             (String.Join(",", data |> Array.map(fun (c,p) -> sprintf "%s = %s" c p.ParameterName ) ))
             pk)
@@ -146,15 +142,15 @@ type internal SQLiteProvider(resolutionPath, referencedAssemblies, runtimeAssemb
         cmd.Parameters.Add pkParam |> ignore
         cmd.CommandText <- sb.ToString()
         cmd
-            
+
     let createDeleteCommand (con:IDbConnection) (sb:Text.StringBuilder) (entity:SqlEntity) =
         let (~~) (t:string) = sb.Append t |> ignore
         let cmd = (this :> ISqlProvider).CreateCommand(con,"")
-        cmd.Connection <- con 
+        cmd.Connection <- con
         sb.Clear() |> ignore
-        let pk = pkLookup.[entity.Table.FullName] 
+        let pk = pkLookup.[entity.Table.FullName]
         sb.Clear() |> ignore
-        let pkValue = 
+        let pkValue =
             match entity.GetColumnOption<obj> pk with
             | Some v -> v
             | None -> failwith "Error - you cannot delete an entity that does not have a primary key."
@@ -165,72 +161,80 @@ type internal SQLiteProvider(resolutionPath, referencedAssemblies, runtimeAssemb
         cmd
 
     interface ISqlProvider with
-        member __.CreateConnection(connectionString) = 
+        member __.CreateConnection(connectionString) =
             //Forces relative paths to be relative to the Runtime assembly
-            let basePath = 
+            let basePath =
                 if String.IsNullOrEmpty(resolutionPath) || resolutionPath = Path.DirectorySeparatorChar.ToString()
                 then runtimeAssembly
                 else resolutionPath
             let connectionString = connectionString.Replace(@"." + Path.DirectorySeparatorChar.ToString(), basePath + Path.DirectorySeparatorChar.ToString())
             Activator.CreateInstance(connectionType,[|box connectionString|]) :?> IDbConnection
+
         member __.CreateCommand(connection,commandText) = Activator.CreateInstance(commandType,[|box commandText;box connection|]) :?> IDbCommand
-        member __.CreateCommandParameter(param,value) = 
+
+        member __.CreateCommandParameter(param,value) =
             let p = Activator.CreateInstance(paramterType,[|box param.Name;box value|]) :?> IDbDataParameter
             p.DbType <- param.TypeMapping.DbType
             p.Direction <- param.Direction
             Option.iter (fun l -> p.Size <- l) param.Length
             p
-        member __.ExecuteSprocCommand(com,definition,retCols,values) =  raise(NotImplementedException())
-        member __.CreateTypeMappings(con) = 
+
+        member __.ExecuteSprocCommand(_,_,_,_) =  raise(NotImplementedException())
+
+        member __.CreateTypeMappings(con) =
             if con.State <> ConnectionState.Open then con.Open()
             createTypeMappings con
             con.Close()
-        member __.GetTables(con,cs) =            
+
+        member __.GetTables(con,_) =
             if con.State <> ConnectionState.Open then con.Open()
             let ret =
-                [ for row in (getSchemaMethod.Invoke(con,[|"Tables"|]) :?> DataTable).Rows do 
+                [ for row in (getSchemaMethod.Invoke(con,[|"Tables"|]) :?> DataTable).Rows do
                     let ty = string row.["TABLE_TYPE"]
                     if ty <> "SYSTEM_TABLE" then
-                        let table = { Schema = string row.["TABLE_CATALOG"] ; Name = string row.["TABLE_NAME"]; Type=ty } 
+                        let table = { Schema = string row.["TABLE_CATALOG"] ; Name = string row.["TABLE_NAME"]; Type=ty }
                         if tableLookup.ContainsKey table.FullName = false then tableLookup.Add(table.FullName,table)
                         yield table ]
             con.Close()
             ret
-        member __.GetPrimaryKey(table) = 
-            match pkLookup.TryGetValue table.FullName with 
+
+        member __.GetPrimaryKey(table) =
+            match pkLookup.TryGetValue table.FullName with
             | true, v -> Some v
             | _ -> None
-        member __.GetColumns(con,table) = 
+
+        member __.GetColumns(con,table) =
             match columnLookup.TryGetValue table.FullName with
             | (true,data) -> data
-            | _ -> 
+            | _ ->
                if con.State <> ConnectionState.Open then con.Open()
                let query = sprintf "pragma table_info(%s)" table.Name
-               use com = (this:>ISqlProvider).CreateCommand(con,query)               
+               use com = (this:>ISqlProvider).CreateCommand(con,query)
                use reader = com.ExecuteReader()
                let columns =
-                  [ while reader.Read() do 
+                  [ while reader.Read() do
                       let dt = reader.GetString(2).ToLower()
                       let dt = if dt.Contains("(") then dt.Substring(0,dt.IndexOf("(")) else dt
                       match findDbType dt with
                       | Some(m) ->
                          let col =
-                            { Column.Name = reader.GetString(1); 
+                            { Column.Name = reader.GetString(1);
                               TypeMapping = m
-                              IsNullable = not <| reader.GetBoolean(3); 
-                              IsPrimarKey = if reader.GetBoolean(5) then true else false } 
+                              IsNullable = not <| reader.GetBoolean(3);
+                              IsPrimarKey = if reader.GetBoolean(5) then true else false }
                          if col.IsPrimarKey && pkLookup.ContainsKey table.FullName = false then pkLookup.Add(table.FullName,col.Name)
-                         yield col 
-                      | _ -> ()]  
+                         yield col
+                      | _ -> ()]
                columnLookup.Add(table.FullName,columns)
                con.Close()
                columns
+
         member __.GetRelationships(con,table) =
             match relationshipLookup.TryGetValue(table.FullName) with
             | true,v -> v
             | _ ->
                 // SQLite doesn't have great metadata capabilities.
-                // while we can use PRGAMA FOREIGN_KEY_LIST, it will only show us 
+                // while we can use PRGAMA FOREIGN_KEY_LIST, it will only show us
                 // relationships in one direction, the only way to get all the relationships
                 // is to retrieve all the relationships in the entire database.  This is not ideal for
                 // huge schemas, but SQLite is not generally used for that purpose so we should be ok.
@@ -239,42 +243,39 @@ type internal SQLiteProvider(resolutionPath, referencedAssemblies, runtimeAssemb
                 if con.State <> ConnectionState.Open then con.Open()
                 let relData = (getSchemaMethod.Invoke(con,[|"ForeignKeys"|]) :?> DataTable)
                 for row in relData.Rows do
-                    let pTable = 
+                    let pTable =
                         { Schema = string row.["FKEY_TO_CATALOG"]     //I've not seen a schema column populated in SQLite so I'm using catalog instead
-                          Name = string row.["FKEY_TO_TABLE"] 
+                          Name = string row.["FKEY_TO_TABLE"]
                           Type = ""}
-                    let fTable = 
-                        { Schema = string row.["TABLE_CATALOG"]   
-                          Name = string row.["TABLE_NAME"] 
+                    let fTable =
+                        { Schema = string row.["TABLE_CATALOG"]
+                          Name = string row.["TABLE_NAME"]
                           Type = ""}
 
                     if not <| relationshipLookup.ContainsKey pTable.FullName then relationshipLookup.Add(pTable.FullName,([],[]))
                     if not <| relationshipLookup.ContainsKey fTable.FullName then relationshipLookup.Add(fTable.FullName,([],[]))
-                    
+
                     let rel = { Name = string row.["CONSTRAINT_NAME"]; PrimaryTable= pTable.FullName; PrimaryKey=string row.["FKEY_TO_COLUMN"]
-                                ForeignTable=fTable.FullName; ForeignKey=string row.["FKEY_FROM_COLUMN"] } 
+                                ForeignTable=fTable.FullName; ForeignKey=string row.["FKEY_FROM_COLUMN"] }
 
                     let (c,p) = relationshipLookup.[pTable.FullName]
                     relationshipLookup.[pTable.FullName] <- (rel::c,p)
                     let (c,p) = relationshipLookup.[fTable.FullName]
                     relationshipLookup.[fTable.FullName] <- (c,rel::p)
                 con.Close()
-                match relationshipLookup.TryGetValue table.FullName with 
+                match relationshipLookup.TryGetValue table.FullName with
                 | true,v -> v
                 | _ -> [],[]
-                
-        
-        /// SQLite does not support stored procedures.
-        member __.GetSprocs(con) = [] 
 
-        member this.GetIndividualsQueryText(table,amount) = sprintf "SELECT * FROM %s LIMIT %i;" table.FullName amount 
-        member this.GetIndividualQueryText(table,column) = sprintf "SELECT * FROM [%s].[%s] WHERE [%s].[%s].[%s] = @id" table.Schema table.Name table.Schema table.Name column
+        member __.GetSprocs(_) = [] // SQLite does not support stored procedures.
+        member __.GetIndividualsQueryText(table,amount) = sprintf "SELECT * FROM %s LIMIT %i;" table.FullName amount
+        member __.GetIndividualQueryText(table,column) = sprintf "SELECT * FROM [%s].[%s] WHERE [%s].[%s].[%s] = @id" table.Schema table.Name table.Schema table.Name column
 
-        member this.GenerateQueryText(sqlQuery,baseAlias,baseTable,projectionColumns) = 
+        member this.GenerateQueryText(sqlQuery,baseAlias,baseTable,projectionColumns) =
             let sb = System.Text.StringBuilder()
             let parameters = ResizeArray<_>()
             let (~~) (t:string) = sb.Append t |> ignore
-            
+
             // all tables should be aliased.
             // the LINQ infrastructure will cause this will happen by default if the query includes more than one table
             // if it does not, then we first need to create an alias for the single table
@@ -284,20 +285,20 @@ type internal SQLiteProvider(resolutionPath, referencedAssemblies, runtimeAssemb
                 | None -> baseTable
 
             let singleEntity = sqlQuery.Aliases.Count = 0
-            
+
             // first build  the select statement, this is easy ...
-            let columns = 
+            let columns =
                 String.Join(",",
                     [|for KeyValue(k,v) in projectionColumns do
                         if v.Count = 0 then   // if no columns exist in the projection then get everything
-                            for col in columnLookup.[(getTable k).FullName] |> List.map(fun c -> c.Name) do 
+                            for col in columnLookup.[(getTable k).FullName] |> List.map(fun c -> c.Name) do
                                 if singleEntity then yield sprintf "[%s].[%s] as '%s'" k col col
                                 else yield sprintf "[%s].[%s] as '[%s].[%s]'" k col k col
                         else
-                            for col in v do 
+                            for col in v do
                                 if singleEntity then yield sprintf "[%s].[%s] as '%s'" k col col
                                 else yield sprintf "[%s].[%s] as '[%s].[%s]'" k col k col|]) // F# makes this so easy :)
-        
+
             // next up is the filter expressions
             // NOTE: really need to assign the parameters their correct db types
             let param = ref 0
@@ -309,15 +310,15 @@ type internal SQLiteProvider(resolutionPath, referencedAssemblies, runtimeAssemb
                 let paramName = nextParam()
                 (this:>ISqlProvider).CreateCommandParameter(QueryParameter.Create(paramName, !param), value)
 
-            let rec filterBuilder = function 
+            let rec filterBuilder = function
                 | [] -> ()
                 | (cond::conds) ->
                     let build op preds (rest:Condition list option) =
                         ~~ "("
                         preds |> List.iteri( fun i (alias,col,operator,data) ->
-                                let extractData data = 
+                                let extractData data =
                                      match data with
-                                     | Some(x) when (box x :? obj array) -> 
+                                     | Some(x) when (box x :? obj array) ->
                                          // in and not in operators pass an array
                                          let strings = box x :?> obj array
                                          strings |> Array.map createParam
@@ -328,19 +329,19 @@ type internal SQLiteProvider(resolutionPath, referencedAssemblies, runtimeAssemb
                                 let paras = extractData data
                                 ~~(sprintf "%s%s" prefix <|
                                     match operator with
-                                    | FSharp.Data.Sql.IsNull -> (sprintf "[%s].[%s] IS NULL") alias col 
-                                    | FSharp.Data.Sql.NotNull -> (sprintf "[%s].[%s] IS NOT NULL") alias col 
-                                    | FSharp.Data.Sql.In ->                                     
+                                    | FSharp.Data.Sql.IsNull -> (sprintf "[%s].[%s] IS NULL") alias col
+                                    | FSharp.Data.Sql.NotNull -> (sprintf "[%s].[%s] IS NOT NULL") alias col
+                                    | FSharp.Data.Sql.In ->
                                         let text = String.Join(",",paras |> Array.map (fun p -> p.ParameterName))
                                         Array.iter parameters.Add paras
                                         (sprintf "[%s].[%s] IN (%s)") alias col text
-                                    | FSharp.Data.Sql.NotIn ->                                    
+                                    | FSharp.Data.Sql.NotIn ->
                                         let text = String.Join(",",paras |> Array.map (fun p -> p.ParameterName))
                                         Array.iter parameters.Add paras
-                                        (sprintf "[%s].[%s] NOT IN (%s)") alias col text 
-                                    | _ -> 
+                                        (sprintf "[%s].[%s] NOT IN (%s)") alias col text
+                                    | _ ->
                                         parameters.Add paras.[0]
-                                        (sprintf "[%s].[%s]%s %s") alias col 
+                                        (sprintf "[%s].[%s]%s %s") alias col
                                          (operator.ToString()) paras.[0].ParameterName)
                         )
                         // there's probably a nicer way to do this
@@ -353,38 +354,38 @@ type internal SQLiteProvider(resolutionPath, referencedAssemblies, runtimeAssemb
                                 ~~ (sprintf " %s " op)
                                 filterBuilder [x]
                                 ~~ (sprintf " %s " op)
-                                aux xs 
+                                aux xs
                             | x::xs ->
                                 filterBuilder [x]
                                 ~~ (sprintf " %s " op)
                                 aux xs
                             | [] -> ()
-                    
+
                         Option.iter aux rest
                         ~~ ")"
-                
+
                     match cond with
                     | Or(preds,rest) -> build "OR" preds rest
-                    | And(preds,rest) ->  build "AND" preds rest 
-                
+                    | And(preds,rest) ->  build "AND" preds rest
+
                     filterBuilder conds
-                
-            // next up is the FROM statement which includes joins .. 
-            let fromBuilder() = 
+
+            // next up is the FROM statement which includes joins ..
+            let fromBuilder() =
                 sqlQuery.Links
                 |> List.iter(fun (fromAlias, data, destAlias)  ->
                     let joinType = if data.OuterJoin then "LEFT OUTER JOIN " else "INNER JOIN "
                     let destTable = getTable destAlias
-                    ~~  (sprintf "%s [%s].[%s] as [%s] on [%s].[%s] = [%s].[%s] " 
-                            joinType destTable.Schema destTable.Name destAlias 
+                    ~~  (sprintf "%s [%s].[%s] as [%s] on [%s].[%s] = [%s].[%s] "
+                            joinType destTable.Schema destTable.Name destAlias
                             (if data.RelDirection = RelationshipDirection.Parents then fromAlias else destAlias)
-                            data.ForeignKey  
-                            (if data.RelDirection = RelationshipDirection.Parents then destAlias else fromAlias) 
+                            data.ForeignKey
+                            (if data.RelDirection = RelationshipDirection.Parents then destAlias else fromAlias)
                             data.PrimaryKey))
 
             let orderByBuilder() =
                 sqlQuery.Ordering
-                |> List.iteri(fun i (alias,column,desc) -> 
+                |> List.iteri(fun i (alias,column,desc) ->
                     if i > 0 then ~~ ", "
                     ~~ (sprintf "[%s].[%s]%s" alias column (if not desc then "DESC" else "")))
 
@@ -393,22 +394,22 @@ type internal SQLiteProvider(resolutionPath, referencedAssemblies, runtimeAssemb
             elif sqlQuery.Count then ~~("SELECT COUNT(1) ")
             else  ~~(sprintf "SELECT %s " columns)
             // FROM
-            ~~(sprintf "FROM %s as %s " baseTable.FullName baseAlias)         
+            ~~(sprintf "FROM %s as %s " baseTable.FullName baseAlias)
             fromBuilder()
             // WHERE
             if sqlQuery.Filters.Length > 0 then
                 // each filter is effectively the entire contents of each where clause in the LINQ  query,
                 // of which there can be many. Simply turn them all into one big AND expression as that is the
-                // only logical way to deal with them. 
+                // only logical way to deal with them.
                 let f = [And([],Some sqlQuery.Filters)]
-                ~~"WHERE " 
+                ~~"WHERE "
                 filterBuilder f
-        
+
             if sqlQuery.Ordering.Length > 0 then
                 ~~"ORDER BY "
                 orderByBuilder()
 
-            if sqlQuery.Take.IsSome then 
+            if sqlQuery.Take.IsSome then
                 ~~(sprintf " LIMIT %i;" sqlQuery.Take.Value)
 
             let sql = sb.ToString()
@@ -416,41 +417,39 @@ type internal SQLiteProvider(resolutionPath, referencedAssemblies, runtimeAssemb
 
         member this.ProcessUpdates(con, entities) =
             let sb = Text.StringBuilder()
-            let (~~) (t:string) = sb.Append t |> ignore
 
             // ensure columns have been loaded
-            entities |> List.map(fun e -> e.Table) 
-                     |> Seq.distinct 
+            entities |> List.map(fun e -> e.Table)
+                     |> Seq.distinct
                      |> Seq.iter(fun t -> (this :> ISqlProvider).GetColumns(con,t) |> ignore )
 
             con.Open()
 
             use scope = Utilities.ensureTransaction()
             try
-                
-                // close the connection first otherwise it won't get enlisted into the transaction 
+                // close the connection first otherwise it won't get enlisted into the transaction
                 if con.State = ConnectionState.Open then con.Close()
-                con.Open()         
+                con.Open()
                 // initially supporting update/create/delete of single entities, no hierarchies yet
                 entities
-                |> List.iter(fun e -> 
+                |> List.iter(fun e ->
                     match e._State with
-                    | Created -> 
+                    | Created ->
                         use cmd = createInsertCommand con sb e
                         Common.QueryEvents.PublishSqlQuery cmd.CommandText
                         let id = cmd.ExecuteScalar()
                         match e.GetColumnOption pkLookup.[e.Table.FullName] with
-                        | Some v -> () // if the primary key exists, do nothing
-                                       // this is because non-identity columns will have been set 
-                                       // manually and in that case scope_identity would bring back 0 "" or whatever
+                        | Some(_) -> () // if the primary key exists, do nothing
+                                        // this is because non-identity columns will have been set
+                                        // manually and in that case scope_identity would bring back 0 "" or whatever
                         | None ->  e.SetColumnSilent(pkLookup.[e.Table.FullName], id)
                         e._State <- Unchanged
-                    | Modified fields -> 
+                    | Modified fields ->
                         use cmd = createUpdateCommand con sb e fields
                         Common.QueryEvents.PublishSqlQuery cmd.CommandText
                         cmd.ExecuteNonQuery() |> ignore
                         e._State <- Unchanged
-                    | Deleted -> 
+                    | Deleted ->
                         use cmd = createDeleteCommand con sb e
                         Common.QueryEvents.PublishSqlQuery cmd.CommandText
                         cmd.ExecuteNonQuery() |> ignore
@@ -463,43 +462,41 @@ type internal SQLiteProvider(resolutionPath, referencedAssemblies, runtimeAssemb
 
         member this.ProcessUpdatesAsync(con, entities) =
             let sb = Text.StringBuilder()
-            let (~~) (t:string) = sb.Append t |> ignore
 
             // ensure columns have been loaded
-            entities |> List.map(fun e -> e.Table) 
-                     |> Seq.distinct 
+            entities |> List.map(fun e -> e.Table)
+                     |> Seq.distinct
                      |> Seq.iter(fun t -> (this :> ISqlProvider).GetColumns(con,t) |> ignore )
 
-            async { 
+            async {
                 use scope = Utilities.ensureTransaction()
                 try
-                
-                    // close the connection first otherwise it won't get enlisted into the transaction 
+                    // close the connection first otherwise it won't get enlisted into the transaction
                     if con.State = ConnectionState.Open then con.Close()
                     do! con.OpenAsync() |> Async.AwaitIAsyncResult |> Async.Ignore
                     // initially supporting update/create/delete of single entities, no hierarchies yet
                     let handleEntity (e: SqlEntity) =
                         match e._State with
-                        | Created -> 
+                        | Created ->
                             async {
                                 use cmd = createInsertCommand con sb e :?> System.Data.Common.DbCommand
                                 Common.QueryEvents.PublishSqlQuery cmd.CommandText
                                 let! id = cmd.ExecuteScalarAsync() |> Async.AwaitTask
                                 match e.GetColumnOption pkLookup.[e.Table.FullName] with
-                                | Some v -> () // if the primary key exists, do nothing
-                                               // this is because non-identity columns will have been set 
-                                               // manually and in that case scope_identity would bring back 0 "" or whatever
+                                | Some(_) -> () // if the primary key exists, do nothing
+                                                // this is because non-identity columns will have been set
+                                                // manually and in that case scope_identity would bring back 0 "" or whatever
                                 | None ->  e.SetColumnSilent(pkLookup.[e.Table.FullName], id)
                                 e._State <- Unchanged
                             }
-                        | Modified fields -> 
+                        | Modified fields ->
                             async {
                                 use cmd = createUpdateCommand con sb e fields :?> System.Data.Common.DbCommand
                                 Common.QueryEvents.PublishSqlQuery cmd.CommandText
                                 do! cmd.ExecuteNonQueryAsync() |> Async.AwaitTask |> Async.Ignore
                                 e._State <- Unchanged
                             }
-                        | Deleted -> 
+                        | Deleted ->
                             async {
                                 use cmd = createDeleteCommand con sb e :?> System.Data.Common.DbCommand
                                 Common.QueryEvents.PublishSqlQuery cmd.CommandText
@@ -514,4 +511,3 @@ type internal SQLiteProvider(resolutionPath, referencedAssemblies, runtimeAssemb
                 finally
                     con.Close()
             }
-

--- a/src/SQLProvider/Providers.SQLite.fs
+++ b/src/SQLProvider/Providers.SQLite.fs
@@ -288,6 +288,7 @@ type internal SQLiteProvider(resolutionPath, referencedAssemblies, runtimeAssemb
 
             // first build  the select statement, this is easy ...
             let columns =
+                if projectionColumns |> Seq.isEmpty then "1" else
                 String.Join(",",
                     [|for KeyValue(k,v) in projectionColumns do
                         if v.Count = 0 then   // if no columns exist in the projection then get everything

--- a/src/SQLProvider/SqlRuntime.DataContext.fs
+++ b/src/SQLProvider/SqlRuntime.DataContext.fs
@@ -1,6 +1,5 @@
 ﻿namespace FSharp.Data.Sql.Runtime
 
-open System
 open System.Collections.Generic
 open System.Data
 open System.Linq
@@ -9,32 +8,32 @@ open FSharp.Data.Sql
 open FSharp.Data.Sql.Common
 open FSharp.Data.Sql.Schema
 
-module internal ProviderBuilder = 
+module internal ProviderBuilder =
     open FSharp.Data.Sql.Providers
 
     let createProvider vendor resolutionPath referencedAssemblies runtimeAssembly owner =
-        match vendor with                
+        match vendor with
         | DatabaseProviderTypes.MSSQLSERVER -> MSSqlServerProvider() :> ISqlProvider
         | DatabaseProviderTypes.SQLITE -> SQLiteProvider(resolutionPath, referencedAssemblies, runtimeAssembly) :> ISqlProvider
         | DatabaseProviderTypes.POSTGRESQL -> PostgresqlProvider(resolutionPath, owner, referencedAssemblies) :> ISqlProvider
         | DatabaseProviderTypes.MYSQL -> MySqlProvider(resolutionPath, owner, referencedAssemblies) :> ISqlProvider
         | DatabaseProviderTypes.ORACLE -> OracleProvider(resolutionPath, owner, referencedAssemblies) :> ISqlProvider
         | DatabaseProviderTypes.MSACCESS -> MSAccessProvider() :> ISqlProvider
-        | DatabaseProviderTypes.ODBC -> OdbcProvider(resolutionPath) :> ISqlProvider
-        | _ -> failwith "Unsupported database provider" 
+        | DatabaseProviderTypes.ODBC -> OdbcProvider() :> ISqlProvider
+        | _ -> failwith "Unsupported database provider"
 
-type public SqlDataContext (typeName,connectionString:string,providerType,resolutionPath, referencedAssemblies, runtimeAssembly, owner, caseSensitivity) =   
+type public SqlDataContext (typeName,connectionString:string,providerType,resolutionPath, referencedAssemblies, runtimeAssembly, owner, caseSensitivity) =
     let pendingChanges = HashSet<SqlEntity>()
     static let providerCache = Dictionary<string,ISqlProvider>()
     do
-        lock providerCache (fun () ->  
+        lock providerCache (fun () ->
             match providerCache .TryGetValue typeName with
             | true, _ -> ()
-            | false,_ -> 
+            | false,_ ->
                 let prov = ProviderBuilder.createProvider providerType resolutionPath referencedAssemblies runtimeAssembly owner
                 use con = prov.CreateConnection(connectionString)
                 con.Open()
-                // create type mappings and also trigger the table info read so the provider has 
+                // create type mappings and also trigger the table info read so the provider has
                 // the minimum base set of data available
                 prov.CreateTypeMappings(con)
                 prov.GetTables(con,caseSensitivity) |> ignore
@@ -42,69 +41,76 @@ type public SqlDataContext (typeName,connectionString:string,providerType,resolu
                 providerCache.Add(typeName,prov))
 
     interface ISqlDataContext with
-        member this.ConnectionString with get() = connectionString
-        member this.CreateConnection() = 
+        member __.ConnectionString with get() = connectionString
+
+        member __.CreateConnection() =
             match providerCache.TryGetValue typeName with
             | true,provider -> provider.CreateConnection(connectionString)
             | false, _ -> failwith "fatal error - provider cache was not populated with expected ISqlprovider instance"
-        member this.GetPrimaryKeyDefinition(tableName) =
+
+        member __.GetPrimaryKeyDefinition(tableName) =
             match providerCache.TryGetValue typeName with
-            | true,provider -> 
+            | true,provider ->
                 use con = provider.CreateConnection(connectionString)
-                provider.GetTables(con, caseSensitivity) 
+                provider.GetTables(con, caseSensitivity)
                 |> List.tryFind (fun t -> t.Name = tableName)
                 |> Option.bind (fun t -> provider.GetPrimaryKey(t))
                 |> (fun x -> defaultArg x "")
             | false, _ -> failwith "fatal error - provider cache was not populated with expected ISqlprovider instance"
-        member this.SubmitChangedEntity e = pendingChanges.Add e |> ignore
-        member this.ClearPendingChanges() = pendingChanges.Clear()
-        member this.GetPendingEntities() = pendingChanges |> Seq.toList
-        member this.SubmitPendingChanges() = 
+
+        member __.SubmitChangedEntity e = pendingChanges.Add e |> ignore
+        member __.ClearPendingChanges() = pendingChanges.Clear()
+        member __.GetPendingEntities() = pendingChanges |> Seq.toList
+
+        member __.SubmitPendingChanges() =
             match providerCache.TryGetValue typeName with
-            | true,provider -> 
+            | true,provider ->
                 use con = provider.CreateConnection(connectionString)
                 provider.ProcessUpdates(con, Seq.toList pendingChanges)
                 pendingChanges.Clear()
             | false, _ -> failwith "fatal error - provider cache was not populated with expected ISqlprovider instance"
-        member this.SubmitPendingChangesAsync() = 
+
+        member __.SubmitPendingChangesAsync() =
             match providerCache.TryGetValue typeName with
-            | true,provider -> 
-                async{
+            | true,provider ->
+                async {
                     use con = provider.CreateConnection(connectionString) :?> System.Data.Common.DbConnection
                     do! provider.ProcessUpdatesAsync(con, Seq.toList pendingChanges)
                     pendingChanges.Clear()
                 }
             | false, _ -> failwith "fatal error - provider cache was not populated with expected ISqlprovider instance"
-                        
-        member this.CreateRelated(inst:SqlEntity,entity,pe,pk,fe,fk,direction) : IQueryable<SqlEntity> =
+
+        member this.CreateRelated(inst:SqlEntity,_,pe,pk,fe,fk,direction) : IQueryable<SqlEntity> =
             match providerCache.TryGetValue typeName with
-            | true,provider -> 
+            | true,provider ->
                if direction = RelationshipDirection.Children then
                    QueryImplementation.SqlQueryable<_>(this,provider,
                       FilterClause(
-                         Condition.And(["__base__",fk,ConditionOperator.Equal, Some(inst.GetColumn pk)],None), 
-                            BaseTable("__base__",Table.FromFullName fe)),ResizeArray<_>()) :> IQueryable<_> 
+                         Condition.And(["__base__",fk,ConditionOperator.Equal, Some(inst.GetColumn pk)],None),
+                            BaseTable("__base__",Table.FromFullName fe)),ResizeArray<_>()) :> IQueryable<_>
                else
                    QueryImplementation.SqlQueryable<_>(this,provider,
                       FilterClause(
-                         Condition.And(["__base__",pk,ConditionOperator.Equal, Some(box<|inst.GetColumn fk)],None), 
-                            BaseTable("__base__",Table.FromFullName pe)),ResizeArray<_>()) :> IQueryable<_> 
+                         Condition.And(["__base__",pk,ConditionOperator.Equal, Some(box<|inst.GetColumn fk)],None),
+                            BaseTable("__base__",Table.FromFullName pe)),ResizeArray<_>()) :> IQueryable<_>
              | false, _ -> failwith "fatal error - provider cache was not populated with expected ISqlprovider instance"
-        member this.CreateEntities(table:string) : IQueryable<SqlEntity> =  
+
+        member this.CreateEntities(table:string) : IQueryable<SqlEntity> =
             match providerCache.TryGetValue typeName with
-            | true,provider -> QueryImplementation.SqlQueryable.Create(Table.FromFullName table,this,provider) 
+            | true,provider -> QueryImplementation.SqlQueryable.Create(Table.FromFullName table,this,provider)
             | false, _ -> failwith "fatal error - provider cache was not populated with expected ISqlprovider instance"
+
         member this.CallSproc(def:RunTimeSprocDefinition, retCols:QueryParameter[], values:obj array) =
             match providerCache.TryGetValue typeName with
-            | true,provider -> 
+            | true,provider ->
                use con = provider.CreateConnection(connectionString)
                con.Open()
                use com = provider.CreateCommand(con, def.Name.DbName)
                com.CommandType <- CommandType.StoredProcedure
-               
+
                let entity = new SqlEntity(this, def.Name.DbName)
 
-               let toEntityArray rowSet = 
+               let toEntityArray rowSet =
                    [|
                        for row in rowSet do
                            let entity = new SqlEntity(this, def.Name.DbName)
@@ -128,26 +134,26 @@ type public SqlDataContext (typeName,connectionString:string,providerType,resolu
                                 entity.SetColumnSilent(name, data)
                        entity |> box
 
-                                  
                if (provider.GetType() <> typeof<Providers.MSAccessProvider>) then con.Close()
                entities
             | false, _ -> failwith "fatal error - provider cache was not populated with expected ISqlprovider instance"
+
         member this.GetIndividual(table,id) : SqlEntity =
             match providerCache.TryGetValue typeName with
-            | true,provider -> 
+            | true,provider ->
                use con = provider.CreateConnection(connectionString)
                con.Open()
                let table = Table.FromFullName table
                // this line is to ensure the columns for the table have been retrieved and therefore
                // its primary key exists in the lookup
                lock provider (fun () -> provider.GetColumns (con,table) |> ignore)
-               let pk = 
+               let pk =
                    match provider.GetPrimaryKey table with
                    | Some v -> v
-                   | None -> 
+                   | None ->
                       // this fail case should not really be possible unless the runtime database is different to the design-time one
-                      failwithf "Primary key could not be found on object %s. Individuals only supported on objects with a single primary key." table.FullName         
-        
+                      failwithf "Primary key could not be found on object %s. Individuals only supported on objects with a single primary key." table.FullName
+
                use com = provider.CreateCommand(con,provider.GetIndividualQueryText(table,pk))
                //todo: establish pk SQL data type
                com.Parameters.Add (provider.CreateCommandParameter(QueryParameter.Create("@id", 0),id)) |> ignore
@@ -157,5 +163,3 @@ type public SqlDataContext (typeName,connectionString:string,providerType,resolu
                if (provider.GetType() <> typeof<Providers.MSAccessProvider>) then con.Close()
                entity
             | false, _ -> failwith "fatal error - connection cache was not populated with expected connection details"
-    
-        


### PR DESCRIPTION
Found in PostgreSQL test script following failing query:

```F#
let employeesFirstNameNoProj = 
    query {
        for emp in ctx.Public.Employees do
        select true
    } |> Seq.toList
```

It results in SQL query starting with `SELECT FROM ...` (select part doesn't have content). This PR adds some default content to select part, so that simple query wouldn't fail: `SELECT 1 FROM ...`. It should handle simple cases where select has constant values which apply to all results. I don't know if it's possible to compose query expression which has no entity projections, but constant values vary between different rows. If it's possible, then current simple fix requires further improvements, because otherwise some operators (like distinct) would give unexpected results.