### PR TITLE
moving supported table into querying doc

### DIFF
--- a/docs/content/core/querying.fsx
+++ b/docs/content/core/querying.fsx
@@ -74,18 +74,62 @@ let itemAsync =
     } |> Async.StartAsTask
 
 (**
+## Supported F# Query Expression Operators
+| Keyword            | Supported  |  Notes
+| --------------------- |:-:|---------------------------------------|
+all	                     |  |                                                       | 
+averageBy                |X |                                                       | 
+averageByNullable        |  |                                                       | 
+contains                |X |                                                       | 
+count                    |X |                                                       | 
+distinct                 |X |                                                       | 
+exactlyOne               |  |                                                       | 
+exactlyOneOrDefault      |  |                                                       | 
+exists                   |X |                                                       | 
+find                     |  |                                                       | 
+groupBy                  |  |                                                       | 
+groupJoin                |  |                                                       | 
+groupValBy	             |  |                                                       | 
+head                     |X |                                                       | 
+headOrDefault            |  |                                                       | 
+if                       |X |                                                       |
+join                     |X |                                                       | 
+last                     |  |                                                       | 
+lastOrDefault            |  |                                                       | 
+leftOuterJoin            |  |                                                       | 
+let                      |  |                                                       |
+maxBy                    |X |                                                       | 
+maxByNullable            |  |                                                       | 
+minBy                    |X |                                                       | 
+minByNullable            |  |                                                       | 
+nth                      |  |                                                       | 
+select                   |X |                                                       | 
+skip                     |X |Broken on SQLServer when combined with sortByDescending + take     | 
+skipWhile                |  |                                                       | 
+sortBy                   |X |                                                       | 
+sortByDescending	       |X |Broken on SQLServer when combined with skip+take       | 
+sortByNullable           |  |                                                       | 
+sortByNullableDescending |  |                                                       | 
+sumBy                    |X |                                                       | 
+sumByNullable            |  |                                                       | 
+take                     |X |Broken on SQLServer when combined with skip+sortByDescending      | 
+takeWhile                |  |                                                       | 
+thenBy	                 |X |                                                       |     
+thenByDescending	       |  |                                                       |   
+thenByNullable           |  |                                                       | 
+thenByNullableDescending |  |                                                       |
+where                    |X | Server side variables must be on left side and only left side of predicates  | 
+
+*)
+
+
+(**
 ## Expressions
 
 These operators perform no specific function in the code itself, rather they
 are placeholders replaced by their database-specific server-side operations.
 Their utility is in forcing the compiler to check against the correct types.
 
-*)
-
-let bergs = ctx.Main.Customers.Individuals.BERGS
-
-
-(**
 ### Operators
 
 * `|=|` (In set)
@@ -93,4 +137,5 @@ let bergs = ctx.Main.Customers.Individuals.BERGS
 * `=%` (Like)
 * `<>%` (Not like)
 * `!!` (Left join)
+
 *)

--- a/docs/content/core/supported.fsx
+++ b/docs/content/core/supported.fsx
@@ -1,3 +1,4 @@
+(**
 | Keyword            | Supported  |  Notes
 | --------------------- |:-:|---------------------------------------|
 all	                     |  |                                                       | 
@@ -42,3 +43,5 @@ thenByDescending	       |  |                                                    
 thenByNullable           |  |                                                       | 
 thenByNullableDescending |  |                                                       |
 where                    |X | Server side variables must be on left side and only left side of predicates  | 
+
+*)


### PR DESCRIPTION
I've moved the table into the querying portion of the docs.
Probably at least one more person should review it before merging and making it live.
