### PR TITLE
Three small documentation fixes

### DIFF
--- a/docs/content/core/mssql.fsx
+++ b/docs/content/core/mssql.fsx
@@ -71,8 +71,8 @@ let [<Literal>] useOptTypes  = true
 
 let sql =
     SqlDataProvider<
-        connString,
         dbVendor,
+        connString,
         resPath,
         indivAmount,
         useOptTypes>

--- a/docs/content/core/parameters.fsx
+++ b/docs/content/core/parameters.fsx
@@ -15,7 +15,7 @@ open FSharp.Data.Sql
 These are the "common" parameters used by all SqlProviders.
 
 All static parameters must be known at compile time, for strings this can be 
-achieved by adding the [<Literal>] attribute if you are not passing it inline.
+achieved by adding the [&gt;Literal&lt;] attribute if you are not passing it inline.
 
 ### ConnectionString
 

--- a/docs/content/core/postgresql.fsx
+++ b/docs/content/core/postgresql.fsx
@@ -83,8 +83,8 @@ let [<Literal>] useOptTypes  = true
 
 let sql =
     SqlDataProvider<
-        connString,
         dbVendor,
+        connString,
         resPath,
         indivAmount,
         useOptTypes>


### PR DESCRIPTION
Escape the less than and greater than characters in parameters.fsx so Literal doesn't disappear
Fix the order of parameters given to SqlDataProvider for PostgreSQL and MSSQL