### PR TITLE
removes trailing slash from respaths

### DIFF
--- a/docs/content/core/mssql.fsx
+++ b/docs/content/core/mssql.fsx
@@ -10,8 +10,6 @@ let connectionString = "Data Source=" + __SOURCE_DIRECTORY__ + @"\northwindEF.db
 let resolutionPath = __SOURCE_DIRECTORY__ + @"..\..\..\files\sqlite"
 #r "FSharp.Data.SqlProvider.dll"
 open FSharp.Data.Sql
-(**
-
 
 # MSSQL Provider
 ## Parameters
@@ -26,6 +24,7 @@ use `Common.DatabaseProviderTypes.MSSQLSERVER`.
 
 let [<Literal>] dbVendor = Common.DatabaseProviderTypes.MSSQLSERVER
 
+(**
 ### ConnectionString
 
 Basic connection string used to connect to MSSQL instance; typical

--- a/docs/content/core/mssql.fsx
+++ b/docs/content/core/mssql.fsx
@@ -11,10 +11,11 @@ let resolutionPath = __SOURCE_DIRECTORY__ + @"..\..\..\files\sqlite"
 #r "FSharp.Data.SqlProvider.dll"
 open FSharp.Data.Sql
 
+(**
 # MSSQL Provider
 ## Parameters
 
-(**
+
 ### DatabaseVendor
 
 From the `FSharp.Data.Sql.Common.DatabaseProviderTypes` enumeration. For MSSQL,

--- a/docs/content/core/mssql.fsx
+++ b/docs/content/core/mssql.fsx
@@ -16,6 +16,16 @@ open FSharp.Data.Sql
 # MSSQL Provider
 ## Parameters
 
+(**
+### DatabaseVendor
+
+From the `FSharp.Data.Sql.Common.DatabaseProviderTypes` enumeration. For MSSQL,
+use `Common.DatabaseProviderTypes.MSSQLSERVER`.
+
+*)
+
+let [<Literal>] dbVendor = Common.DatabaseProviderTypes.MSSQLSERVER
+
 ### ConnectionString
 
 Basic connection string used to connect to MSSQL instance; typical
@@ -39,14 +49,13 @@ connectionString key/value pair stored in App.config.
 let [<Literal>] connexStringName = "DefaultConnectionString"
 
 (**
-### DatabaseVendor
-
-From the `FSharp.Data.Sql.Common.DatabaseProviderTypes` enumeration. For MSSQL,
-use `Common.DatabaseProviderTypes.MSSQLSERVER`.
-
+### Resolution Path
+Path to search for assemblies containing database vendor specific connections 
+and custom types. Type the path where SQL Server dll is stored.
 *)
 
-let [<Literal>] dbVendor = Common.DatabaseProviderTypes.MSSQLSERVER
+let [<Literal>] resPath = @"C:\Projects\Libs\YourPathHere"
+
 
 (**
 ### IndividualsAmount

--- a/docs/content/core/mysql.fsx
+++ b/docs/content/core/mysql.fsx
@@ -51,7 +51,7 @@ Path to search for assemblies containing database vendor specific connections an
 
 *)
 [<Literal>]
-let resPath = __SOURCE_DIRECTORY__ + @"/../../../packages/scripts/MySql.Data/lib/net45/"
+let resPath = __SOURCE_DIRECTORY__ + @"/../../../packages/scripts/MySql.Data/lib/net45"
 
 (**
 ### Individuals Amount

--- a/docs/content/core/postgresql.fsx
+++ b/docs/content/core/postgresql.fsx
@@ -58,7 +58,7 @@ and custom types. Type the path where `Npgsql.Data.dll` is stored.
 
 *)
 
-let [<Literal>] resPath = @"C:\Projects\Libs\Npgsql\"
+let [<Literal>] resPath = @"C:\Projects\Libs\Npgsql"
 
 (**
 ### IndividualsAmount

--- a/docs/content/core/postgresql.fsx
+++ b/docs/content/core/postgresql.fsx
@@ -18,6 +18,17 @@ open FSharp.Data.Sql
 
 ## Parameters
 
+### DatabaseVendor
+
+From the `FSharp.Data.Sql.Common.DatabaseProviderTypes` enumeration. For PostgreSQL,
+use `Common.DatabaseProviderTypes.POSTGRESQL`.
+
+*)
+
+let [<Literal>] dbVendor = Common.DatabaseProviderTypes.POSTGRESQL
+
+(**
+
 ### ConnectionString
 
 Basic connection string used to connect to PostgreSQL instance; typical 
@@ -39,16 +50,6 @@ connectionString key/value pair stored in App.config (TODO: confirm file name).
 
 // found in App.config (TOOD: confirm)
 let [<Literal>] connexStringName = "DefaultConnectionString"
-
-(**
-### DatabaseVendor
-
-From the `FSharp.Data.Sql.Common.DatabaseProviderTypes` enumeration. For PostgreSQL,
-use `Common.DatabaseProviderTypes.POSTGRESQL`.
-
-*)
-
-let [<Literal>] dbVendor = Common.DatabaseProviderTypes.POSTGRESQL
 
 (**
 ### Resolution Path


### PR DESCRIPTION
removes trailing slash from resolutionPaths in Postgres, and MySql docs, as this can lead users into an obscure and painful bug in the type provider. See issue #289 

also added missing respath to SQL Server example
