### PR TITLE
Updated SQLite documentation.

### DIFF
--- a/docs/content/core/parameters.fsx
+++ b/docs/content/core/parameters.fsx
@@ -98,7 +98,8 @@ This sets the owner of the scheme when running queries against the server.
 
 ### SQLite
 
-No extra parameters.
+The additional [SQLiteLibrary parameter](sqlite.html#SQLiteLibrary) can be used to specify
+which SQLite library to load.
 
 ### PostgreSQL
 

--- a/docs/content/core/sqlite.fsx
+++ b/docs/content/core/sqlite.fsx
@@ -16,7 +16,10 @@ Basic connection string used to connect to the SQLite database.
 *)
 
 [<Literal>]
-let connectionString = "Data Source=" + __SOURCE_DIRECTORY__ + @"/../../../tests/SqlProvider.Tests/scripts/northwindEF.db;Version=3"
+let connectionString = 
+    "Data Source=" + 
+    __SOURCE_DIRECTORY__ + @"/../../../tests/SqlProvider.Tests/scripts/northwindEF.db;" + 
+    "Version=3;foreign keys=true"
 
 (**
 ### ResolutionPath


### PR DESCRIPTION
Added a link to SQLiteLibrary doc on the "SQL Provider Static Parameters" page, and reformatted exceedingly long line on the SQLite doc page.