### PR TITLE
Support for composite keys.

### DIFF
--- a/src/SQLProvider/Providers.MySql.fs
+++ b/src/SQLProvider/Providers.MySql.fs
@@ -246,7 +246,7 @@ module MySql =
             Set(cols |> Array.map (processReturnColumn reader))
 
 type internal MySqlProvider(resolutionPath, owner, referencedAssemblies) as this =
-    let pkLookup = ConcurrentDictionary<string,string>()
+    let pkLookup = ConcurrentDictionary<string,KeyColumn>()
     let tableLookup = ConcurrentDictionary<string,Table>()
     let columnLookup = ConcurrentDictionary<string,ColumnLookup>()
     let relationshipLookup = ConcurrentDictionary<string,Relationship list * Relationship list>()
@@ -278,19 +278,23 @@ type internal MySqlProvider(resolutionPath, owner, referencedAssemblies) as this
         cmd.CommandText <- sb.ToString()
         cmd
 
-    let createUpdateCommand (con:IDbConnection) (sb:Text.StringBuilder) (entity:SqlEntity) changedColumns =
+    let createUpdateCommand (con:IDbConnection) (sb:Text.StringBuilder) (entity:SqlEntity) (changedColumns: string list) =
         let (~~) (t:string) = sb.Append t |> ignore
         let cmd = (this :> ISqlProvider).CreateCommand(con,"")
         cmd.Connection <- con
-        let pk = pkLookup.[entity.Table.FullName]
+        let haspk = pkLookup.ContainsKey(entity.Table.FullName)
+        let pk = if haspk then pkLookup.[entity.Table.FullName] else NoKeys
         sb.Clear() |> ignore
 
-        if changedColumns |> List.exists ((=)pk) then failwith "Error - you cannot change the primary key of an entity."
+        match pk with
+        | Key x when changedColumns |> List.exists ((=)x)
+            -> failwith "Error - you cannot change the primary key of an entity."
+        | _ -> ()
 
-        let pkValue =
-            match entity.GetColumnOption<obj> pk with
-            | Some v -> v
-            | None -> failwith "Error - you cannot update an entity that does not have a primary key."
+        let pkValues =
+            match entity.GetPkColumnOption<obj> pk with
+            | [] -> failwith ("Error - you cannot update an entity that does not have a primary key. (" + entity.Table.FullName + ")")
+            | v -> v
 
         let data =
             (([],0),changedColumns)
@@ -305,15 +309,24 @@ type internal MySqlProvider(resolutionPath, owner, referencedAssemblies) as this
             |> List.rev
             |> List.toArray
 
-        let pkParam = (this :> ISqlProvider).CreateCommandParameter((MySql.createParam "@pk" 0 pkValue),pkValue)
-
-        ~~(sprintf "UPDATE %s SET %s WHERE %s = @pk;"
-            (entity.Table.FullName.Replace("[","`").Replace("]","`"))
-            (String.Join(",", data |> Array.map(fun (c,p) -> sprintf "`%s` = %s" c p.ParameterName )))
-            pk)
+        match pk with
+        | NoKeys -> ()
+        | Key x ->
+            ~~(sprintf "UPDATE %s SET %s WHERE %s = @pk0;"
+                (entity.Table.FullName.Replace("[","`").Replace("]","`"))
+                (String.Join(",", data |> Array.map(fun (c,p) -> sprintf "`%s` = %s" c p.ParameterName )))
+                x)
+        | CompositeKey ks -> 
+            ~~(sprintf "UPDATE %s SET %s WHERE "
+                (entity.Table.FullName.Replace("[","`").Replace("]","`"))
+                (String.Join(",", data |> Array.map(fun (c,p) -> sprintf "`%s` = %s" c p.ParameterName ))))
+            ~~(String.Join(" AND ", ks |> List.mapi(fun i k -> (sprintf "%s = @pk%i" k i))) + ";")
 
         data |> Array.map snd |> Array.iter (cmd.Parameters.Add >> ignore)
-        cmd.Parameters.Add pkParam |> ignore
+
+        pkValues |> List.iteri(fun i pkValue ->
+            let p = (this :> ISqlProvider).CreateCommandParameter((MySql.createParam ("@pk"+i.ToString()) i pkValue),pkValue)
+            cmd.Parameters.Add(p) |> ignore)
         cmd.CommandText <- sb.ToString()
         cmd
 
@@ -322,15 +335,24 @@ type internal MySqlProvider(resolutionPath, owner, referencedAssemblies) as this
         let cmd = (this :> ISqlProvider).CreateCommand(con,"")
         cmd.Connection <- con
         sb.Clear() |> ignore
-        let pk = pkLookup.[entity.Table.FullName]
+        let haspk = pkLookup.ContainsKey(entity.Table.FullName)
+        let pk = if haspk then pkLookup.[entity.Table.FullName] else NoKeys
         sb.Clear() |> ignore
-        let pkValue =
-            match entity.GetColumnOption<obj> pk with
-            | Some v -> v
-            | None -> failwith ("Error - you cannot delete an entity that does not have a primary key. (" + entity.Table.FullName + ")")
-        let p = (this :> ISqlProvider).CreateCommandParameter((MySql.createParam "@id" 0 pkValue),pkValue)
-        cmd.Parameters.Add(p) |> ignore
-        ~~(sprintf "DELETE FROM %s WHERE %s = @id" (entity.Table.FullName.Replace("[","`").Replace("]","`")) pk )
+        let pkValues =
+            match entity.GetPkColumnOption<obj> pk with
+            | [] -> failwith ("Error - you cannot delete an entity that does not have a primary key. (" + entity.Table.FullName + ")")
+            | v -> v
+
+        pkValues |> List.iteri(fun i pkValue ->
+            let p = (this :> ISqlProvider).CreateCommandParameter((MySql.createParam ("@id"+i.ToString()) i pkValue),pkValue)
+            cmd.Parameters.Add(p) |> ignore)
+
+        match pk with
+        | NoKeys -> ()
+        | Key k -> ~~(sprintf "DELETE FROM %s WHERE %s = @id0;" (entity.Table.FullName.Replace("[","`").Replace("]","`")) k )
+        | CompositeKey ks -> 
+            ~~(sprintf "DELETE FROM %s WHERE " (entity.Table.FullName.Replace("[","`").Replace("]","`")))
+            ~~(String.Join(" AND ", ks |> List.mapi(fun i k -> (sprintf "%s = @id%i" k i))) + ";")
         cmd.CommandText <- sb.ToString()
         cmd
 
@@ -341,11 +363,11 @@ type internal MySqlProvider(resolutionPath, owner, referencedAssemblies) as this
 
     let checkKey id (e:SqlEntity) =
         if pkLookup.ContainsKey e.Table.FullName then
-            match e.GetColumnOption pkLookup.[e.Table.FullName] with
-            | Some(_) -> () // if the primary key exists, do nothing
+            match e.GetPkColumnOption pkLookup.[e.Table.FullName] with
+            | [] ->  e.SetPkColumnSilent(pkLookup.[e.Table.FullName], id)
+            | _ -> () // if the primary key exists, do nothing
                             // this is because non-identity columns will have been set
                             // manually and in that case scope_identity would bring back 0 "" or whatever
-            | None ->  e.SetColumnSilent(pkLookup.[e.Table.FullName], id)
 
     interface ISqlProvider with
         member __.CreateConnection(connectionString) = MySql.createConnection connectionString
@@ -369,12 +391,12 @@ type internal MySqlProvider(resolutionPath, owner, referencedAssemblies) as this
 
         member __.GetPrimaryKey(table) =
             match pkLookup.TryGetValue table.FullName with
-            | true, v -> Some v
+            | true, Key v -> Some v
             | _ -> None
 
         member __.GetColumns(con,table) =
             match columnLookup.TryGetValue table.FullName with
-            | (true,data) -> data
+            | (true,data) when data.Count > 0 -> data
             | _ ->
                 // note this data can be obtained using con.GetSchema, but with an epic schema we only want to get the data
                 // we are interested in on demand
@@ -409,12 +431,19 @@ type internal MySqlProvider(resolutionPath, owner, referencedAssemblies) as this
                                   IsNullable = let b = reader.GetString(4) in if b = "YES" then true else false
                                   IsPrimaryKey = if reader.GetString(5) = "PRIMARY KEY" then true else false }
                             if col.IsPrimaryKey then 
-                                pkLookup.AddOrUpdate(table.FullName, col.Name, fun key old -> col.Name) |> ignore
+                                pkLookup.AddOrUpdate(table.FullName, Key(col.Name), fun key old -> 
+                                    match col.Name with 
+                                    | "" -> old 
+                                    | x -> match old with
+                                           | Key o when o<>x -> CompositeKey([o;x] |> List.sort)
+                                           | CompositeKey(os) -> x::os |> Seq.distinct |> Seq.toList |> List.sort |> CompositeKey
+                                           | _ -> Key(x)
+                                ) |> ignore
                             yield (col.Name,col)
                         | _ -> ()]
                     |> Map.ofList
                 con.Close()
-                columnLookup.GetOrAdd(table.FullName,columns)
+                columnLookup.AddOrUpdate(table.FullName, columns, fun x old -> match columns.Count with 0 -> old | x -> columns)
 
         member __.GetRelationships(con,table) =
           relationshipLookup.GetOrAdd(table.FullName, fun name ->
@@ -681,7 +710,7 @@ type internal MySqlProvider(resolutionPath, owner, referencedAssemblies) as this
                         Common.QueryEvents.PublishSqlQuery cmd.CommandText
                         cmd.ExecuteNonQuery() |> ignore
                         // remove the pk to prevent this attempting to be used again
-                        e.SetColumnOptionSilent(pkLookup.[e.Table.FullName], None)
+                        e.SetPkColumnOptionSilent(pkLookup.[e.Table.FullName], None)
                         e._State <- Deleted
                     | Deleted | Unchanged -> failwith "Unchanged entity encountered in update list - this should not be possible!")
 
@@ -734,7 +763,7 @@ type internal MySqlProvider(resolutionPath, owner, referencedAssemblies) as this
                                 Common.QueryEvents.PublishSqlQuery cmd.CommandText
                                 do! cmd.ExecuteNonQueryAsync() |> Async.AwaitTask |> Async.Ignore
                                 // remove the pk to prevent this attempting to be used again
-                                e.SetColumnOptionSilent(pkLookup.[e.Table.FullName], None)
+                                e.SetPkColumnOptionSilent(pkLookup.[e.Table.FullName], None)
                                 e._State <- Deleted
                             }
                         | Deleted | Unchanged -> failwith "Unchanged entity encountered in update list - this should not be possible!"

--- a/src/SQLProvider/Providers.Odbc.fs
+++ b/src/SQLProvider/Providers.Odbc.fs
@@ -10,7 +10,7 @@ open FSharp.Data.Sql.Schema
 open FSharp.Data.Sql.Common
 
 type internal OdbcProvider() =
-    let pkLookup = ConcurrentDictionary<string,string>()
+    let pkLookup = ConcurrentDictionary<string,KeyColumn>()
     let tableLookup = ConcurrentDictionary<string,Table>()
     let columnLookup = ConcurrentDictionary<string,ColumnLookup>()
 
@@ -99,19 +99,23 @@ type internal OdbcProvider() =
         cmd.CommandText <- "SELECT @@IDENTITY AS id;"
         cmd
 
-    let createUpdateCommand (con:IDbConnection) (sb:Text.StringBuilder) (entity:SqlEntity) changedColumns =
+    let createUpdateCommand (con:IDbConnection) (sb:Text.StringBuilder) (entity:SqlEntity) (changedColumns: string list) =
         let (~~) (t:string) = sb.Append t |> ignore
         let cmd = new OdbcCommand()
         cmd.Connection <- con :?> OdbcConnection
-        let pk = pkLookup.[entity.Table.FullName]
+        let haspk = pkLookup.ContainsKey(entity.Table.FullName)
+        let pk = if haspk then pkLookup.[entity.Table.FullName] else NoKeys
         sb.Clear() |> ignore
 
-        if changedColumns |> List.exists ((=)pk) then failwith "Error - you cannot change the primary key of an entity."
+        match pk with
+        | Key x when changedColumns |> List.exists ((=)x)
+            -> failwith "Error - you cannot change the primary key of an entity."
+        | _ -> ()
 
-        let pkValue =
-            match entity.GetColumnOption<obj> pk with
-            | Some v -> v
-            | None -> failwith "Error - you cannot update an entity that does not have a primary key."
+        let pkValues =
+            match entity.GetPkColumnOption<obj> pk with
+            | [] -> failwith ("Error - you cannot update an entity that does not have a primary key. (" + entity.Table.FullName + ")")
+            | v -> v
 
         let data =
             (([],0),changedColumns)
@@ -125,15 +129,23 @@ type internal OdbcProvider() =
             |> List.rev
             |> List.toArray
 
-        let pkParam = OdbcParameter(null, pkValue)
-
-        ~~(sprintf "UPDATE %s SET %s WHERE %s = ?;"
-            entity.Table.Name
-            (String.Join(",", data |> Array.map(fun (c,_) -> sprintf "%s = %s" c "?" ) ))
-            pk)
+        match pk with
+        | NoKeys -> ()
+        | Key x ->
+            ~~(sprintf "UPDATE %s SET %s WHERE %s = ?;"
+                entity.Table.Name
+                (String.Join(",", data |> Array.map(fun (c,_) -> sprintf "%s = %s" c "?" ) ))
+                x)
+        | CompositeKey ks -> 
+            // TODO: What is the ?-mark parameter? Look from other providers how this is done.
+            failwith ("CompositeKey items update is not Supported in Odbc. (" + entity.Table.FullName + ")")
 
         cmd.Parameters.AddRange(data |> Array.map snd)
-        cmd.Parameters.Add pkParam |> ignore
+
+        pkValues |> List.iteri(fun i pkValue ->
+            let pkParam = OdbcParameter(null, pkValue)
+            cmd.Parameters.Add pkParam |> ignore
+            )
         cmd.CommandText <- sb.ToString()
         cmd
 
@@ -142,24 +154,33 @@ type internal OdbcProvider() =
         let cmd = new OdbcCommand()
         cmd.Connection <- con :?> OdbcConnection
         sb.Clear() |> ignore
-        let pk = pkLookup.[entity.Table.FullName]
+        let haspk = pkLookup.ContainsKey(entity.Table.FullName)
+        let pk = if haspk then pkLookup.[entity.Table.FullName] else NoKeys
         sb.Clear() |> ignore
-        let pkValue =
-            match entity.GetColumnOption<obj> pk with
-            | Some v -> v
-            | None -> failwith ("Error - you cannot delete an entity that does not have a primary key. (" + entity.Table.FullName + ")")
-        cmd.Parameters.AddWithValue("@id",pkValue) |> ignore
-        ~~(sprintf "DELETE FROM %s WHERE %s = ?" entity.Table.Name pk )
+        let pkValues =
+            match entity.GetPkColumnOption<obj> pk with
+            | [] -> failwith ("Error - you cannot delete an entity that does not have a primary key. (" + entity.Table.FullName + ")")
+            | v -> v
+
+        pkValues |> List.iteri(fun i pkValue ->
+            cmd.Parameters.AddWithValue("@id"+i.ToString(),pkValue) |> ignore)
+
+        match pk with
+        | NoKeys -> ()
+        | Key k -> ~~(sprintf "DELETE FROM %s WHERE %s = ?;" entity.Table.FullName k )
+        | CompositeKey ks -> 
+            // TODO: What is the ?-mark parameter? Look from other providers how this is done.
+            failwith ("CompositeKey items deletion is not Supported in Odbc. (" + entity.Table.FullName + ")")
         cmd.CommandText <- sb.ToString()
         cmd
 
     let checkKey id (e:SqlEntity) =
         if pkLookup.ContainsKey e.Table.FullName then
-            match e.GetColumnOption pkLookup.[e.Table.FullName] with
-            | Some(_) -> () // if the primary key exists, do nothing
+            match e.GetPkColumnOption pkLookup.[e.Table.FullName] with
+            | [] ->  e.SetPkColumnSilent(pkLookup.[e.Table.FullName], id)
+            | _ -> () // if the primary key exists, do nothing
                             // this is because non-identity columns will have been set
                             // manually and in that case scope_identity would bring back 0 "" or whatever
-            | None ->  e.SetColumnSilent(pkLookup.[e.Table.FullName], id)
 
     interface ISqlProvider with
         member __.CreateConnection(connectionString) = upcast new OdbcConnection(connectionString)
@@ -193,12 +214,12 @@ type internal OdbcProvider() =
 
         member __.GetPrimaryKey(table) =
             match pkLookup.TryGetValue table.FullName with
-            | true, v -> Some v
+            | true, Key v -> Some v
             | _ -> None
 
         member __.GetColumns(con,table) =
             match columnLookup.TryGetValue table.FullName with
-            | (true,data) -> data
+            | (true,data) when data.Count > 0 -> data
             | _ ->
                 let con = con :?> OdbcConnection
                 if con.State <> ConnectionState.Open then con.Open()
@@ -216,11 +237,18 @@ type internal OdbcProvider() =
                                   IsNullable = let b = i.[17] :?> string in if b = "YES" then true else false
                                   IsPrimaryKey = if primaryKey.Length > 0 && primaryKey.[0].[8] = box name then true else false }
                             if col.IsPrimaryKey then 
-                                pkLookup.AddOrUpdate(table.FullName, col.Name, fun key old -> col.Name) |> ignore
+                                pkLookup.AddOrUpdate(table.FullName, Key(col.Name), fun key old ->
+                                    match col.Name with 
+                                    | "" -> old 
+                                    | x -> match old with
+                                           | Key o when o<>x -> CompositeKey([o;x] |> List.sort)
+                                           | CompositeKey(os) -> x::os |> Seq.distinct |> Seq.toList |> List.sort |> CompositeKey
+                                           | _ -> Key(x)
+                                ) |> ignore
                             yield (col.Name,col)
                         | _ -> ()]
                     |> Map.ofList
-                columnLookup.GetOrAdd(table.FullName,columns)
+                columnLookup.AddOrUpdate(table.FullName, columns, fun x old -> match columns.Count with 0 -> old | x -> columns)
 
         member __.GetRelationships(_,_) = ([],[]) // The ODBC type provider does not currently support GetRelationships operations.
         member __.GetSprocs(_) = []
@@ -437,7 +465,7 @@ type internal OdbcProvider() =
                         Common.QueryEvents.PublishSqlQuery cmd.CommandText
                         cmd.ExecuteNonQuery() |> ignore
                         // remove the pk to prevent this attempting to be used again
-                        e.SetColumnOptionSilent(pkLookup.[e.Table.FullName], None)
+                        e.SetPkColumnOptionSilent(pkLookup.[e.Table.FullName], None)
                         e._State <- Deleted
                     | Deleted | Unchanged -> failwith "Unchanged entity encountered in update list - this should not be possible!")
                 scope.Complete()
@@ -489,7 +517,7 @@ type internal OdbcProvider() =
                                 Common.QueryEvents.PublishSqlQuery cmd.CommandText
                                 do! cmd.ExecuteNonQueryAsync() |> Async.AwaitTask |> Async.Ignore
                                 // remove the pk to prevent this attempting to be used again
-                                e.SetColumnOptionSilent(pkLookup.[e.Table.FullName], None)
+                                e.SetPkColumnOptionSilent(pkLookup.[e.Table.FullName], None)
                                 e._State <- Deleted
                             }
                         | Deleted | Unchanged -> failwith "Unchanged entity encountered in update list - this should not be possible!"

--- a/src/SQLProvider/Providers.Oracle.fs
+++ b/src/SQLProvider/Providers.Oracle.fs
@@ -714,10 +714,7 @@ type internal OracleProvider(resolutionPath, owner, referencedAssemblies, tableN
             let sb = Text.StringBuilder()
             let provider = this :> ISqlProvider
 
-            // ensure columns have been loaded
-            entities |> Seq.map(fun e -> e.Key.Table)
-                     |> Seq.distinct
-                     |> Seq.iter(fun t -> provider.GetColumns(con,t) |> ignore )
+            CommonTasks.``ensure columns have been loaded`` (this :> ISqlProvider) con entities
 
             if entities.Count = 0 then 
                 ()
@@ -766,10 +763,7 @@ type internal OracleProvider(resolutionPath, owner, referencedAssemblies, tableN
             let sb = Text.StringBuilder()
             let provider = this :> ISqlProvider
 
-            // ensure columns have been loaded
-            entities |> Seq.map(fun e -> e.Key.Table)
-                     |> Seq.distinct
-                     |> Seq.iter(fun t -> provider.GetColumns(con,t) |> ignore )
+            CommonTasks.``ensure columns have been loaded`` (this :> ISqlProvider) con entities
 
             if entities.Count = 0 then 
                 async { () }

--- a/src/SQLProvider/Providers.Oracle.fs
+++ b/src/SQLProvider/Providers.Oracle.fs
@@ -234,7 +234,7 @@ module internal Oracle =
                 |> Option.map (fun m ->
                     { Name = columnName
                       TypeMapping = m
-                      IsPrimaryKey = primaryKeys.Values |> Seq.exists (fun x -> x.Table = tableName && x.Column = columnName)
+                      IsPrimaryKey = primaryKeys.Values |> Seq.exists (fun x -> x.Table = tableName && x.Column = Key(columnName))
                       IsNullable = nullable }
                 ))
         |> Seq.choose id
@@ -251,15 +251,16 @@ module internal Oracle =
             |> DataTable.mapChoose (fun row ->
                 let name = Sql.dbUnbox row.[4]
                 match primaryKeys.TryGetValue(table) with
-                | true, pk ->
-                    match foreignKeyCols.TryFind name with
-                    | Some(fk) ->
+                | true, pks ->
+                    match pks.Column, foreignKeyCols.TryFind name with
+                    | Key pk, Some(fk) ->
                          { Name = name
                            PrimaryTable = Table.CreateFullName(Sql.dbUnbox row.[1],Sql.dbUnbox row.[2])
-                           PrimaryKey = pk.Column
+                           PrimaryKey = pk
                            ForeignTable = Table.CreateFullName(Sql.dbUnbox row.[3],Sql.dbUnbox row.[5])
                            ForeignKey = fk } |> Some
-                    | None -> None
+                    | _, Some(fk) -> None
+                    | _, None -> None
                 | false, _ -> None
             )
         let children =
@@ -387,14 +388,14 @@ module internal Oracle =
         entities
 
 type internal OracleProvider(resolutionPath, owner, referencedAssemblies, tableNames) =
-    let mutable primaryKeyCache : IDictionary<string,PrimaryKey> = null
+    let mutable primaryKeyColumn : IDictionary<string,PrimaryKey> = null
     let relationshipCache = new ConcurrentDictionary<string, Relationship list * Relationship list>()
     let columnCache = new ConcurrentDictionary<string,ColumnLookup>()
     let mutable tableCache : Table list = []
 
     let isPrimaryKey tableName columnName = 
-        match primaryKeyCache.TryGetValue tableName with
-        | true, pk when pk.Column = columnName -> true
+        match primaryKeyColumn.TryGetValue tableName with
+        | true, pk when pk.Column = Key(columnName) -> true
         | _ -> false
 
     let createInsertCommand (provider:ISqlProvider) (con:IDbConnection) (sb:Text.StringBuilder) (entity:SqlEntity) =
@@ -420,18 +421,18 @@ type internal OracleProvider(resolutionPath, owner, referencedAssemblies, tableN
         values |> Array.iter (cmd.Parameters.Add >> ignore)
         cmd
 
-    let createUpdateCommand (provider:ISqlProvider) (con:IDbConnection) (sb:Text.StringBuilder) (entity:SqlEntity) changedColumns =
+    let createUpdateCommand (provider:ISqlProvider) (con:IDbConnection) (sb:Text.StringBuilder) (entity:SqlEntity) (changedColumns: string list) =
         let (~~) (t:string) = sb.Append t |> ignore
         sb.Clear() |> ignore
 
         if changedColumns |> List.exists (isPrimaryKey entity.Table.Name) 
         then failwith "Error - you cannot change the primary key of an entity."
 
-        let pk = primaryKeyCache.[entity.Table.Name]
-        let pkValue =
-            match entity.GetColumnOption<obj> pk.Column with
-            | Some v -> v
-            | None -> failwith "Error - you cannot update an entity that does not have a primary key."
+        let pk = primaryKeyColumn.[entity.Table.Name]
+        let pkValues =
+            match entity.GetPkColumnOption<obj> pk.Column with
+            | [] -> failwith ("Error - you cannot update an entity that does not have a primary key. (" + entity.Table.FullName + ")")
+            | v -> v
 
         let columns, parameters =
             (([],0),changedColumns)
@@ -447,35 +448,53 @@ type internal OracleProvider(resolutionPath, owner, referencedAssemblies, tableN
             |> List.toArray
             |> Array.unzip
 
-        let pkParam = provider.CreateCommandParameter(QueryParameter.Create(":pk",0), pkValue)
-
-        ~~(sprintf "UPDATE %s SET (%s) = (%s) WHERE %s = :pk"
-            (entity.Table.FullName)
-            (String.Join(",", columns))
-            (String.Join(",", parameters |> Array.map (fun p -> p.ParameterName)))
-            pk.Column)
+        match pk.Column with
+        | NoKeys -> ()
+        | Key x ->
+            ~~(sprintf "UPDATE %s SET (%s) = (%s) WHERE %s = :pk0"
+                (entity.Table.FullName)
+                (String.Join(",", columns))
+                (String.Join(",", parameters |> Array.map (fun p -> p.ParameterName)))
+                x)
+        | CompositeKey ks -> 
+            ~~(sprintf "UPDATE %s SET (%s) = (%s) WHERE "
+                (entity.Table.FullName)
+                (String.Join(",", columns))
+                (String.Join(",", parameters |> Array.map (fun p -> p.ParameterName))))
+            ~~(String.Join(" AND ", ks |> List.mapi(fun i k -> (sprintf "%s = :pk%i" k i))))
 
         let cmd = provider.CreateCommand(con, sb.ToString())
         parameters |> Array.iter (cmd.Parameters.Add >> ignore)
-        cmd.Parameters.Add pkParam |> ignore
+        pkValues |> List.iteri(fun i pkValue ->
+            let pkParam = provider.CreateCommandParameter(QueryParameter.Create((":pk"+i.ToString()),i), pkValue)
+            cmd.Parameters.Add pkParam |> ignore
+        )
         cmd
 
     let createDeleteCommand (provider:ISqlProvider) (con:IDbConnection) (sb:Text.StringBuilder) (entity:SqlEntity) =
         let (~~) (t:string) = sb.Append t |> ignore
-        let pk = primaryKeyCache.[entity.Table.Name]
+        let pk = primaryKeyColumn.[entity.Table.Name]
         sb.Clear() |> ignore
-        let pkValue =
-            match entity.GetColumnOption<obj> pk.Column with
-            | Some v -> v
-            | None -> failwith ("Error - you cannot delete an entity that does not have a primary key. (" + entity.Table.FullName + ")")
-        ~~(sprintf "DELETE FROM %s WHERE %s = :id" (entity.Table.FullName) pk.Column )
+        let pkValues =
+            match entity.GetPkColumnOption<obj> pk.Column with
+            | [] -> failwith ("Error - you cannot delete an entity that does not have a primary key. (" + entity.Table.FullName + ")")
+            | v -> v
+
+        match pk.Column with
+        | NoKeys -> ()
+        | Key k -> ~~(sprintf "DELETE FROM %s WHERE %s = :id0" (entity.Table.FullName) k )
+        | CompositeKey ks -> 
+            ~~(sprintf "DELETE FROM %s WHERE " entity.Table.FullName)
+            ~~(String.Join(" AND ", ks |> List.mapi(fun i k -> (sprintf "%s = :id%i" k i))))
+
         let cmd = provider.CreateCommand(con, sb.ToString())
         cmd.CommandType <- CommandType.Text
-        let pkType = pkValue.GetType().ToString();
-        match Oracle.findClrType pkType with
-        | Some(m) ->
-            cmd.Parameters.Add(provider.CreateCommandParameter(QueryParameter.Create(":id",0, m), pkValue)) |> ignore
-        | None -> ()
+        pkValues |> List.iteri(fun i pkValue ->
+            let pkType = pkValue.GetType().ToString();
+            match Oracle.findClrType pkType with
+            | Some(m) ->
+                cmd.Parameters.Add(provider.CreateCommandParameter(QueryParameter.Create((":id"+i.ToString()),i, m), pkValue)) |> ignore
+            | None -> ())
         cmd
 
     do
@@ -492,7 +511,7 @@ type internal OracleProvider(resolutionPath, owner, referencedAssemblies, tableN
         member __.CreateTypeMappings(con) =
             Sql.connect con (fun con ->
                 Oracle.createTypeMappings con
-                primaryKeyCache <- (Oracle.getPrimaryKeys tableNames con))
+                primaryKeyColumn <- (Oracle.getPrimaryKeys tableNames con))
 
         member __.GetTables(con,_) =
                match tableCache with
@@ -503,20 +522,20 @@ type internal OracleProvider(resolutionPath, owner, referencedAssemblies, tableN
                 | a -> a
 
         member __.GetPrimaryKey(table) =
-            match primaryKeyCache.TryGetValue table.Name with
-            | true, v -> Some v.Column
+            match primaryKeyColumn.TryGetValue table.Name with
+            | true, v -> match v.Column with Key x -> Some(x) | _ -> None
             | _ -> None
 
         member __.GetColumns(con,table) =
             match columnCache.TryGetValue table.FullName  with
-            | true, cols -> cols
-            | false, _ ->
-                let cols = Sql.connect con (Oracle.getColumns primaryKeyCache table.Name)
+            | true, cols when cols.Count > 0 -> cols
+            | _ ->
+                let cols = Sql.connect con (Oracle.getColumns primaryKeyColumn table.Name)
                 columnCache.GetOrAdd(table.FullName, cols)
 
         member __.GetRelationships(con,table) =
             relationshipCache.GetOrAdd(table.FullName, fun name ->
-                    let rels = Sql.connect con (Oracle.getRelationships primaryKeyCache table.Name)
+                    let rels = Sql.connect con (Oracle.getRelationships primaryKeyColumn table.Name)
                     rels)
 
         member __.GetSprocs(con) = Sql.connect con Oracle.getSprocs
@@ -726,11 +745,11 @@ type internal OracleProvider(resolutionPath, owner, referencedAssemblies, tableN
                         let cmd = createInsertCommand provider con sb e
                         Common.QueryEvents.PublishSqlQuery cmd.CommandText
                         let id = cmd.ExecuteScalar()
-                        match e.GetColumnOption primaryKeyCache.[e.Table.Name].Column with
-                        | Some(_) -> () // if the primary key exists, do nothing
+                        match e.GetPkColumnOption primaryKeyColumn.[e.Table.Name].Column with
+                        | [] ->  e.SetPkColumnSilent(primaryKeyColumn.[e.Table.Name].Column, id)
+                        | _ -> () // if the primary key exists, do nothing
                                         // this is because non-identity columns will have been set
                                         // manually and in that case scope_identity would bring back 0 "" or whatever
-                        | None ->  e.SetColumnSilent(primaryKeyCache.[e.Table.Name].Column, id)
                         e._State <- Unchanged
                     | Modified fields ->
                         let cmd = createUpdateCommand provider con sb e fields
@@ -742,7 +761,7 @@ type internal OracleProvider(resolutionPath, owner, referencedAssemblies, tableN
                         Common.QueryEvents.PublishSqlQuery cmd.CommandText
                         cmd.ExecuteNonQuery() |> ignore
                         // remove the pk to prevent this attempting to be used again
-                        e.SetColumnOptionSilent(primaryKeyCache.[e.Table.Name].Column, None)
+                        e.SetPkColumnOptionSilent(primaryKeyColumn.[e.Table.Name].Column, None)
                         e._State <- Deleted
                     | Deleted | Unchanged -> failwith "Unchanged entity encountered in update list - this should not be possible!")
                 scope.Complete()
@@ -779,11 +798,11 @@ type internal OracleProvider(resolutionPath, owner, referencedAssemblies, tableN
                                 let cmd = createInsertCommand provider con sb e :?> System.Data.Common.DbCommand
                                 Common.QueryEvents.PublishSqlQuery cmd.CommandText
                                 let! id = cmd.ExecuteScalarAsync() |> Async.AwaitTask
-                                match e.GetColumnOption primaryKeyCache.[e.Table.Name].Column with
-                                | Some(_) -> () // if the primary key exists, do nothing
+                                match e.GetPkColumnOption primaryKeyColumn.[e.Table.Name].Column with
+                                | [] ->  e.SetPkColumnSilent(primaryKeyColumn.[e.Table.Name].Column, id)
+                                | _ -> () // if the primary key exists, do nothing
                                                 // this is because non-identity columns will have been set
                                                 // manually and in that case scope_identity would bring back 0 "" or whatever
-                                | None ->  e.SetColumnSilent(primaryKeyCache.[e.Table.Name].Column, id)
                                 e._State <- Unchanged
                             }
                         | Modified fields ->
@@ -799,7 +818,7 @@ type internal OracleProvider(resolutionPath, owner, referencedAssemblies, tableN
                                 Common.QueryEvents.PublishSqlQuery cmd.CommandText
                                 do! cmd.ExecuteNonQueryAsync() |> Async.AwaitTask |> Async.Ignore
                                 // remove the pk to prevent this attempting to be used again
-                                e.SetColumnOptionSilent(primaryKeyCache.[e.Table.Name].Column, None)
+                                e.SetPkColumnOptionSilent(primaryKeyColumn.[e.Table.Name].Column, None)
                                 e._State <- Deleted
                             }
                         | Deleted | Unchanged -> failwith "Unchanged entity encountered in update list - this should not be possible!"

--- a/src/SQLProvider/Providers.SQLite.fs
+++ b/src/SQLProvider/Providers.SQLite.fs
@@ -12,7 +12,7 @@ open FSharp.Data.Sql.Common
 type internal SQLiteProvider(resolutionPath, referencedAssemblies, runtimeAssembly) as this =
     // note we intentionally do not hang onto a connection object at any time,
     // as the type provider will dicate the connection lifecycles
-    let pkLookup = ConcurrentDictionary<string,string>()
+    let pkLookup = ConcurrentDictionary<string,KeyColumn>()
     let tableLookup = ConcurrentDictionary<string,Table>()
     let columnLookup = ConcurrentDictionary<string,ColumnLookup>()
     let relationshipLookup = Dictionary<string,Relationship list * Relationship list>()
@@ -120,19 +120,23 @@ type internal SQLiteProvider(resolutionPath, referencedAssemblies, runtimeAssemb
         cmd.CommandText <- sb.ToString()
         cmd
 
-    let createUpdateCommand (con:IDbConnection) (sb:Text.StringBuilder) (entity:SqlEntity) changedColumns =
+    let createUpdateCommand (con:IDbConnection) (sb:Text.StringBuilder) (entity:SqlEntity) (changedColumns: string list) =
         let (~~) (t:string) = sb.Append t |> ignore
         let cmd = (this :> ISqlProvider).CreateCommand(con,"")
         cmd.Connection <- con
-        let pk = pkLookup.[entity.Table.FullName]
+        let haspk = pkLookup.ContainsKey(entity.Table.FullName)
+        let pk = if haspk then pkLookup.[entity.Table.FullName] else NoKeys
         sb.Clear() |> ignore
 
-        if changedColumns |> List.exists ((=)pk) then failwith "Error - you cannot change the primary key of an entity."
+        match pk with
+        | Key x when changedColumns |> List.exists ((=)x)
+            -> failwith "Error - you cannot change the primary key of an entity."
+        | _ -> ()
 
-        let pkValue =
-            match entity.GetColumnOption<obj> pk with
-            | Some v -> v
-            | None -> failwith "Error - you cannot update an entity that does not have a primary key."
+        let pkValues =
+            match entity.GetPkColumnOption<obj> pk with
+            | [] -> failwith ("Error - you cannot update an entity that does not have a primary key. (" + entity.Table.FullName + ")")
+            | v -> v
 
         let data =
             (([],0),changedColumns)
@@ -147,15 +151,23 @@ type internal SQLiteProvider(resolutionPath, referencedAssemblies, runtimeAssemb
             |> List.rev
             |> List.toArray
 
-        let pkParam = createParam "@pk" 0 pkValue
-        
-        ~~(sprintf "UPDATE %s SET %s WHERE %s = @pk;"
-            entity.Table.FullName
-            (String.Join(",", data |> Array.map(fun (c,p) -> sprintf "%s = %s" c p.ParameterName ) ))
-            pk)
+        match pk with
+        | NoKeys -> ()
+        | Key x ->
+            ~~(sprintf "UPDATE %s SET %s WHERE %s = @pk0;"
+                entity.Table.FullName
+                (String.Join(",", data |> Array.map(fun (c,p) -> sprintf "%s = %s" c p.ParameterName ) ))
+                x)
+        | CompositeKey ks -> 
+            ~~(sprintf "UPDATE %s SET %s WHERE "
+                entity.Table.FullName
+                (String.Join(",", data |> Array.map(fun (c,p) -> sprintf "%s = %s" c p.ParameterName ) )))
+            ~~(String.Join(" AND ", ks |> List.mapi(fun i k -> (sprintf "%s = @pk%i" k i))) + ";")
 
         data |> Array.map snd |> Array.iter (cmd.Parameters.Add >> ignore)
-        cmd.Parameters.Add pkParam |> ignore
+        pkValues |> List.iteri(fun i pkValue ->
+            let p = createParam ("@pk"+i.ToString()) i pkValue
+            cmd.Parameters.Add(p) |> ignore)
         cmd.CommandText <- sb.ToString()
         cmd
 
@@ -164,25 +176,33 @@ type internal SQLiteProvider(resolutionPath, referencedAssemblies, runtimeAssemb
         let cmd = (this :> ISqlProvider).CreateCommand(con,"")
         cmd.Connection <- con
         sb.Clear() |> ignore
-        let pk = pkLookup.[entity.Table.FullName]
+        let haspk = pkLookup.ContainsKey(entity.Table.FullName)
+        let pk = if haspk then pkLookup.[entity.Table.FullName] else NoKeys
         sb.Clear() |> ignore
-        let pkValue =
-            match entity.GetColumnOption<obj> pk with
-            | Some v -> v
-            | None -> failwith ("Error - you cannot delete an entity that does not have a primary key. (" + entity.Table.FullName + ")")
-        let p = createParam "@id" 0 pkValue
-        cmd.Parameters.Add(p) |> ignore
-        ~~(sprintf "DELETE FROM %s WHERE %s = @id" entity.Table.FullName pk )
+        let pkValues =
+            match entity.GetPkColumnOption<obj> pk with
+            | [] -> failwith ("Error - you cannot delete an entity that does not have a primary key. (" + entity.Table.FullName + ")")
+            | v -> v
+        pkValues |> List.iteri(fun i pkValue ->
+            let p = createParam ("@id"+i.ToString()) i pkValue
+            cmd.Parameters.Add(p) |> ignore)
+
+        match pk with
+        | NoKeys -> ()
+        | Key k -> ~~(sprintf "DELETE FROM %s WHERE %s = @id0;" entity.Table.FullName k )
+        | CompositeKey ks -> 
+            ~~(sprintf "DELETE FROM %s WHERE " entity.Table.FullName)
+            ~~(String.Join(" AND ", ks |> List.mapi(fun i k -> (sprintf "%s = @id%i" k i))) + ";")
         cmd.CommandText <- sb.ToString()
         cmd
 
     let checkKey id (e:SqlEntity) =
         if pkLookup.ContainsKey e.Table.FullName then
-            match e.GetColumnOption pkLookup.[e.Table.FullName] with
-            | Some(_) -> () // if the primary key exists, do nothing
+            match e.GetPkColumnOption pkLookup.[e.Table.FullName] with
+            | [] ->  e.SetPkColumnSilent(pkLookup.[e.Table.FullName], id)
+            | _  -> () // if the primary key exists, do nothing
                             // this is because non-identity columns will have been set
                             // manually and in that case scope_identity would bring back 0 "" or whatever
-            | None ->  e.SetColumnSilent(pkLookup.[e.Table.FullName], id)
 
     interface ISqlProvider with
         member __.CreateConnection(connectionString) =
@@ -238,12 +258,12 @@ type internal SQLiteProvider(resolutionPath, referencedAssemblies, runtimeAssemb
 
         member __.GetPrimaryKey(table) =
             match pkLookup.TryGetValue table.FullName with
-            | true, v -> Some v
+            | true, Key v -> Some v
             | _ -> None
 
         member __.GetColumns(con,table) =
             match columnLookup.TryGetValue table.FullName with
-            | (true,data) -> data
+            | (true,data) when data.Count > 0 -> data
             | _ ->
                 if con.State <> ConnectionState.Open then con.Open()
                 let query = sprintf "pragma table_info(%s)" table.Name
@@ -260,12 +280,20 @@ type internal SQLiteProvider(resolutionPath, referencedAssemblies, runtimeAssemb
                                   TypeMapping = m
                                   IsNullable = not <| reader.GetBoolean(3);
                                   IsPrimaryKey = if reader.GetBoolean(5) then true else false }
-                            if col.IsPrimaryKey then pkLookup.AddOrUpdate(table.FullName, col.Name, fun key old -> col.Name) |> ignore
+                            if col.IsPrimaryKey then 
+                                pkLookup.AddOrUpdate(table.FullName, Key(col.Name), fun key old -> 
+                                    match col.Name with 
+                                    | "" -> old 
+                                    | x -> match old with
+                                           | Key o when o<>x -> CompositeKey([o;x] |> List.sort)
+                                           | CompositeKey(os) -> x::os |> Seq.distinct |> Seq.toList |> List.sort |> CompositeKey
+                                           | _ -> Key(x)
+                                ) |> ignore
                             yield (col.Name,col)
                         | _ -> ()]
                     |> Map.ofList
                 con.Close()
-                columnLookup.GetOrAdd(table.FullName,columns)
+                columnLookup.AddOrUpdate(table.FullName, columns, fun x old -> match columns.Count with 0 -> old | x -> columns)
 
         member __.GetRelationships(con,table) =
           System.Threading.Monitor.Enter relationshipLookup
@@ -525,7 +553,7 @@ type internal SQLiteProvider(resolutionPath, referencedAssemblies, runtimeAssemb
                         Common.QueryEvents.PublishSqlQuery cmd.CommandText
                         cmd.ExecuteNonQuery() |> ignore
                         // remove the pk to prevent this attempting to be used again
-                        e.SetColumnOptionSilent(pkLookup.[e.Table.FullName], None)
+                        e.SetPkColumnOptionSilent(pkLookup.[e.Table.FullName], None)
                         e._State <- Deleted
                     | Deleted | Unchanged -> failwith "Unchanged entity encountered in update list - this should not be possible!")
                 scope.Complete()
@@ -575,7 +603,7 @@ type internal SQLiteProvider(resolutionPath, referencedAssemblies, runtimeAssemb
                                 Common.QueryEvents.PublishSqlQuery cmd.CommandText
                                 do! cmd.ExecuteNonQueryAsync() |> Async.AwaitTask |> Async.Ignore
                                 // remove the pk to prevent this attempting to be used again
-                                e.SetColumnOptionSilent(pkLookup.[e.Table.FullName], None)
+                                e.SetPkColumnOptionSilent(pkLookup.[e.Table.FullName], None)
                                 e._State <- Deleted
                             }
                         | Deleted | Unchanged -> failwith "Unchanged entity encountered in update list - this should not be possible!"

--- a/src/SQLProvider/SqlSchema.fs
+++ b/src/SQLProvider/SqlSchema.fs
@@ -85,15 +85,10 @@ type Sproc =
     | Sproc of CompileTimeSprocDefinition
     | Empty
 
-type KeyColumn =
-| NoKeys
-| Key of string
-| CompositeKey of string list
-
 type PrimaryKey =
     { Name: string
       Table: string
-      Column: KeyColumn
+      Column: string list
       IndexName: string }
 
 type Table =

--- a/src/SQLProvider/SqlSchema.fs
+++ b/src/SQLProvider/SqlSchema.fs
@@ -85,10 +85,15 @@ type Sproc =
     | Sproc of CompileTimeSprocDefinition
     | Empty
 
+type KeyColumn =
+| NoKeys
+| Key of string
+| CompositeKey of string list
+
 type PrimaryKey =
     { Name: string
       Table: string
-      Column: string
+      Column: KeyColumn
       IndexName: string }
 
 type Table =

--- a/tests/SqlProvider.Tests/scripts/MSAccessTests.fsx
+++ b/tests/SqlProvider.Tests/scripts/MSAccessTests.fsx
@@ -40,6 +40,10 @@ let orderDetail =
         for c in ctx.Northwind.OrderDetails do
         select c
         head }
+//orderDetail.Discount <- 0.5f
+//orderDetail.Delete()
+//ctx.SubmitUpdates()
+
 
 /// CRUD Test. To use CRUD you have to have a primary key in your table. 
 let crudops =


### PR DESCRIPTION
Initial idea is simple:

Change

```
let primaryKeyLookup = ConcurrentDictionary< tablename:string, primarykey:string >()
```

...to be...
```
type KeyColumn =
| Key of string
| CompositeKey of string list

let primaryKeyLookup = ConcurrentDictionary< tablename:string, primarykey:KeyColumn >()
```

and then when there is update or delete command, just match that if CompositeKey, parse AND combination:

```
DELETE FROM table WHERE myKey1 = @pk0 AND myKey2 = @pk1;
```

Tested to work with MSSQL-Server and Access.
