### PR TITLE
fix (mono): mapping support for SqlDbType time and date

### DIFF
--- a/src/SQLProvider/Providers.MsSqlServer.fs
+++ b/src/SQLProvider/Providers.MsSqlServer.fs
@@ -26,7 +26,9 @@ module MSSqlServer =
 
         let getDbType(providerType:int) =
             let p = new SqlParameter()
-            p.SqlDbType <- (Enum.ToObject(typeof<SqlDbType>, providerType) :?> SqlDbType)
+            if providerType = 31 || providerType = 32
+            then p.SqlDbType <- SqlDbType.DateTime
+            else p.SqlDbType <- (Enum.ToObject(typeof<SqlDbType>, providerType) :?> SqlDbType)
             p.DbType
 
         let getClrType (input:string) =
@@ -40,6 +42,10 @@ module MSSqlServer =
                     let clrType =
                         if oleDbType = "tinyint"
                         then typeof<byte>.ToString()
+                        else if oleDbType = "date"
+                        then  typeof<DateTime>.ToString()
+                        else if oleDbType = "time"
+                        then  typeof<DateTime>.ToString()
                         else getClrType (string r.["DataType"])
                     let providerType = unbox<int> r.["ProviderDbType"]
                     let dbType = getDbType providerType


### PR DESCRIPTION
Fix (mono) type mapping issue SqlDbType time and date to ClrType DateTime.

```
Unhandled Exception:
System.TypeInitializationException: The type initializer for 'App.DBAdapter' threw an exception. ---> System.TypeInitializationException: The type initi
alizer for '<StartupCode$exporter>.$DBAdapter' threw an exception. ---> System.ArgumentOutOfRangeException: No mapping exists from SqlDbType Date to a known DbType.
Parameter name: SqlDbType
  at System.Data.SqlClient.SqlParameter.SetSqlDbType (SqlDbType type) <0x41243810 + 0x00b0b> in <filename unknown>:0
  at System.Data.SqlClient.SqlParameter.set_SqlDbType (SqlDbType value) <0x412437d0 + 0x00017> in <filename unknown>:0
  at (wrapper remoting-invoke-with-check) System.Data.SqlClient.SqlParameter:set_SqlDbType (System.Data.SqlDbType)
  at FSharp.Data.Sql.Providers.MSSqlServer.getDbType@27 (Int32 providerType) <0x41241df0 + 0x0008f> in <filename unknown>:0
  at FSharp.Data.Sql.Providers.MSSqlServer+mappings@38.GenerateNext (IEnumerable`1& next) <0x41253db0 + 0x007eb> in <filename unknown>:0
  at Microsoft.FSharp.Core.CompilerServices.GeneratedSequenceBase`1[T].MoveNextImpl () <0x41253b50 + 0x00069> in <filename unknown>:0
  at Microsoft.FSharp.Core.CompilerServices.GeneratedSequenceBase`1[T].System-Collections-IEnumerator-MoveNext () <0x41253b20 + 0x00017> in <filename unknown>:0

  at Microsoft.FSharp.Collections.SeqModule.ToList[T] (IEnumerable`1 source) <0x41253560 + 0x001f2> in <filename unknown>:0
  at FSharp.Data.Sql.Providers.MSSqlServer.createTypeMappings (IDbConnection con) <0x412311c0 + 0x000a3> in <filename unknown>:0
  at FSharp.Data.Sql.Providers.MSSqlServerProvider.FSharp-Data-Sql-Common-ISqlProvider-CreateTypeMappings (IDbConnection con) <0x41231190 + 0x00013> in <filenam
e unknown>:0
  at <StartupCode$FSharp-Data-SqlProvider>.$SqlRuntime.DataContext+-ctor@34-34.Invoke (System.String arg) <0x411ec780 + 0x00087> in <filename unknown>:0
  at System.Collections.Concurrent.ConcurrentDictionary`2[TKey,TValue].GetOrAdd (System.Collections.Concurrent.TKey key, System.Func`2 valueFactory) <0x7f854572
7c50 + 0x00066> in <filename unknown>:0
  at FSharp.Data.Sql.Runtime.SqlDataContext..ctor (System.String typeName, System.String connectionString, DatabaseProviderTypes providerType, System.String res
olutionPath, System.String[] referencedAssemblies, System.String runtimeAssembly, System.String owner, CaseSensitivityChange caseSensitivity, System.String tabl
eNames) <0x411eba50 + 0x00236> in <filename unknown>:0
  at <StartupCode$exporter>.$DBAdapter..cctor () <0x411ea2d0 + 0x00613> in <filename unknown>:0
```