### PR TITLE
Improve option type usage in join and where clauses.

### DIFF
--- a/src/SQLProvider/SqlRuntime.Linq.fs
+++ b/src/SQLProvider/SqlRuntime.Linq.fs
@@ -219,15 +219,19 @@ module internal QueryImplementation =
                             | OptionIsSome(SqlColumnGet(ti,key,_)) ->
                                 paramNames.Add(ti) |> ignore
                                 Some(ti,key,ConditionOperator.NotNull,None)
-                            | OptionIsNone(SqlColumnGet(ti,key,_)) ->
+                            | OptionIsNone(SqlColumnGet(ti,key,_))
+                            | SqlCondOp(ConditionOperator.Equal,(SqlColumnGet(ti,key,_)),OptionNone) ->
                                 paramNames.Add(ti) |> ignore
                                 Some(ti,key,ConditionOperator.IsNull,None)
+                            | SqlCondOp(ConditionOperator.NotEqual,(SqlColumnGet(ti,key,_)),OptionNone) ->
+                                paramNames.Add(ti) |> ignore
+                                Some(ti,key,ConditionOperator.NotNull,None)
                             // matches column to constant with any operator eg c.name = "john", c.age > 42
-                            | SqlCondOp(op,(SqlColumnGet(ti,key,_)),ConstantOrNullableConstant(c)) ->
+                            | SqlCondOp(op,(SqlColumnGet(ti,key,_)),OptionalFSharpOptionValue(ConstantOrNullableConstant(c))) ->
                                 paramNames.Add(ti) |> ignore
                                 Some(ti,key,op,c)
                             // matches to another property getter, method call or new expression
-                            | SqlCondOp(op,SqlColumnGet(ti,key,_),(((:? MemberExpression) | (:? MethodCallExpression) | (:? NewExpression)) as meth)) ->
+                            | SqlCondOp(op,SqlColumnGet(ti,key,_),OptionalFSharpOptionValue((((:? MemberExpression) | (:? MethodCallExpression) | (:? NewExpression)) as meth))) ->
                                 paramNames.Add(ti) |> ignore
                                 Some(ti,key,op,Some(Expression.Lambda(meth).Compile().DynamicInvoke()))
                             | _ -> None


### PR DESCRIPTION
Added some logic to support alternative usage of `Option<_>` types in where and join clauses.

Join criteria now can be used as follows:

```F#
for emp in ctx.Public.Employees do
join d in ctx.Public.Departments on (emp.DepartmentId = Some(d.DepartmentId))
```
in addition to previous alternative
```F#
for emp in ctx.Public.Employees do
join d in ctx.Public.Departments on (emp.DepartmentId.Value = d.DepartmentId)
```
Using `em.DepartmentId = None` is not supported in join criteria, because I think current link data record cannot handle it.

Also, it's now possible to use `= Some(_)` or `= None` filters in where clause, which should meet expected behavior in issue #135.