### PR TITLE
Update Providers.Postgresql.fs

### DIFF
--- a/src/SQLProvider/Providers.Postgresql.fs
+++ b/src/SQLProvider/Providers.Postgresql.fs
@@ -182,8 +182,8 @@ module PostgreSQL =
 
     let createCommandParameter (param:QueryParameter) value =
         let value =
-            if not (isOptionValue value) then value else
-            match tryReadValueProperty value with Some(v) -> v | None -> null
+            if not (isOptionValue value) then (if value = null || value.GetType() = typeof<DBNull> then box DBNull.Value else value) else
+            match tryReadValueProperty value with Some(v) -> v | None -> box DBNull.Value
         let p = Activator.CreateInstance(parameterType.Value, [||]) :?> IDbDataParameter
         p.ParameterName <- param.Name
         Option.iter (fun dbt -> dbTypeSetter.Value.Invoke(p, [| dbt |]) |> ignore) param.TypeMapping.ProviderType


### PR DESCRIPTION
When executing SqlEntity.SetColumn or SetColumnOption with null / None value,
Exception would be throw in Npgsql in the section in file NpgsqlParameter.cs:

https://github.com/npgsql/npgsql/blob/dev/src/Npgsql/NpgsqlParameter.cs

        internal int ValidateAndGetLength()
        {
            if (_value == null) {
                throw new InvalidCastException($"Parameter {ParameterName} must be set");
            }

            if (_value is DBNull) {
                return 0;
            }
