### PR TITLE
Fixing individuals link

### DIFF
--- a/docs/content/core/parameters.fsx
+++ b/docs/content/core/parameters.fsx
@@ -63,7 +63,7 @@ let resolutionPath =
 (**
 ### IndividualsAmount
 
-Number of instances to retrieve when using the [individuals](core/individuals.html) feature.
+Number of instances to retrieve when using the [individuals](individuals.html) feature.
 Default is 1000.
 *)
 


### PR DESCRIPTION
The individuals link is broken, pointing to http://fsprojects.github.io/SQLProvider/core/core/individuals.html instead of http://fsprojects.github.io/SQLProvider/core/individuals.html