### PR TITLE
Support for nested projections. And let -keyword.

### DIFF
--- a/docs/content/core/querying.fsx
+++ b/docs/content/core/querying.fsx
@@ -97,7 +97,7 @@ join                     |X |                                                   
 last                     |  |                                                       | 
 lastOrDefault            |  |                                                       | 
 leftOuterJoin            |  |                                                       | 
-let                      |  |                                                       |
+let                      |X | ...but not using tmp variables in where-clauses       |
 maxBy                    |X |                                                       | 
 maxByNullable            |X |                                                       | 
 minBy                    |X |                                                       | 
@@ -119,7 +119,7 @@ thenByDescending	     |X |                                                      
 thenByNullable           |X |                                                       | 
 thenByNullableDescending |X |                                                       |
 where                    |X | Server side variables must be on left side and only left side of predicates  | 
-
+                         |  | (excluding boolean database fields and LINQ-Contains) | 
 *)
 
 (**

--- a/src/SQLProvider/SqlRuntime.Linq.fs
+++ b/src/SQLProvider/SqlRuntime.Linq.fs
@@ -479,7 +479,7 @@ module internal QueryImplementation =
 
                     | MethodCall(None, (MethodWithName "Select"), [ SourceWithQueryData source; OptionalQuote (Lambda([ v1 ], _) as lambda) ]) as whole ->
                         let ty = typedefof<SqlQueryable<_>>.MakeGenericType((lambda :?> LambdaExpression).ReturnType )
-                        if v1.Name.StartsWith "_arg" then
+                        if v1.Name.StartsWith "_arg" && v1.Type <> typeof<SqlEntity> then
                             // this is the projection from a join - ignore
                             ty.GetConstructors().[0].Invoke [| source.DataContext; source.Provider; source.SqlExpression; source.TupleIndex; |] :?> IQueryable<_>
                         else

--- a/src/SQLProvider/Utils.fs
+++ b/src/SQLProvider/Utils.fs
@@ -25,7 +25,7 @@ module internal Utilities =
     let resolveTuplePropertyName (name:string) (tupleIndex:string ResizeArray) =
         // eg "Item1" -> tupleIndex.[0]
         let itemid = (int <| name.Remove(0, 4))
-        if(tupleIndex.Count < itemid) then "tmp" + name
+        if(tupleIndex.Count < itemid) then ""
         else tupleIndex.[itemid - 1]
 
     let quoteWhiteSpace (str:String) = 

--- a/tests/SqlProvider.Tests/QueryTests.fs
+++ b/tests/SqlProvider.Tests/QueryTests.fs
@@ -189,8 +189,20 @@ let ``simplest select query let temp``() =
     
     CollectionAssert.IsNotEmpty query
 
+[<Test>]
+let ``simple select query let temp nested``() = 
+    let dc = sql.GetDataContext()
+    let query = 
+        query {
+            for cust in dc.Main.Customers do
+            let y1 = cust.Address
+            let y2 = cust.City
+            select (y1, y2)
+        } |> Seq.toArray
+    
+    CollectionAssert.IsNotEmpty query
 
-[<Test; Ignore("Not Supported")>]
+[<Test>]
 let ``simple select query let temp``() = 
     let dc = sql.GetDataContext()
     let query = 
@@ -201,6 +213,37 @@ let ``simple select query let temp``() =
         } |> Seq.toArray
     
     CollectionAssert.IsNotEmpty query
+    Assert.AreEqual("Berlintest", query.[0])
+
+
+[<Test>]
+let ``simple select query let where``() = 
+    let dc = sql.GetDataContext()
+    let query = 
+        query {
+            for cust in dc.Main.Customers do
+            let y = cust.City + "test"
+            where (cust.Address <> "")
+            select y
+        } |> Seq.toArray
+    
+    CollectionAssert.IsNotEmpty query
+    Assert.AreEqual("Berlintest", query.[0])
+
+[<Test; Ignore("Not supported")>]
+let ``simple select query let temp used in where``() = 
+    let dc = sql.GetDataContext()
+    let query = 
+        query {
+            for cust in dc.Main.Customers do
+            let y = cust.City + "test"
+            where (y <> "")
+            select y
+        } |> Seq.toArray
+    
+    CollectionAssert.IsNotEmpty query
+    Assert.AreEqual("Berlintest", query.[0])
+
 
 [<Test >]
 let ``simple select query with operations in select``() = 


### PR DESCRIPTION
If we have a complex query, e.g. with let, join, group by, ..:

```fsharp
let qry = query{
   for x in xs do
   let y = x, "hello"
   select y
}
```

Now, the projections executed after the query are:

1) `(_arg -> arg.Item1)`
2) `(entityObj -> AnonymousTuple(entityObj , String))`

How it used to fail is because _arg is unbound as this lambda has no entity-objects. What it does after this commit is it will inject the object with function composition f >> g for the lambda expressions:
`(entityObj -> AnonymousTuple(entityObj , String).Item1)`
and from this we do already know the required entity object to fetch from db.
 
---

Joins have been implemented (years ago) with some kind of hack by cutting the joining lambda away:

```fsharp
let ty = typedefof<SqlQueryable<_>>.MakeGenericType((lambda :?> LambdaExpression).ReturnType )
if v1.Name.StartsWith "_arg" && v1.Type <> typeof<SqlEntity> then
    // this is the projection from a join - ignore
    ty.GetConstructors().[0].Invoke [| source.DataContext; source.Provider; source.SqlExpression; source.TupleIndex; |] :?> IQueryable<_>
else
    ty.GetConstructors().[0].Invoke [| source.DataContext; source.Provider; Projection(whole,source.SqlExpression); source.TupleIndex;|] :?> IQueryable<_>
```

This could be now done correctly (deleting the `if v1.Name.StartsWith "_arg"`) BUT first we would have to get the return parameter type for the first lambda. Currently it is expected to be a SqlEntity-object: `Expression.Parameter(typeof<SqlEntity>,"result")` and for joins it is actually an anonymous object. This could be parsed dynamically for the lamda (not included in the source code):

```fsharp
let initDbParam = 
    // Usually it's just SqlEntity but it can be also tuple in joins etc.
    let rec foundInitParamType : Expression -> ParameterExpression = function
        | :? LambdaExpression as lambda when lambda.Parameters.Count = 1 ->
            let t = lambda.Parameters.[0].Type
            Expression.Parameter(lambda.Parameters.[0].Type,"result")
        | :? MethodCallExpression as meth when meth.Arguments.Count = 1 ->
            Expression.Parameter(meth.Arguments.[0].Type,"result")
        | :? UnaryExpression as ce -> 
            foundInitParamType ce.Operand
        | _ -> Expression.Parameter(typeof<SqlEntity>,"result")

    match projs.Head with
    // We have this wrap and the lambda is the second argument:
    | :? MethodCallExpression as meth when meth.Arguments.Count = 2 ->
        foundInitParamType meth.Arguments.[1]
    | _ -> foundInitParamType projs.Head
    Expression.Parameter(typeof<SqlEntity>,"result")
```
...and then this would work, but the problem is then that we should also refactor the query responses to allow other than SqlEntities from executeQuery:

```fsharp
    use reader = cmd.ExecuteReader()
    let results = dc.ReadEntities(baseTable.FullName, columns, reader)
    let results = seq { for e in results -> projector.DynamicInvoke(e) } |> Seq.cache :> System.Collections.IEnumerable
``` 

where dc.ReadEntities returns SqlEntities and not something like 'T or maybe an union type of anon-obects and SqlEntity-arrays?:

```fsharp
abstract ReadEntities               : string * ColumnLookup * IDataReader -> SqlEntity[]
```

...but I think this has to be changed somehow for group-by support anyways?
