### PR TITLE
Initial version of GroupBy working.

### DIFF
--- a/docs/content/core/querying.fsx
+++ b/docs/content/core/querying.fsx
@@ -91,7 +91,7 @@ exactlyOne               |X |                                                   
 exactlyOneOrDefault      |X |                                                       | 
 exists                   |X |                                                       | 
 find                     |X |                                                       | 
-groupBy                  |  | Initially only very simple groupBy is supported       | 
+groupBy                  |x | Initially only very simple groupBy (and having) is supported: on single-table with single-key-column. | 
 groupJoin                |  |                                                       | 
 groupValBy	             |  |                                                       | 
 head                     |X |                                                       | 
@@ -101,7 +101,7 @@ join                     |X |                                                   
 last                     |  |                                                       | 
 lastOrDefault            |  |                                                       | 
 leftOuterJoin            |  |                                                       | 
-let                      |X | ...but not using tmp variables in where-clauses       |
+let                      |x | ...but not using tmp variables in where-clauses       |
 maxBy                    |X |                                                       | 
 maxByNullable            |X |                                                       | 
 minBy                    |X |                                                       | 
@@ -122,7 +122,7 @@ thenBy	                 |X |                                                    
 thenByDescending	     |X |                                                       |   
 thenByNullable           |X |                                                       | 
 thenByNullableDescending |X |                                                       |
-where                    |X | Server side variables must be on left side and only left side of predicates (excluding boolean database fields and LINQ-Contains) | 
+where                    |x | Server side variables must be on left side and only left side of predicates (excluding parentheses, boolean database fields and LINQ-Contains) | 
 *)
 
 (**

--- a/docs/content/core/querying.fsx
+++ b/docs/content/core/querying.fsx
@@ -91,7 +91,7 @@ exactlyOne               |X |                                                   
 exactlyOneOrDefault      |X |                                                       | 
 exists                   |X |                                                       | 
 find                     |X |                                                       | 
-groupBy                  |x | Initially only very simple groupBy (and having) is supported: on single-table with single-key-column. | 
+groupBy                  |x | Initially only very simple groupBy (and having) is supported: On single-table with single-key-column and direct aggregates like `.Count()` or direct parameter calls like `.Sum(fun entity -> entity.UnitPrice)`. | 
 groupJoin                |  |                                                       | 
 groupValBy	             |  |                                                       | 
 head                     |X |                                                       | 

--- a/docs/content/core/querying.fsx
+++ b/docs/content/core/querying.fsx
@@ -91,7 +91,7 @@ exactlyOne               |X |                                                   
 exactlyOneOrDefault      |X |                                                       | 
 exists                   |X |                                                       | 
 find                     |X |                                                       | 
-groupBy                  |  |                                                       | 
+groupBy                  |  | Initially only very simple groupBy is supported       | 
 groupJoin                |  |                                                       | 
 groupValBy	             |  |                                                       | 
 head                     |X |                                                       | 

--- a/src/SQLProvider/Operators.fs
+++ b/src/SQLProvider/Operators.fs
@@ -37,6 +37,13 @@ type ConditionOperator =
         | NotIn         -> "NOT IN"
         | NestedNotIn      -> "NOT IN"
 
+type AggregateOperation =
+| Max
+| Min
+| Sum
+| Avg
+| CountOp
+
 // Dummy operators, these are placeholders that are replaced in the expression tree traversal with special server-side operations such as In, Like
 // The operators here are used to force the compiler to statically check against the correct types
 [<AutoOpenAttribute>]

--- a/src/SQLProvider/Operators.fs
+++ b/src/SQLProvider/Operators.fs
@@ -37,12 +37,12 @@ type ConditionOperator =
         | NotIn         -> "NOT IN"
         | NestedNotIn      -> "NOT IN"
 
-type AggregateOperation =
-| Max
-| Min
-| Sum
-| Avg
-| CountOp
+type AggregateOperation = // Aggregate (column name if not default)
+| Max of string Option
+| Min of string Option
+| Sum of string Option
+| Avg of string Option
+| CountOp of string Option
 
 // Dummy operators, these are placeholders that are replaced in the expression tree traversal with special server-side operations such as In, Like
 // The operators here are used to force the compiler to statically check against the correct types

--- a/src/SQLProvider/Providers.MSAccess.fs
+++ b/src/SQLProvider/Providers.MSAccess.fs
@@ -291,8 +291,14 @@ type internal MSAccessProvider() =
                         match String.IsNullOrEmpty(al) with
                         | true -> sprintf "[%s]" col
                         | false -> sprintf "[%s_%s]" al col
-                    FSharp.Data.Sql.Common.Utilities.parseAggregates fieldNotation fieldNotationAlias sqlQuery.AggregateOp
-                // Currently we support only aggregate or select. selectcolumns + String.Join(",", extracolumns) when groupBy is ready
+
+                    match sqlQuery.Grouping with
+                    | [] -> FSharp.Data.Sql.Common.Utilities.parseAggregates fieldNotation fieldNotationAlias sqlQuery.AggregateOp
+                    | g  -> 
+                        let keys = g |> List.map(fst) |> List.concat |> List.map(fieldNotation)
+                        let aggs = g |> List.map(snd) |> List.concat
+                        let res2 = FSharp.Data.Sql.Common.Utilities.parseAggregates fieldNotation fieldNotationAlias aggs |> List.toSeq
+                        [String.Join(", ", keys) + (match aggs with [] -> "" | _ -> ", ") + String.Join(", ", res2)] 
                 match extracolumns with
                 | [] when String.IsNullOrEmpty(selectcolumns) -> "*"
                 | [] -> selectcolumns
@@ -399,6 +405,12 @@ type internal MSAccessProvider() =
                             primaryKey)))
                     if (numLinks > 0)  then ~~ ")")//append close paren after each JOIN, if necessary
 
+            let groupByBuilder() =
+                sqlQuery.Grouping |> List.map(fst) |> List.concat
+                |> List.iteri(fun i (alias,column) ->
+                    if i > 0 then ~~ ", "
+                    ~~ (sprintf "[%s].[%s]" alias column))
+
             let orderByBuilder() =
                 sqlQuery.Ordering
                 |> List.iteri(fun i (alias,column,desc) ->
@@ -425,6 +437,12 @@ type internal MSAccessProvider() =
                 ~~"WHERE "
                 filterBuilder f
 
+            // GROUP BY
+            if sqlQuery.Grouping.Length > 0 then
+                ~~" GROUP BY "
+                groupByBuilder()
+
+            // ORDER BY
             if sqlQuery.Ordering.Length > 0 then
                 ~~"ORDER BY "
                 orderByBuilder()

--- a/src/SQLProvider/Providers.MSAccess.fs
+++ b/src/SQLProvider/Providers.MSAccess.fs
@@ -358,6 +358,8 @@ type internal MSAccessProvider() =
                                         (sprintf "[%s].[%s] NOT IN (%s)") alias col innersql
                                     | _ ->
                                         parameters.Add paras.[0]
+                                        if alias="" then (sprintf "%s %s %s") col (operator.ToString()) paras.[0].ParameterName
+                                        else
                                         (sprintf "[%s].[%s]%s %s") alias col
                                          (operator.ToString()) paras.[0].ParameterName)
                         )
@@ -441,6 +443,13 @@ type internal MSAccessProvider() =
             if sqlQuery.Grouping.Length > 0 then
                 ~~" GROUP BY "
                 groupByBuilder()
+
+            if sqlQuery.HavingFilters.Length > 0 then
+                let keys = sqlQuery.Grouping |> List.map(fst) |> List.concat
+
+                let f = [And([],Some (sqlQuery.HavingFilters |> CommonTasks.parseHaving keys))]
+                ~~" HAVING "
+                filterBuilder f
 
             // ORDER BY
             if sqlQuery.Ordering.Length > 0 then

--- a/src/SQLProvider/Providers.MsSqlServer.fs
+++ b/src/SQLProvider/Providers.MsSqlServer.fs
@@ -551,8 +551,14 @@ type internal MSSqlServerProvider(tableNames:string) =
                         match String.IsNullOrEmpty(al) with
                         | true -> sprintf "'%s'" col
                         | false -> sprintf "'[%s%s]'" al col
-                    FSharp.Data.Sql.Common.Utilities.parseAggregates fieldNotation fieldNotationAlias sqlQuery.AggregateOp
-                // Currently we support only aggregate or select. selectcolumns + String.Join(",", extracolumns) when groupBy is ready
+
+                    match sqlQuery.Grouping with
+                    | [] -> FSharp.Data.Sql.Common.Utilities.parseAggregates fieldNotation fieldNotationAlias sqlQuery.AggregateOp
+                    | g  -> 
+                        let keys = g |> List.map(fst) |> List.concat |> List.map(fieldNotation)
+                        let aggs = g |> List.map(snd) |> List.concat
+                        let res2 = FSharp.Data.Sql.Common.Utilities.parseAggregates fieldNotation fieldNotationAlias aggs |> List.toSeq
+                        [String.Join(", ", keys) + (match aggs with [] -> "" | _ -> ", ") + String.Join(", ", res2)] 
                 match extracolumns with
                 | [] -> selectcolumns
                 | h::t -> h
@@ -665,6 +671,12 @@ type internal MSSqlServerProvider(tableNames:string) =
                             primaryKey
                         ))))
 
+            let groupByBuilder() =
+                sqlQuery.Grouping |> List.map(fst) |> List.concat
+                |> List.iteri(fun i (alias,column) ->
+                    if i > 0 then ~~ ", "
+                    ~~ (sprintf "[%s].[%s]" alias column))
+
             let orderByBuilder() =
                 sqlQuery.Ordering
                 |> List.iteri(fun i (alias,column,desc) ->
@@ -690,6 +702,12 @@ type internal MSSqlServerProvider(tableNames:string) =
                 ~~"WHERE "
                 filterBuilder f
 
+            // GROUP BY
+            if sqlQuery.Grouping.Length > 0 then
+                ~~" GROUP BY "
+                groupByBuilder()
+
+            // ORDER BY
             if sqlQuery.Ordering.Length > 0 then
                 ~~"ORDER BY "
                 orderByBuilder()

--- a/src/SQLProvider/Providers.MsSqlServer.fs
+++ b/src/SQLProvider/Providers.MsSqlServer.fs
@@ -625,6 +625,8 @@ type internal MSSqlServerProvider(tableNames:string) =
                                     | FSharp.Data.Sql.NestedNotIn -> operatorInQuery operator paras
                                     | _ ->
                                         parameters.Add paras.[0]
+                                        if alias="" then (sprintf "%s %s %s") col (operator.ToString()) paras.[0].ParameterName
+                                        else
                                         (sprintf "[%s].[%s]%s %s") alias col
                                          (operator.ToString()) paras.[0].ParameterName)
                         )
@@ -706,6 +708,13 @@ type internal MSSqlServerProvider(tableNames:string) =
             if sqlQuery.Grouping.Length > 0 then
                 ~~" GROUP BY "
                 groupByBuilder()
+
+            if sqlQuery.HavingFilters.Length > 0 then
+                let keys = sqlQuery.Grouping |> List.map(fst) |> List.concat
+
+                let f = [And([],Some (sqlQuery.HavingFilters |> CommonTasks.parseHaving keys))]
+                ~~" HAVING "
+                filterBuilder f
 
             // ORDER BY
             if sqlQuery.Ordering.Length > 0 then

--- a/src/SQLProvider/Providers.MySql.fs
+++ b/src/SQLProvider/Providers.MySql.fs
@@ -587,6 +587,8 @@ type internal MySqlProvider(resolutionPath, owner, referencedAssemblies) as this
                                     | FSharp.Data.Sql.NestedNotIn -> operatorInQuery operator paras
                                     | _ ->
                                         parameters.Add paras.[0]
+                                        if alias="" then (sprintf "%s %s %s") col (operator.ToString()) paras.[0].ParameterName
+                                        else
                                         (sprintf "`%s`.`%s`%s %s") alias col
                                          (operator.ToString()) paras.[0].ParameterName)
                         )
@@ -665,6 +667,13 @@ type internal MySqlProvider(resolutionPath, owner, referencedAssemblies) as this
             if sqlQuery.Grouping.Length > 0 then
                 ~~" GROUP BY "
                 groupByBuilder()
+
+            if sqlQuery.HavingFilters.Length > 0 then
+                let keys = sqlQuery.Grouping |> List.map(fst) |> List.concat
+
+                let f = [And([],Some (sqlQuery.HavingFilters |> CommonTasks.parseHaving keys))]
+                ~~" HAVING "
+                filterBuilder f
 
             // ORDER BY
             if sqlQuery.Ordering.Length > 0 then

--- a/src/SQLProvider/Providers.Odbc.fs
+++ b/src/SQLProvider/Providers.Odbc.fs
@@ -354,6 +354,8 @@ type internal OdbcProvider(quotehcar : OdbcQuoteCharacter) =
                                         (sprintf "%c%s%c.%c%s%c NOT IN (%s)") cOpen alias cClose cOpen col cClose innersql
                                     | _ ->
                                         parameters.Add paras.[0]
+                                        if alias="" then (sprintf "%s %s %s") col (operator.ToString()) paras.[0].ParameterName
+                                        else
                                         (sprintf "%c%s%c.%s %s %s") cOpen alias cClose col
                                          (operator.ToString()) paras.[0].ParameterName)
                         )
@@ -438,6 +440,13 @@ type internal OdbcProvider(quotehcar : OdbcQuoteCharacter) =
             if sqlQuery.Grouping.Length > 0 then
                 ~~" GROUP BY "
                 groupByBuilder()
+
+            if sqlQuery.HavingFilters.Length > 0 then
+                let keys = sqlQuery.Grouping |> List.map(fst) |> List.concat
+
+                let f = [And([],Some (sqlQuery.HavingFilters |> CommonTasks.parseHaving keys))]
+                ~~" HAVING "
+                filterBuilder f
 
             // ORDER BY
             if sqlQuery.Ordering.Length > 0 then

--- a/src/SQLProvider/Providers.Odbc.fs
+++ b/src/SQLProvider/Providers.Odbc.fs
@@ -295,8 +295,14 @@ type internal OdbcProvider(quotehcar : OdbcQuoteCharacter) =
                         match String.IsNullOrEmpty(al) with
                         | true -> sprintf "%c%s%c" cOpen col cClose
                         | false -> sprintf "%c%s_%s%c" cOpen al col cClose
-                    FSharp.Data.Sql.Common.Utilities.parseAggregates fieldNotation fieldNotationAlias sqlQuery.AggregateOp
-                // Currently we support only aggregate or select. selectcolumns + String.Join(",", extracolumns) when groupBy is ready
+
+                    match sqlQuery.Grouping with
+                    | [] -> FSharp.Data.Sql.Common.Utilities.parseAggregates fieldNotation fieldNotationAlias sqlQuery.AggregateOp
+                    | g  -> 
+                        let keys = g |> List.map(fst) |> List.concat |> List.map(fieldNotation)
+                        let aggs = g |> List.map(snd) |> List.concat
+                        let res2 = FSharp.Data.Sql.Common.Utilities.parseAggregates fieldNotation fieldNotationAlias aggs |> List.toSeq
+                        [String.Join(", ", keys) + (match aggs with [] -> "" | _ -> ", ") + String.Join(", ", res2)] 
                 match extracolumns with
                 | [] -> selectcolumns
                 | h::t -> h
@@ -395,6 +401,12 @@ type internal OdbcProvider(quotehcar : OdbcQuoteCharacter) =
                             (if data.RelDirection = RelationshipDirection.Parents then destAlias else fromAlias)
                             cClose cOpen primaryKey cClose))))
 
+            let groupByBuilder() =
+                sqlQuery.Grouping |> List.map(fst) |> List.concat
+                |> List.iteri(fun i (alias,column) ->
+                    if i > 0 then ~~ ", "
+                    ~~ (sprintf "%c%s%c.%c%s%c" cOpen alias cClose cOpen column cClose ))
+
             let orderByBuilder() =
                 sqlQuery.Ordering
                 |> List.iteri(fun i (alias,column,desc) ->
@@ -422,6 +434,12 @@ type internal OdbcProvider(quotehcar : OdbcQuoteCharacter) =
                 ~~"WHERE "
                 filterBuilder f
 
+            // GROUP BY
+            if sqlQuery.Grouping.Length > 0 then
+                ~~" GROUP BY "
+                groupByBuilder()
+
+            // ORDER BY
             if sqlQuery.Ordering.Length > 0 then
                 ~~"ORDER BY "
                 orderByBuilder()

--- a/src/SQLProvider/Providers.Oracle.fs
+++ b/src/SQLProvider/Providers.Oracle.fs
@@ -611,8 +611,14 @@ type internal OracleProvider(resolutionPath, owner, referencedAssemblies, tableN
                         match String.IsNullOrEmpty(al) with
                         | true -> sprintf "\"%s\"" col
                         | false -> sprintf "\"%s.%s\"" al col
-                    FSharp.Data.Sql.Common.Utilities.parseAggregates fieldNotation fieldNotationAlias sqlQuery.AggregateOp
-                // Currently we support only aggregate or select. selectcolumns + String.Join(",", extracolumns) when groupBy is ready
+
+                    match sqlQuery.Grouping with
+                    | [] -> FSharp.Data.Sql.Common.Utilities.parseAggregates fieldNotation fieldNotationAlias sqlQuery.AggregateOp
+                    | g  -> 
+                        let keys = g |> List.map(fst) |> List.concat |> List.map(fieldNotation)
+                        let aggs = g |> List.map(snd) |> List.concat
+                        let res2 = FSharp.Data.Sql.Common.Utilities.parseAggregates fieldNotation fieldNotationAlias aggs |> List.toSeq
+                        [String.Join(", ", keys) + (match aggs with [] -> "" | _ -> ", ") + String.Join(", ", res2)] 
                 match extracolumns with
                 | [] -> selectcolumns
                 | h::t -> h
@@ -715,6 +721,12 @@ type internal OracleProvider(resolutionPath, owner, referencedAssemblies, tableN
                             (if data.RelDirection = RelationshipDirection.Parents then destAlias else fromAlias)
                             primaryKey))))
 
+            let groupByBuilder() =
+                sqlQuery.Grouping |> List.map(fst) |> List.concat
+                |> List.iteri(fun i (alias,column) ->
+                    if i > 0 then ~~ ", "
+                    ~~ (sprintf "%s.%s" alias (quoteWhiteSpace column)))
+
             let orderByBuilder() =
                 sqlQuery.Ordering
                 |> List.iteri(fun i (alias,column,desc) ->
@@ -737,6 +749,12 @@ type internal OracleProvider(resolutionPath, owner, referencedAssemblies, tableN
                 ~~"WHERE "
                 filterBuilder f
 
+            // GROUP BY
+            if sqlQuery.Grouping.Length > 0 then
+                ~~" GROUP BY "
+                groupByBuilder()
+
+            // ORDER BY
             if sqlQuery.Ordering.Length > 0 then
                 ~~"ORDER BY "
                 orderByBuilder()

--- a/src/SQLProvider/Providers.Oracle.fs
+++ b/src/SQLProvider/Providers.Oracle.fs
@@ -675,6 +675,8 @@ type internal OracleProvider(resolutionPath, owner, referencedAssemblies, tableN
                                         (sprintf "%s.%s NOT IN (%s)") alias (quoteWhiteSpace col) innersql
                                     | _ ->
                                         parameters.Add paras.[0]
+                                        if alias="" then (sprintf "%s %s %s") (quoteWhiteSpace col) (operator.ToString()) paras.[0].ParameterName
+                                        else
                                         (sprintf "%s.%s %s %s") alias (quoteWhiteSpace col)
                                          (operator.ToString()) paras.[0].ParameterName)
                         )
@@ -753,6 +755,13 @@ type internal OracleProvider(resolutionPath, owner, referencedAssemblies, tableN
             if sqlQuery.Grouping.Length > 0 then
                 ~~" GROUP BY "
                 groupByBuilder()
+
+            if sqlQuery.HavingFilters.Length > 0 then
+                let keys = sqlQuery.Grouping |> List.map(fst) |> List.concat
+
+                let f = [And([],Some (sqlQuery.HavingFilters |> CommonTasks.parseHaving keys))]
+                ~~" HAVING "
+                filterBuilder f
 
             // ORDER BY
             if sqlQuery.Ordering.Length > 0 then

--- a/src/SQLProvider/Providers.Postgresql.fs
+++ b/src/SQLProvider/Providers.Postgresql.fs
@@ -706,6 +706,8 @@ type internal PostgresqlProvider(resolutionPath, owner, referencedAssemblies) =
                                         (sprintf "\"%s\".\"%s\" NOT IN (%s)") alias col innersql
                                     | _ ->
                                         parameters.Add paras.[0]
+                                        if alias="" then (sprintf "%s %s %s") col (operator.ToString()) paras.[0].ParameterName
+                                        else
                                         (sprintf "\"%s\".\"%s\" %s %s") alias col
                                          (operator.ToString()) paras.[0].ParameterName)
                         )
@@ -785,6 +787,13 @@ type internal PostgresqlProvider(resolutionPath, owner, referencedAssemblies) =
             if sqlQuery.Grouping.Length > 0 then
                 ~~" GROUP BY "
                 groupByBuilder()
+
+            if sqlQuery.HavingFilters.Length > 0 then
+                let keys = sqlQuery.Grouping |> List.map(fst) |> List.concat
+
+                let f = [And([],Some (sqlQuery.HavingFilters |> CommonTasks.parseHaving keys))]
+                ~~" HAVING "
+                filterBuilder f
 
             // ORDER BY
             if sqlQuery.Ordering.Length > 0 then

--- a/src/SQLProvider/Providers.Postgresql.fs
+++ b/src/SQLProvider/Providers.Postgresql.fs
@@ -643,8 +643,14 @@ type internal PostgresqlProvider(resolutionPath, owner, referencedAssemblies) =
                         match String.IsNullOrEmpty(al) with
                         | true -> sprintf "\"%s\"" col
                         | false -> sprintf "\"%s.%s\"" al col
-                    FSharp.Data.Sql.Common.Utilities.parseAggregates fieldNotation fieldNotationAlias sqlQuery.AggregateOp
-                // Currently we support only aggregate or select. selectcolumns + String.Join(",", extracolumns) when groupBy is ready
+
+                    match sqlQuery.Grouping with
+                    | [] -> FSharp.Data.Sql.Common.Utilities.parseAggregates fieldNotation fieldNotationAlias sqlQuery.AggregateOp
+                    | g  -> 
+                        let keys = g |> List.map(fst) |> List.concat |> List.map(fieldNotation)
+                        let aggs = g |> List.map(snd) |> List.concat
+                        let res2 = FSharp.Data.Sql.Common.Utilities.parseAggregates fieldNotation fieldNotationAlias aggs |> List.toSeq
+                        [String.Join(", ", keys) + (match aggs with [] -> "" | _ -> ", ") + String.Join(", ", res2)] 
                 match extracolumns with
                 | [] -> selectcolumns
                 | h::t -> h
@@ -746,6 +752,12 @@ type internal PostgresqlProvider(resolutionPath, owner, referencedAssemblies) =
                             (if data.RelDirection = RelationshipDirection.Parents then destAlias else fromAlias)
                             primaryKey))))
 
+            let groupByBuilder() =
+                sqlQuery.Grouping |> List.map(fst) |> List.concat
+                |> List.iteri(fun i (alias,column) ->
+                    if i > 0 then ~~ ", "
+                    ~~ (sprintf "\"%s\".\"%s\"" alias column))
+
             let orderByBuilder() =
                 sqlQuery.Ordering
                 |> List.iteri(fun i (alias,column,desc) ->
@@ -769,6 +781,12 @@ type internal PostgresqlProvider(resolutionPath, owner, referencedAssemblies) =
                 ~~"WHERE "
                 filterBuilder f
 
+            // GROUP BY
+            if sqlQuery.Grouping.Length > 0 then
+                ~~" GROUP BY "
+                groupByBuilder()
+
+            // ORDER BY
             if sqlQuery.Ordering.Length > 0 then
                 ~~"ORDER BY "
                 orderByBuilder()

--- a/src/SQLProvider/Providers.SQLite.fs
+++ b/src/SQLProvider/Providers.SQLite.fs
@@ -434,6 +434,8 @@ type internal SQLiteProvider(resolutionPath, referencedAssemblies, runtimeAssemb
                                         (sprintf "[%s].[%s] NOT IN (%s)") alias col innersql
                                     | _ ->
                                         parameters.Add paras.[0]
+                                        if alias="" then (sprintf "%s %s %s") col (operator.ToString()) paras.[0].ParameterName
+                                        else
                                         (sprintf "[%s].[%s]%s %s") alias col
                                          (operator.ToString()) paras.[0].ParameterName)
                         )
@@ -512,6 +514,13 @@ type internal SQLiteProvider(resolutionPath, referencedAssemblies, runtimeAssemb
             if sqlQuery.Grouping.Length > 0 then
                 ~~" GROUP BY "
                 groupByBuilder()
+
+            if sqlQuery.HavingFilters.Length > 0 then
+                let keys = sqlQuery.Grouping |> List.map(fst) |> List.concat
+
+                let f = [And([],Some (sqlQuery.HavingFilters |> CommonTasks.parseHaving keys))]
+                ~~" HAVING "
+                filterBuilder f
 
             // ORDER BY
             if sqlQuery.Ordering.Length > 0 then

--- a/src/SQLProvider/Providers.SQLite.fs
+++ b/src/SQLProvider/Providers.SQLite.fs
@@ -372,8 +372,14 @@ type internal SQLiteProvider(resolutionPath, referencedAssemblies, runtimeAssemb
                         match String.IsNullOrEmpty(al) with
                         | true -> sprintf "'%s'" col
                         | false -> sprintf "'[%s].[%s]'" al col
-                    FSharp.Data.Sql.Common.Utilities.parseAggregates fieldNotation fieldNotationAlias sqlQuery.AggregateOp
-                // Currently we support only aggregate or select. selectcolumns + String.Join(",", extracolumns) when groupBy is ready
+                    
+                    match sqlQuery.Grouping with
+                    | [] -> FSharp.Data.Sql.Common.Utilities.parseAggregates fieldNotation fieldNotationAlias sqlQuery.AggregateOp
+                    | g  -> 
+                        let keys = g |> List.map(fst) |> List.concat |> List.map(fieldNotation)
+                        let aggs = g |> List.map(snd) |> List.concat
+                        let res2 = FSharp.Data.Sql.Common.Utilities.parseAggregates fieldNotation fieldNotationAlias aggs |> List.toSeq
+                        [String.Join(", ", keys) + (match aggs with [] -> "" | _ -> ", ") + String.Join(", ", res2)] 
                 match extracolumns with
                 | [] -> selectcolumns
                 | h::t -> h
@@ -474,6 +480,12 @@ type internal SQLiteProvider(resolutionPath, referencedAssemblies, runtimeAssemb
                             (if data.RelDirection = RelationshipDirection.Parents then destAlias else fromAlias)
                             primaryKey))))
 
+            let groupByBuilder() =
+                sqlQuery.Grouping |> List.map(fst) |> List.concat
+                |> List.iteri(fun i (alias,column) ->
+                    if i > 0 then ~~ ", "
+                    ~~ (sprintf "[%s].[%s]" alias column))
+
             let orderByBuilder() =
                 sqlQuery.Ordering
                 |> List.iteri(fun i (alias,column,desc) ->
@@ -496,6 +508,12 @@ type internal SQLiteProvider(resolutionPath, referencedAssemblies, runtimeAssemb
                 ~~"WHERE "
                 filterBuilder f
 
+            // GROUP BY
+            if sqlQuery.Grouping.Length > 0 then
+                ~~" GROUP BY "
+                groupByBuilder()
+
+            // ORDER BY
             if sqlQuery.Ordering.Length > 0 then
                 ~~" ORDER BY "
                 orderByBuilder()

--- a/src/SQLProvider/SqlRuntime.Async.fs
+++ b/src/SQLProvider/SqlRuntime.Async.fs
@@ -16,10 +16,7 @@ module AsyncOperations =
             }
         async {
             match s with
-            | :? SqlQueryable<'T> as coll ->
-                let! en = coll.GetAsyncEnumerator()
-                return yieldseq en
-            | :? SqlOrderedQueryable<'T> as coll ->
+            | :? IAsyncEnumerable<'T> as coll ->
                 let! en = coll.GetAsyncEnumerator()
                 return yieldseq en
             | c ->
@@ -30,11 +27,7 @@ module AsyncOperations =
     let private fetchTakeOne (s:Linq.IQueryable<'T>) =
         async {
             match s with
-            | :? SqlQueryable<'T> as coll ->
-                let svc = (coll :> IWithSqlService)
-                return! executeQueryAsync svc.DataContext svc.Provider (Take(1, svc.SqlExpression)) svc.TupleIndex
-            | :? SqlOrderedQueryable<'T> as coll ->
-                let svc = (coll :> IWithSqlService)
+            | :? IWithSqlService as svc ->
                 return! executeQueryAsync svc.DataContext svc.Provider (Take(1, svc.SqlExpression)) svc.TupleIndex
             | c ->
                 return c :> Collections.IEnumerable
@@ -55,12 +48,7 @@ module AsyncOperations =
     let getCountAsync (s:Linq.IQueryable<'T>) =
         async {
             match s with
-            | :? SqlQueryable<'T> as coll ->
-                let svc = (coll :> IWithSqlService)
-                let! res = executeQueryScalarAsync svc.DataContext svc.Provider (Count(svc.SqlExpression)) svc.TupleIndex
-                return res |> unbox
-            | :? SqlOrderedQueryable<'T> as coll ->
-                let svc = (coll :> IWithSqlService)
+            | :? IWithSqlService as svc ->
                 let! res = executeQueryScalarAsync svc.DataContext svc.Provider (Count(svc.SqlExpression)) svc.TupleIndex
                 return res |> unbox
             | c ->

--- a/src/SQLProvider/SqlRuntime.Common.fs
+++ b/src/SQLProvider/SqlRuntime.Common.fs
@@ -306,6 +306,12 @@ and LinkData =
         member x.Rev() =
             { x with PrimaryTable = x.ForeignTable; PrimaryKey = x.ForeignKey; ForeignTable = x.PrimaryTable; ForeignKey = x.PrimaryKey }
 
+and GroupData =
+    { PrimaryTable       : Table
+      KeyColumns         : (alias * string) list
+      AggregateColumns   : (AggregateOperation * alias * string) list
+      Projection         : Expression option }
+
 and alias = string
 and table = string
 
@@ -320,9 +326,10 @@ and Condition =
     | ConstantTrue
     | ConstantFalse
 
+and SelectData = LinkQuery of LinkData | GroupQuery of GroupData
 and internal SqlExp =
     | BaseTable    of alias * Table                      // name of the initiating IQueryable table - this isn't always the ultimate table that is selected
-    | SelectMany   of alias * alias * LinkData * SqlExp  // from alias, to alias and join data including to and from table names. Note both the select many and join syntax end up here
+    | SelectMany   of alias * alias * SelectData * SqlExp  // from alias, to alias and join data including to and from table names. Note both the select many and join syntax end up here
     | FilterClause of Condition * SqlExp                 // filters from the where clause(es)
     | Projection   of Expression * SqlExp                // entire LINQ projection expression tree
     | Distinct     of SqlExp                             // distinct indicator
@@ -331,7 +338,7 @@ and internal SqlExp =
     | Skip         of int * SqlExp
     | Take         of int * SqlExp
     | Count        of SqlExp
-    | AggregateOp  of Utilities.AggregateOperation * alias * string * SqlExp
+    | AggregateOp  of AggregateOperation * alias * string * SqlExp
     with member this.HasAutoTupled() =
             let rec aux = function
                 | BaseTable(_) -> false
@@ -353,15 +360,16 @@ and internal SqlQuery =
       Aliases       : Map<string, Table>
       Ordering      : (alias * string * bool) list
       Projection    : Expression list
+      Grouping      : (list<alias * string> * list<AggregateOperation * alias * string>) list //key columns, aggregate columns
       Distinct      : bool
       UltimateChild : (string * Table) option
       Skip          : int option
       Take          : int option
       Union         : (bool*string) option
       Count         : bool 
-      AggregateOp   : (Utilities.AggregateOperation * alias * string) list }
+      AggregateOp   : (AggregateOperation * alias * string) list }
     with
-        static member Empty = { Filters = []; Links = []; Aliases = Map.empty; Ordering = []; Count = false; AggregateOp = []
+        static member Empty = { Filters = []; Links = []; Grouping = []; Aliases = Map.empty; Ordering = []; Count = false; AggregateOp = []
                                 Projection = []; Distinct = false; UltimateChild = None; Skip = None; Take = None; Union = None }
 
         static member ofSqlExp(exp,entityIndex: string ResizeArray) =
@@ -377,14 +385,24 @@ and internal SqlQuery =
                                                 // but rather the later alias of the same object after it has been tupled.
                                                   { q with UltimateChild = Some(legaliseName entityIndex.[0], e) }
                                         | None -> { q with UltimateChild = Some(legaliseName a,e) }
-                | SelectMany(a,b,link,rest) ->
-                   match link.RelDirection with
-                   | RelationshipDirection.Children ->
+                | SelectMany(a,b,dat,rest) ->
+                   match dat with
+                   | LinkQuery(link) when link.RelDirection = RelationshipDirection.Children ->
                          convert { q with Aliases = q.Aliases.Add(legaliseName b,link.ForeignTable).Add(legaliseName a,link.PrimaryTable);
                                           Links = (legaliseName a, link, legaliseName b)  :: q.Links } rest
-                   | _ ->
+                   | LinkQuery(link) ->
                          convert { q with Aliases = q.Aliases.Add(legaliseName a,link.ForeignTable).Add(legaliseName b,link.PrimaryTable);
                                          Links = (legaliseName a, link, legaliseName b) :: q.Links  } rest
+                   | GroupQuery(grp) ->
+                         convert { q with 
+                                    Aliases = q.Aliases.Add(legaliseName a,grp.PrimaryTable).Add(legaliseName b,grp.PrimaryTable);
+                                    Links = q.Links  
+                                    Grouping = 
+                                        let baseAlias:alias = grp.PrimaryTable.Name
+                                        let f = grp.KeyColumns |> List.map (fun (a,k) -> legaliseName (match a<>"" with true -> a | false -> baseAlias), k)
+                                        let s = grp.AggregateColumns |> List.map (fun (op,a,key) -> op, legaliseName (match a<>"" with true -> a | false -> baseAlias), key)
+                                        (f,s)::q.Grouping
+                                    Projection = match grp.Projection with Some p -> p::q.Projection | None -> q.Projection } rest
                 | FilterClause(c,rest) ->  convert { q with Filters = (c)::q.Filters } rest
                 | Projection(exp,rest) ->
                     convert { q with Projection = exp::q.Projection } rest
@@ -455,6 +473,34 @@ and internal ISqlProvider =
     ///Builds a command representing a call to a stored procedure
     abstract ExecuteSprocCommand : IDbCommand * QueryParameter[] * QueryParameter[] *  obj[] -> ReturnValueType
 
+
+type GroupResultItems<'key>(keyname:String, keyval, distinctItem:SqlEntity) =
+    inherit ResizeArray<SqlEntity> ([|distinctItem|]) 
+    let fetchItem itemType =
+        let itm =
+            distinctItem.ColumnValues 
+            |> Seq.filter(fun (s,k) -> 
+                let sUp = s.ToUpperInvariant()
+                sUp.Contains(keyname.ToUpperInvariant()) && sUp.Contains(itemType)) |> Seq.head |> snd
+        match itm with
+        | :? string as s when Int32.TryParse s |> fst -> Int32.Parse s |> box
+        | :? string as s when Decimal.TryParse s |> fst -> Decimal.Parse s |> box
+        | :? string as s when DateTime.TryParse s |> fst -> DateTime.Parse s |> box
+        | :? int as i -> i |> box
+        | :? int16 as i -> int32 i |> box
+        | :? int64 as i -> int32 i |> box  
+        | :? float as i -> decimal i |> box
+        | :? decimal as i -> decimal i |> box
+        | :? double as i -> decimal i |> box
+        | i -> i |> box
+    member __.Values = [|distinctItem|]
+    interface System.Linq.IGrouping<'key, SqlEntity> with
+        member __.Key = keyval
+    member __.AggregateCount<'T>() = fetchItem "[COUNT]" :?> 'T
+    member __.AggregateSum<'T>() = fetchItem "[SUM]" :?> 'T
+    member __.AggregateAvg<'T>() = fetchItem "[AVG]" :?> 'T
+    member __.AggregateMin<'T>() = fetchItem "[MIN]" :?> 'T
+    member __.AggregateMax<'T>() = fetchItem "[MAX]" :?> 'T
 
 module internal CommonTasks =
 

--- a/src/SQLProvider/SqlRuntime.Common.fs
+++ b/src/SQLProvider/SqlRuntime.Common.fs
@@ -295,6 +295,7 @@ and ISqlDataContext =
     abstract ReadEntities               : string * ColumnLookup * IDataReader -> SqlEntity[]
     abstract ReadEntitiesAsync          : string * ColumnLookup * DbDataReader -> Async<SqlEntity[]>
 
+// LinkData is for joins with SelectMany
 and LinkData =
     { PrimaryTable       : Table
       PrimaryKey         : string list
@@ -306,6 +307,7 @@ and LinkData =
         member x.Rev() =
             { x with PrimaryTable = x.ForeignTable; PrimaryKey = x.ForeignKey; ForeignTable = x.PrimaryTable; ForeignKey = x.PrimaryKey }
 
+// GroupData is for group-by projections
 and GroupData =
     { PrimaryTable       : Table
       KeyColumns         : (alias * string) list
@@ -474,6 +476,10 @@ and internal ISqlProvider =
     abstract ExecuteSprocCommand : IDbCommand * QueryParameter[] * QueryParameter[] *  obj[] -> ReturnValueType
 
 
+/// GroupResultItems is an item to create key-igrouping-structure.
+/// From the select group-by projection, aggregate operations like Enumerable.Count() 
+/// is replaced to GroupResultItems.AggregateCount call and this is used to fetch the 
+/// SQL result instead of actually counting anything
 type GroupResultItems<'key>(keyname:String, keyval, distinctItem:SqlEntity) =
     inherit ResizeArray<SqlEntity> ([|distinctItem|]) 
     let fetchItem itemType =

--- a/src/SQLProvider/SqlRuntime.Linq.fs
+++ b/src/SQLProvider/SqlRuntime.Linq.fs
@@ -794,14 +794,14 @@ module internal QueryImplementation =
                         let sqlExpression =
                                
                                match meth.Name, source.SqlExpression with
-                               | "Sum", BaseTable("",entity)  -> AggregateOp(Sum,"",key,BaseTable(alias,entity))
-                               | "Sum", _ ->  AggregateOp(Sum,alias,key,source.SqlExpression)
-                               | "Max", BaseTable("",entity)  -> AggregateOp(Max,"",key,BaseTable(alias,entity))
-                               | "Max", _ ->  AggregateOp(Max,alias,key,source.SqlExpression)
-                               | "Min", BaseTable("",entity)  -> AggregateOp(Min,"",key,BaseTable(alias,entity))
-                               | "Min", _ ->  AggregateOp(Min,alias,key,source.SqlExpression)
-                               | "Average", BaseTable("",entity)  -> AggregateOp(Avg,"",key,BaseTable(alias,entity))
-                               | "Average", _ ->  AggregateOp(Avg,alias,key,source.SqlExpression)
+                               | "Sum", BaseTable("",entity)  -> AggregateOp(Sum(None),"",key,BaseTable(alias,entity))
+                               | "Sum", _ ->  AggregateOp(Sum(None),alias,key,source.SqlExpression)
+                               | "Max", BaseTable("",entity)  -> AggregateOp(Max(None),"",key,BaseTable(alias,entity))
+                               | "Max", _ ->  AggregateOp(Max(None),alias,key,source.SqlExpression)
+                               | "Min", BaseTable("",entity)  -> AggregateOp(Min(None),"",key,BaseTable(alias,entity))
+                               | "Min", _ ->  AggregateOp(Min(None),alias,key,source.SqlExpression)
+                               | "Average", BaseTable("",entity)  -> AggregateOp(Avg(None),"",key,BaseTable(alias,entity))
+                               | "Average", _ ->  AggregateOp(Avg(None),alias,key,source.SqlExpression)
                                | _ -> failwithf "Unsupported aggregation `%s` in execution expression `%s`" meth.Name (e.ToString())
                         let res = executeQueryScalar source.DataContext source.Provider sqlExpression source.TupleIndex 
                         match box Unchecked.defaultof<'T>, res with 

--- a/src/SQLProvider/SqlRuntime.Patterns.fs
+++ b/src/SQLProvider/SqlRuntime.Patterns.fs
@@ -175,7 +175,7 @@ let (|SqlColumnGet|_|) = function
     | _ -> None
 
 let (|TupleSqlColumnsGet|_|) = function 
-    | OptionalFSharpOptionValue(NewExpr(cons, args)) when cons.DeclaringType.Name.StartsWith("AnonymousObject") ->
+    | OptionalFSharpOptionValue(NewExpr(cons, args)) when cons.DeclaringType.Name.StartsWith("Tuple") || cons.DeclaringType.Name.StartsWith("AnonymousObject") ->
         let items = args |> List.choose(function
                             | SqlColumnGet(ti,key,t) -> Some(ti, key, t)
                             | _-> None)

--- a/src/SQLProvider/SqlRuntime.QueryExpression.fs
+++ b/src/SQLProvider/SqlRuntime.QueryExpression.fs
@@ -1,6 +1,7 @@
 ﻿namespace FSharp.Data.Sql.QueryExpression
 
 open System
+open System.Reflection
 open System.Linq.Expressions
 open System.Collections.Generic
 
@@ -9,6 +10,8 @@ open FSharp.Data.Sql.Patterns
 open FSharp.Data.Sql.Schema
 
 module internal QueryExpressionTransformer =
+    open FSharp.Data.Sql
+
     let myLock = new Object();
     let getSubEntityMi =
         match <@ (Unchecked.defaultof<SqlEntity>).GetSubTable("", "") @> with
@@ -32,6 +35,7 @@ module internal QueryExpressionTransformer =
             // onto GetSubEntity on the result parameter with the correct alias
 
         let projectionMap = Dictionary<string,string ResizeArray>()
+        let groupProjectionMap = ResizeArray<AggregateOperation>()
         
         let (|SourceTupleGet|_|) (e:Expression) =
             match e with
@@ -52,6 +56,36 @@ module internal QueryExpressionTransformer =
                 elif ultimateChild.IsSome then
                     Some (alias,fst(ultimateChild.Value), Some(key,mi))
                 else None
+            | _ -> None
+
+        let (|GroupByAggregate|_|) (e:Expression) =
+            match e.NodeType, e with
+            | ExpressionType.Call, (:? MethodCallExpression as e) -> 
+                let isGrouping = 
+                    e.Arguments.Count > 0 &&
+                    e.Arguments.[0].Type.Name.StartsWith("IGrouping")
+                let op =
+                    match e.Method.Name with
+                    | "Count" -> Some CountOp
+                    | "Sum" -> Some Sum
+                    | "Avg" -> Some Avg
+                    | "Min" -> Some Min
+                    | "Max" -> Some Max
+                    | _ -> None
+                
+                match isGrouping, op with
+                | true, Some o when not(groupProjectionMap.Contains(o)) -> 
+                    let methodname = "Aggregate"+e.Method.Name
+
+                    let ty = typedefof<GroupResultItems<_>>.MakeGenericType(e.Arguments.[0].Type.GetGenericArguments().[0])
+                    let meth = ty.GetMethod(methodname)
+                    let generic = meth.MakeGenericMethod(e.Method.ReturnType);
+                    let replacementExpr = 
+                            Expression.Call(
+                                Expression.Convert(e.Arguments.[0], ty),
+                                generic)
+                    Some (o, replacementExpr)
+                | _ -> None
             | _ -> None
 
         // this is not tail recursive but it shouldn't matter in practice ....
@@ -146,7 +180,13 @@ module internal QueryExpressionTransformer =
                                                                                     if replaceParams.Count>0 then
                                                                                         ExpressionOptimizer.Methods.``remove AnonymousType`` memb
                                                                                     else upcast memb
-            | ExpressionType.Call,               (:? MethodCallExpression as e)  -> upcast Expression.Call( (if e.Object = null then null else transform en e.Object), e.Method, e.Arguments |> Seq.map(fun a -> transform en a))
+            | ExpressionType.Call,               (:? MethodCallExpression as e)  -> let transformed = Expression.Call( (if e.Object = null then null else transform en e.Object), e.Method, e.Arguments |> Seq.map(fun a -> transform en a))
+                                                                                    match transformed with
+                                                                                    | GroupByAggregate(param, callreplace) -> 
+                                                                                        groupProjectionMap.Add(param)
+                                                                                        upcast callreplace
+                                                                                    | _ -> 
+                                                                                        upcast transformed
             | ExpressionType.Lambda,             (:? LambdaExpression as e)      -> let exType = e.GetType()
                                                                                     if  exType.IsGenericType
                                                                                         && exType.GetGenericTypeDefinition() = typeof<Expression<obj>>.GetGenericTypeDefinition()
@@ -175,7 +215,7 @@ module internal QueryExpressionTransformer =
             | SingleTable(OptionalQuote(lambda))
             | MultipleTables(OptionalQuote(lambda)) -> transform None lambda
 
-        newProjection, projectionMap
+        newProjection, projectionMap, groupProjectionMap
 
     let convertExpression exp (entityIndex:string ResizeArray) con (provider:ISqlProvider) =
         // first convert the abstract query tree into a more useful format
@@ -185,6 +225,7 @@ module internal QueryExpressionTransformer =
         let entityIndex = new ResizeArray<_>(entityIndex |> Seq.map (legaliseName))
 
         let sqlQuery = SqlQuery.ofSqlExp(exp,entityIndex)
+        let groupgin = new ResizeArray<_>()
 
          // note : the baseAlias here will always be "" when no criteria has been applied, because the LINQ tree never needed to refer to it
         let baseAlias,baseTable =
@@ -196,20 +237,19 @@ module internal QueryExpressionTransformer =
         let (projectionDelegate,projectionColumns) =
             match sqlQuery.Projection with
             | [] ->
+
                 // this case happens when there are only where clauses with a single table and a projection containing just the table's entire rows. example:
                 // for x in dc.john
                 // where x.y = 1
                 // select x
                 // this does not create a call to .select() after .where(), therefore in this case we must provide our own projection that simply selects a whole row
-                let initDbParam = Expression.Parameter(typeof<SqlEntity>,"result")
+                let initDbParam = 
+                    match sqlQuery.Grouping.Length > 0 with
+                    | true -> Expression.Parameter(typeof<System.Linq.IGrouping<_,SqlEntity>>,"result")
+                    | false -> Expression.Parameter(typeof<SqlEntity>,"result")
                 let pmap = Dictionary<string,string ResizeArray>()
                 pmap.Add(baseAlias, new ResizeArray<_>())
                 (Expression.Lambda(initDbParam,initDbParam).Compile(),pmap)
-            | [proj] -> // This branch is actually not needed anymore. It's just special case of the lower one.
-                let initDbParam = Expression.Parameter(typeof<SqlEntity>,"result")
-                let newProjection, projectionMap = transform proj entityIndex initDbParam sqlQuery.Aliases sqlQuery.UltimateChild (Dictionary<ParameterExpression, LambdaExpression>())
-                QueryEvents.PublishExpression newProjection
-                (Expression.Lambda( (newProjection :?> LambdaExpression).Body,initDbParam).Compile(),projectionMap)
             | projs -> 
                 let replaceParams = Dictionary<ParameterExpression, LambdaExpression>()
 
@@ -217,7 +257,27 @@ module internal QueryExpressionTransformer =
                 // But currently SQL will always return a list of SqlEntities.
 
                 let initDbParam = 
-                    Expression.Parameter(typeof<SqlEntity>,"result")
+                    // The current join would break here, as it fakes anonymous object to be SqlEntity by skipping projection lambda.
+                    if sqlQuery.Aliases.Count > 0 && sqlQuery.Grouping.Length = 0 then //join
+                        Expression.Parameter(typeof<SqlEntity>,"result")
+                    else
+
+                    // Usually it's just SqlEntity but it can be also tuple in joins etc.
+                    let rec foundInitParamType : Expression -> ParameterExpression = function
+                        | :? LambdaExpression as lambda when lambda.Parameters.Count = 1 ->
+                            let t = lambda.Parameters.[0].Type
+                            Expression.Parameter(lambda.Parameters.[0].Type,"result")
+                        | :? MethodCallExpression as meth when meth.Arguments.Count = 1 ->
+                            Expression.Parameter(meth.Arguments.[0].Type,"result")
+                        | :? UnaryExpression as ce -> 
+                            foundInitParamType ce.Operand
+                        | _ -> Expression.Parameter(typeof<SqlEntity>,"result")
+
+                    match projs.Head with
+                    // We have this wrap and the lambda is the second argument:
+                    | :? MethodCallExpression as meth when meth.Arguments.Count = 2 ->
+                        foundInitParamType meth.Arguments.[1]
+                    | _ -> foundInitParamType projs.Head
 
                 // Multiple projections found. We need to do a function composition: prevProj >> currentProj
                 // for Lamda Expressions. So this is an expression tree visitor.
@@ -246,8 +306,25 @@ module internal QueryExpressionTransformer =
                         | _ -> ()
 
                     generateReplacementParams(currentProj)
-                    let newProjection, projectionMap = transform currentProj entityIndex dbParam sqlQuery.Aliases sqlQuery.UltimateChild replaceParams
+                    let newProjection, projectionMap, groupProjectionMap = transform currentProj entityIndex dbParam sqlQuery.Aliases sqlQuery.UltimateChild replaceParams
                     let fixedParams = Expression.Lambda((newProjection:?>LambdaExpression).Body,initDbParam)
+                    
+                    if sqlQuery.Grouping.Length > 0 then
+                            
+                        let gatheredAggregations = 
+                            sqlQuery.Grouping |> List.map(fun (group,_) ->
+                                // GroupBy: collect aggreagte operations
+                                let aggregations:(AggregateOperation * alias * string) list =
+                                    groupProjectionMap 
+                                    |> Seq.map(fun op -> 
+//                                        match group |> Seq.tryFind(fun (a,s) -> a=aliasAndOps.Key) with
+//                                        | Some(_, keyitm) -> aliasAndOps.Value |> Seq.map(fun ao -> ao, aliasAndOps.Key, keyitm)
+//                                        | None -> Seq.empty
+                                        group |> Seq.map(fun (a,n) -> op,a,n)
+                                    ) |> Seq.concat |> Seq.toList
+                                group, aggregations)
+                        groupgin.AddRange(gatheredAggregations)
+
                     //QueryEvents.PublishExpression fixedParams
                     fixedParams,projectionMap
                 
@@ -262,6 +339,11 @@ module internal QueryExpressionTransformer =
                 let generatedMegaLambda, finalParams = composeProjections projs (Unchecked.defaultof<LambdaExpression>) (Dictionary<string, ResizeArray<string>>())
                 QueryEvents.PublishExpression generatedMegaLambda
                 (generatedMegaLambda.Compile(),finalParams)
+
+        let sqlQuery = 
+            if groupgin.Count > 0 then
+                { sqlQuery with Grouping = groupgin |> Seq.toList }
+            else sqlQuery
 
         // a special case here to handle queries that start from the relationship of an individual
         let sqlQuery,baseAlias =

--- a/src/SQLProvider/SqlRuntime.QueryExpression.fs
+++ b/src/SQLProvider/SqlRuntime.QueryExpression.fs
@@ -314,6 +314,7 @@ module internal QueryExpressionTransformer =
                         let gatheredAggregations = 
                             sqlQuery.Grouping |> List.map(fun (group,_) ->
                                 // GroupBy: collect aggreagte operations
+                                // Should gather the column names what we want to aggregate, not just operations.
                                 let aggregations:(AggregateOperation * alias * string) list =
                                     groupProjectionMap 
                                     |> Seq.map(fun op -> 

--- a/src/SQLProvider/SqlRuntime.QueryExpression.fs
+++ b/src/SQLProvider/SqlRuntime.QueryExpression.fs
@@ -62,7 +62,7 @@ module internal QueryExpressionTransformer =
             match e.NodeType, e with
             | ExpressionType.Call, (:? MethodCallExpression as e) -> 
                 let isGrouping = 
-                    e.Arguments.Count > 0 &&
+                    e.Arguments.Count = 1 &&
                     e.Arguments.[0].Type.Name.StartsWith("IGrouping")
                 let op =
                     match e.Method.Name with

--- a/src/SQLProvider/Utils.fs
+++ b/src/SQLProvider/Utils.fs
@@ -76,15 +76,17 @@ module internal Utilities =
             match query with
             | [] -> selectColumns
             | (agop, opAlias, sumCol)::tail ->
-                let aggregate = 
+                let aggregate, selCol = 
                     match (agop) with
-                    | FSharp.Data.Sql.AggregateOperation.Sum -> "SUM"
-                    | FSharp.Data.Sql.AggregateOperation.Max -> "MAX"
-                    | FSharp.Data.Sql.AggregateOperation.Min -> "MIN"
-                    | FSharp.Data.Sql.AggregateOperation.Avg -> "AVG"
-                    | FSharp.Data.Sql.AggregateOperation.CountOp -> "COUNT"
+                    | FSharp.Data.Sql.AggregateOperation.Sum x -> "SUM", x
+                    | FSharp.Data.Sql.AggregateOperation.Max x -> "MAX", x
+                    | FSharp.Data.Sql.AggregateOperation.Min x -> "MIN", x
+                    | FSharp.Data.Sql.AggregateOperation.Avg x -> "AVG", x
+                    | FSharp.Data.Sql.AggregateOperation.CountOp x -> "COUNT", x
+
+                let col = match selCol with None -> sumCol | Some x -> x
                 let parsed = 
-                         (aggregate + "(" + fieldNotation(opAlias, sumCol) + ") as " + fieldNotationAlias(sumCol, aggregate)) :: selectColumns
+                         (aggregate + "(" + fieldNotation(opAlias, col) + ") as " + fieldNotationAlias(col, aggregate)) :: selectColumns
                 parseAggregates' fieldNotation fieldNotationAlias tail parsed
         parseAggregates' fieldNotation fieldNotationAlias query []
 

--- a/tests/SqlProvider.Tests/QueryTests.fs
+++ b/tests/SqlProvider.Tests/QueryTests.fs
@@ -23,181 +23,181 @@ FSharp.Data.Sql.Common.QueryEvents.SqlQueryEvent |> Event.add (printfn "Executin
 [<Test>]
 let ``simple select with contains query``() =
     let dc = sql.GetDataContext()
-    let query = 
+    let qry = 
         query {
             for cust in dc.Main.Customers do
             select cust.CustomerId
             contains "ALFKI"
         }
-    Assert.IsTrue(query)    
+    Assert.IsTrue(qry)    
 
 [<Test>]
 let ``simple select with contains query with where``() =
     let dc = sql.GetDataContext()
-    let query = 
+    let qry = 
         query {
             for cust in dc.Main.Customers do
             where (cust.City <> "")
             select cust.CustomerId
             contains "ALFKI"
         }
-    Assert.IsTrue(query)    
+    Assert.IsTrue(qry)    
 
 [<Test>]
 let ``simple select with contains query when not exists``() =
     let dc = sql.GetDataContext()
-    let query = 
+    let qry = 
         query {
             for cust in dc.Main.Customers do
             select cust.CustomerId
             contains "ALFKI2"
         }
-    Assert.IsFalse(query)    
+    Assert.IsFalse(qry)    
 
 [<Test >]
 let ``simple select with count``() =
     let dc = sql.GetDataContext()
-    let query = 
+    let qry = 
         query {
             for cust in dc.Main.Customers do
             select cust.CustomerId
             count
         }
-    Assert.AreEqual(91, query)   
+    Assert.AreEqual(91, qry)   
 
 [<Test; Ignore("Not Supported")>]
 let ``simple select with last``() =
     let dc = sql.GetDataContext()
-    let query = 
+    let qry = 
         query {
             for cust in dc.Main.Customers do
             sortBy cust.CustomerId
             select cust.CustomerId
             last
         }
-    Assert.AreEqual("WOLZA", query)   
+    Assert.AreEqual("WOLZA", qry)   
 
 [<Test; Ignore("Not Supported")>]
 let ``simple select with last or default when not exists``() =
     let dc = sql.GetDataContext()
-    let query = 
+    let qry = 
         query {
             for cust in dc.Main.Customers do
             where (cust.CustomerId = "ZZZZ")
             select cust.CustomerId
             lastOrDefault
         }
-    Assert.AreEqual(null, query)   
+    Assert.AreEqual(null, qry)   
 
 [<Test>]
 let ``simple exists when exists``() =
     let dc = sql.GetDataContext()
-    let query = 
+    let qry = 
         query {
             for cust in dc.Main.Customers do
             exists (cust.CustomerId = "WOLZA")
         }
-    Assert.AreEqual(true, query)  
+    Assert.AreEqual(true, qry)  
 
 [<Test; Ignore("Not Supported")>]
 let ``simple select with last or default when exists``() =
     let dc = sql.GetDataContext()
-    let query = 
+    let qry = 
         query {
             for cust in dc.Main.Customers do
             where (cust.CustomerId = "WOLZA")
             select cust.CustomerId
             lastOrDefault
         }
-    Assert.AreEqual("WOLZA", query)  
+    Assert.AreEqual("WOLZA", qry)  
 
 [<Test >]
 let ``simple select with exactly one``() =
     let dc = sql.GetDataContext()
-    let query = 
+    let qry = 
         query {
             for cust in dc.Main.Customers do
             where (cust.CustomerId = "ALFKI")
             select cust.CustomerId
             exactlyOne
         }
-    Assert.AreEqual("ALFKI", query)  
+    Assert.AreEqual("ALFKI", qry)  
 
 [<Test>]
 let ``simple select with exactly one when not exists``() =
     let dc = sql.GetDataContext()
-    let query = 
+    let qry = 
         query {
             for cust in dc.Main.Customers do
             where (cust.CustomerId = "ZZZZ")
             select cust.CustomerId
             exactlyOneOrDefault
         }
-    Assert.AreEqual(null, query)  
+    Assert.AreEqual(null, qry)  
 
 [<Test >]
 let ``simple select with head``() =
     let dc = sql.GetDataContext()
-    let query = 
+    let qry = 
         query {
             for cust in dc.Main.Customers do
             where (cust.CustomerId = "ALFKI")
             select cust.CustomerId
             head
         }
-    Assert.AreEqual("ALFKI", query)  
+    Assert.AreEqual("ALFKI", qry)  
 
 [<Test>]
 let ``simple select with head or Default``() =
     let dc = sql.GetDataContext()
-    let query = 
+    let qry = 
         query {
             for cust in dc.Main.Customers do
             where (cust.CustomerId = "ALFKI")
             select cust.CustomerId
             headOrDefault
         }
-    Assert.AreEqual("ALFKI", query)  
+    Assert.AreEqual("ALFKI", qry)  
 
 [<Test>]
 let ``simple select with head or Default when not exists``() =
     let dc = sql.GetDataContext()
-    let query = 
+    let qry = 
         query {
             for cust in dc.Main.Customers do
             where (cust.CustomerId = "ZZZZ")
             select cust.CustomerId
             headOrDefault
         }
-    Assert.AreEqual(null, query)  
+    Assert.AreEqual(null, qry)  
 
 [<Test >]
 let ``simple select query``() = 
     let dc = sql.GetDataContext()
-    let query = 
+    let qry = 
         query {
             for cust in dc.Main.Customers do
             select cust
         } |> Seq.toArray
     
-    CollectionAssert.IsNotEmpty query
+    CollectionAssert.IsNotEmpty qry
 
 [<Test>]
 let ``simplest select query let temp``() = 
     let dc = sql.GetDataContext()
-    let query = 
+    let qry = 
         query {
             for cust in dc.Main.Customers do
             let y = cust.City
             select cust.Address
         } |> Seq.toArray
     
-    CollectionAssert.IsNotEmpty query
+    CollectionAssert.IsNotEmpty qry
 
 [<Test>]
 let ``simple select query let temp nested``() = 
     let dc = sql.GetDataContext()
-    let query = 
+    let qry = 
         query {
             for cust in dc.Main.Customers do
             let y1 = cust.Address
@@ -205,27 +205,27 @@ let ``simple select query let temp nested``() =
             select (y1, y2)
         } |> Seq.toArray
     
-    CollectionAssert.IsNotEmpty query
+    CollectionAssert.IsNotEmpty qry
 
 [<Test>]
 let ``simple select query let temp``() = 
     let dc = sql.GetDataContext()
-    let query = 
+    let qry = 
         query {
             for cust in dc.Main.Customers do
             let y = cust.City + "test"
             select y
         } |> Seq.toArray
     
-    CollectionAssert.IsNotEmpty query
-    //Assert.AreEqual("Aachentest", query.[0])
-    //Assert.AreEqual("Berlintest", query.[0])
+    CollectionAssert.IsNotEmpty qry
+    //Assert.AreEqual("Aachentest", qry.[0])
+    //Assert.AreEqual("Berlintest", qry.[0])
 
 
 [<Test>]
 let ``simple select query let where``() = 
     let dc = sql.GetDataContext()
-    let query = 
+    let qry = 
         query {
             for cust in dc.Main.Customers do
             let y = cust.City + "test"
@@ -233,13 +233,13 @@ let ``simple select query let where``() =
             select y
         } |> Seq.toArray
     
-    CollectionAssert.IsNotEmpty query
-    Assert.AreEqual("Berlintest", query.[0])
+    CollectionAssert.IsNotEmpty qry
+    Assert.AreEqual("Berlintest", qry.[0])
 
 [<Test; Ignore("Not supported")>]
 let ``simple select query let temp used in where``() = 
     let dc = sql.GetDataContext()
-    let query = 
+    let qry = 
         query {
             for cust in dc.Main.Customers do
             let y = cust.City + "test"
@@ -247,65 +247,65 @@ let ``simple select query let temp used in where``() =
             select y
         } |> Seq.toArray
     
-    CollectionAssert.IsNotEmpty query
-    Assert.AreEqual("Berlintest", query.[0])
+    CollectionAssert.IsNotEmpty qry
+    Assert.AreEqual("Berlintest", qry.[0])
 
 
 [<Test >]
 let ``simple select query with operations in select``() = 
     let dc = sql.GetDataContext()
-    let query = 
+    let qry = 
         query {
             for cust in dc.Main.Customers do
             select (cust.Country + " " + cust.Address + (1).ToString())
         } |> Seq.toArray
     
-    CollectionAssert.IsNotEmpty query
+    CollectionAssert.IsNotEmpty qry
 
 [<Test >]
 let ``simple select where query``() =
     let dc = sql.GetDataContext()
-    let query = 
+    let qry = 
         query {
             for cust in dc.Main.Customers do
             where (cust.CustomerId = "ALFKI")
             select cust
         } |> Seq.toArray
 
-    CollectionAssert.IsNotEmpty query
-    Assert.AreEqual(1, query.Length)
-    Assert.AreEqual("Berlin", query.[0].City)
+    CollectionAssert.IsNotEmpty qry
+    Assert.AreEqual(1, qry.Length)
+    Assert.AreEqual("Berlin", qry.[0].City)
 
 [<Test >]
 let ``simple nth query``() =
     let dc = sql.GetDataContext()
-    let query = 
+    let qry = 
         query {
             for cust in dc.Main.Customers do
             select cust
             nth 4
         }
-    Assert.AreEqual("London", query.City)
+    Assert.AreEqual("London", qry.City)
 
 
 [<Test >]
 let ``simple select where not query``() =
     let dc = sql.GetDataContext()
-    let query = 
+    let qry = 
         query {
             for cust in dc.Main.Customers do
             where (not(cust.CustomerId = "ALFKI"))
             select cust
         } |> Seq.toArray
 
-    CollectionAssert.IsNotEmpty query
-    Assert.AreEqual(90, query.Length)
+    CollectionAssert.IsNotEmpty qry
+    Assert.AreEqual(90, qry.Length)
 
 [<Test >]
 let ``simple select where in query``() =
     let dc = sql.GetDataContext()
     let arr = ["ALFKI"; "ANATR"; "AROUT"]
-    let query = 
+    let qry = 
         query {
             for cust in dc.Main.Customers do
             where (arr.Contains(cust.CustomerId))
@@ -313,9 +313,9 @@ let ``simple select where in query``() =
         } |> Seq.toArray
     let res = query
 
-    CollectionAssert.IsNotEmpty query
-    Assert.AreEqual(3, query.Length)
-    Assert.IsTrue(query.Contains("ANATR"))
+    CollectionAssert.IsNotEmpty qry
+    Assert.AreEqual(3, qry.Length)
+    Assert.IsTrue(qry.Contains("ANATR"))
 
     
     
@@ -323,7 +323,7 @@ let ``simple select where in query``() =
 let ``simple select where not-in query``() =
     let dc = sql.GetDataContext()
     let arr = ["ALFKI"; "ANATR"; "AROUT"]
-    let query = 
+    let qry = 
         query {
             for cust in dc.Main.Customers do
             where (not(arr.Contains(cust.CustomerId)))
@@ -331,9 +331,9 @@ let ``simple select where not-in query``() =
         } |> Seq.toArray
     let res = query
 
-    CollectionAssert.IsNotEmpty query
-    Assert.AreEqual(88, query.Length)
-    Assert.IsFalse(query.Contains("ANATR"))
+    CollectionAssert.IsNotEmpty qry
+    Assert.AreEqual(88, qry.Length)
+    Assert.IsFalse(qry.Contains("ANATR"))
 
 [<Test >]
 let ``simple select where in queryable query``() =
@@ -363,130 +363,167 @@ let ``simple select where in queryable query``() =
 let ``simple select where in query custom syntax``() =
     let dc = sql.GetDataContext()
     let arr = ["ALFKI"; "ANATR"; "AROUT"]
-    let query = 
+    let qry = 
         query {
             for cust in dc.Main.Customers do
             where (cust.CustomerId |=| arr)
             select cust.CustomerId
         } |> Seq.toArray
 
-    CollectionAssert.IsNotEmpty query
-    Assert.AreEqual(3, query.Length)
-    Assert.IsTrue(query.Contains("ANATR"))
+    CollectionAssert.IsNotEmpty qry
+    Assert.AreEqual(3, qry.Length)
+    Assert.IsTrue(qry.Contains("ANATR"))
 
 [<Test >]
 let ``simple select where like query``() =
     let dc = sql.GetDataContext()
-    let query = 
+    let qry = 
         query {
             for cust in dc.Main.Customers do
             where (cust.CustomerId.Contains("a"))
             select cust.CustomerId
         } |> Seq.toArray
 
-    CollectionAssert.IsNotEmpty query
+    CollectionAssert.IsNotEmpty qry
 
 [<Test >]
 let ``simple select where query with operations in where``() =
     let dc = sql.GetDataContext()
-    let query = 
+    let qry = 
         query {
             for cust in dc.Main.Customers do
             where (cust.CustomerId = "ALFKI" && (cust.City.StartsWith("B")))
             select cust
         } |> Seq.toArray
 
-    CollectionAssert.IsNotEmpty query
-    Assert.AreEqual(1, query.Length)
-    Assert.AreEqual("Berlin", query.[0].City)
+    CollectionAssert.IsNotEmpty qry
+    Assert.AreEqual(1, qry.Length)
+    Assert.AreEqual("Berlin", qry.[0].City)
 
 [<Test>]
 let ``simple select query with minBy``() = 
     let dc = sql.GetDataContext()
-    let query = 
+    let qry = 
         query {
             for ord in dc.Main.OrderDetails do
             minBy (decimal ord.Discount)
         }   
-    Assert.AreEqual(0m, query)
+    Assert.AreEqual(0m, qry)
 
 [<Test>]
 let ``simple select query with minBy DateTime``() = 
     let dc = sql.GetDataContext()
-    let query = 
+    let qry = 
         query {
             for emp in dc.Main.Employees do
             minBy (emp.BirthDate)
         }   
-    Assert.AreEqual(DateTime(1937, 09, 19), query)
+    Assert.AreEqual(DateTime(1937, 09, 19), qry)
 
 [<Test>]
 let ``simple select query with maxBy``() = 
     let dc = sql.GetDataContext()
-    let query = 
+    let qry = 
         query {
             for od in dc.Main.OrderDetails do
             sumBy od.UnitPrice
         }
-    Assert.Greater(56501m, query)
-    Assert.Less(56499m, query)
+    Assert.Greater(56501m, qry)
+    Assert.Less(56499m, qry)
 
 [<Test>]
 let ``simple select query with averageBy``() = 
     let dc = sql.GetDataContext()
-    let query = 
+    let qry = 
         query {
             for od in dc.Main.OrderDetails do
             averageBy od.UnitPrice
         }
-    Assert.Greater(27m, query)
-    Assert.Less(26m, query)
+    Assert.Greater(27m, qry)
+    Assert.Less(26m, qry)
 
-[<Test; Ignore("Not Supported")>]
+[<Test>]
+let ``simplest select query with groupBy``() = 
+    let dc = sql.GetDataContext()
+    let qry = 
+        query {
+            for cust in dc.Main.Customers do
+            groupBy cust.City
+        } |> Seq.toArray
+
+    Assert.IsNotEmpty(qry)
+
+[<Test>]
 let ``simple select query with groupBy``() = 
     let dc = sql.GetDataContext()
-    let query = 
+    let qry = 
         query {
             for cust in dc.Main.Customers do
             groupBy cust.City into c
             select (c.Key, c.Count())
+        }
+    let res = qry |> dict  
+    Assert.IsNotEmpty(res)
+    Assert.AreEqual(6, res.["London"])
+    
+
+[<Test>]
+let ``simple select query with groupBy date``() = 
+    let dc = sql.GetDataContext()
+    let qry = 
+        query {
+            for emp in dc.Main.Employees do
+            groupBy emp.BirthDate into e
+            select (e.Key, e.Count())
+        }
+    let res = qry |> dict  
+    Assert.IsNotEmpty(res)
+
+[<Test; Ignore("Not Supported")>]
+let ``simple select query with groupBy2``() = 
+    let dc = sql.GetDataContext()
+    let qry = 
+        query {
+            for cust in dc.Main.Customers do
+            groupBy (cust.City, cust.Country) into c
+            select (c.Key, c.Count()+1)
         } |> dict  
-    Assert.AreEqual(6, query.["London"])
+    Assert.IsNotNull(qry)
 
 [<Test; Ignore("Not Supported")>]
 let ``simple select query with groupValBy``() = 
     let dc = sql.GetDataContext()
-    let query = 
+    let qry = 
         query {
             for cust in dc.Main.Customers do
             groupValBy cust.ContactTitle cust.City into g
             select (g.Key, g.Count())
         } |> dict  
-    Assert.IsNotEmpty(query)
+    Assert.IsNotEmpty(qry)
 
 [<Test; Ignore("Not Supported")>]
 let ``complex select query with groupValBy``() = 
     let dc = sql.GetDataContext()
-    let query = 
+    let qry = 
         query {
             for cust in dc.Main.Customers do
             groupValBy (cust.ContactTitle, Int32.Parse(cust.PostalCode)) (cust.PostalCode, cust.City) into g
             let maxPlusOne = 1 + query {for i in g do sumBy (snd i) }
             select (snd(g.Key), maxPlusOne)
         } |> dict  
-    Assert.IsNotEmpty(query)
+    Assert.IsNotEmpty(qry)
 
 [<Test;>]
 let ``simple if query``() = 
     let dc = sql.GetDataContext()
-    let query = 
+    let qry = 
         query {
             for cust in dc.Main.Customers do
             if cust.Country = "UK" then select cust.City
         } |> Seq.toArray
-    CollectionAssert.IsNotEmpty query
-    CollectionAssert.Contains(query, "London")
-    CollectionAssert.DoesNotContain(query, "Helsinki")
+    CollectionAssert.IsNotEmpty qry
+    CollectionAssert.Contains(qry, "London")
+    CollectionAssert.DoesNotContain(qry, "Helsinki")
 
 [<Test;>]
 let ``simple select query with case``() = 
@@ -494,44 +531,44 @@ let ``simple select query with case``() =
     // Expected: SELECT CASE [cust].[Country] WHEN "UK" THEN [cust].[City] ELSE "Outside UK" END as 'City' FROM main.Customers as [cust]
     // Actual: SELECT [cust].[Country] as 'Country',[cust].[City] as 'City' FROM main.Customers as [cust]
     let dc = sql.GetDataContext()
-    let query = 
+    let qry = 
         query {
             for cust in dc.Main.Customers do
             select (if cust.Country = "UK" then (cust.City)
                 else ("Outside UK"))
         } |> Seq.toArray
-    CollectionAssert.IsNotEmpty query
+    CollectionAssert.IsNotEmpty qry
 
 [<Test >]
 let ``simple select and sort query``() =
     let dc = sql.GetDataContext()
-    let query = 
+    let qry = 
         query {
             for cust in dc.Main.Customers do
             sortBy cust.City
             select cust.City
         } |> Seq.toArray
 
-    CollectionAssert.IsNotEmpty query    
-    CollectionAssert.AreEquivalent([|"Aachen"; "Albuquerque"; "Anchorage"|], query.[0..2])
+    CollectionAssert.IsNotEmpty qry    
+    CollectionAssert.AreEquivalent([|"Aachen"; "Albuquerque"; "Anchorage"|], qry.[0..2])
 
 [<Test >]
 let ``simple select and sort desc query``() =
     let dc = sql.GetDataContext()
-    let query = 
+    let qry = 
         query {
             for cust in dc.Main.Customers do
             sortByDescending cust.City
             select cust.City
         } |> Seq.toArray
 
-    CollectionAssert.IsNotEmpty query    
-    CollectionAssert.AreEquivalent([|"Århus"; "Warszawa"; "Walla Walla"|], query.[0..2])
+    CollectionAssert.IsNotEmpty qry    
+    CollectionAssert.AreEquivalent([|"Århus"; "Warszawa"; "Walla Walla"|], qry.[0..2])
 
 [<Test>]
 let ``simple select and sort query with then by query``() =
     let dc = sql.GetDataContext()
-    let query = 
+    let qry = 
         query {
             for cust in dc.Main.Customers do
             sortBy cust.Country
@@ -539,13 +576,13 @@ let ``simple select and sort query with then by query``() =
             select cust.City
         } |> Seq.toArray
 
-    CollectionAssert.IsNotEmpty query    
-    CollectionAssert.AreEquivalent([|"Buenos Aires"; "Buenos Aires"; "Buenos Aires"; "Graz"|], query.[0..3])
+    CollectionAssert.IsNotEmpty qry    
+    CollectionAssert.AreEquivalent([|"Buenos Aires"; "Buenos Aires"; "Buenos Aires"; "Graz"|], qry.[0..3])
 
 [<Test>]
 let ``simple select and sort query with then by desc query``() =
     let dc = sql.GetDataContext()
-    let query = 
+    let qry = 
         query {
             for cust in dc.Main.Customers do
             sortBy cust.Country
@@ -553,71 +590,101 @@ let ``simple select and sort query with then by desc query``() =
             select cust.City
         } |> Seq.toArray
 
-    CollectionAssert.IsNotEmpty query    
-    CollectionAssert.AreEquivalent([|"Buenos Aires"; "Buenos Aires"; "Buenos Aires"; "Salzburg"|], query.[0..3])
+    CollectionAssert.IsNotEmpty qry    
+    CollectionAssert.AreEquivalent([|"Buenos Aires"; "Buenos Aires"; "Buenos Aires"; "Salzburg"|], qry.[0..3])
 
 [<Test >]
 let ``simple select query with join``() = 
     let dc = sql.GetDataContext()
-    let query = 
+    let qry = 
         query {
             for cust in dc.Main.Customers do
             join order in dc.Main.Orders on (cust.CustomerId = order.CustomerId)
             select (cust.CustomerId, order.OrderDate)
         } |> Seq.toArray
     
-    CollectionAssert.IsNotEmpty query
+    CollectionAssert.IsNotEmpty qry
     CollectionAssert.AreEquivalent(
         [|
             "VINET", new DateTime(1996,7,4)
             "TOMSP", new DateTime(1996,7,5)
             "HANAR", new DateTime(1996,7,8)
             "VICTE", new DateTime(1996,7,8)
-        |], query.[0..3])
+        |], qry.[0..3])
+
+
+[<Test; Ignore("Grouping over multiple tables is not supported yet")>]
+let ``simple select query with join and then groupBy``() = 
+    let dc = sql.GetDataContext()
+    let qry = 
+        query {
+            for cust in dc.Main.Customers do
+            join order in dc.Main.Orders on (cust.CustomerId = order.CustomerId)
+            groupBy cust.City into c
+            select (c.Key, c.Count())
+        }
+    let res = qry |> dict  
+    Assert.IsNotEmpty(res)
+    Assert.AreEqual(6, res.["London"])
+
+[<Test; Ignore("Joining over grouping is not supported yet")>]
+let ``simple select query with groupBy and then join``() = 
+    let dc = sql.GetDataContext()
+    let qry = 
+        query {
+            for cust in dc.Main.Customers do
+            groupBy cust.City into c
+            join order in dc.Main.Orders on (c.Key = order.ShipCity)
+            select (c.Key, c.Count())
+        }
+    let res = qry |> dict  
+    Assert.IsNotEmpty(res)
+    Assert.AreEqual(6, res.["London"])
+
 
 [<Test >]
 let ``simple select query with join multi columns``() = 
     let dc = sql.GetDataContext()
-    let query = 
+    let qry = 
         query {
             for cust in dc.Main.Customers do
             join order in dc.Main.Orders on ((cust.CustomerId, cust.CustomerId) = (order.CustomerId, order.CustomerId))
             select (cust.CustomerId, order.OrderDate)
         } |> Seq.toArray
     
-    CollectionAssert.IsNotEmpty query
+    CollectionAssert.IsNotEmpty qry
     CollectionAssert.AreEquivalent(
         [|
             "VINET", new DateTime(1996,7,4)
             "TOMSP", new DateTime(1996,7,5)
             "HANAR", new DateTime(1996,7,8)
             "VICTE", new DateTime(1996,7,8)
-        |], query.[0..3])
+        |], qry.[0..3])
 
 
 [<Test >]
 let ``simple select query with join using relationships``() = 
     let dc = sql.GetDataContext()
-    let query = 
+    let qry = 
         query {
             for cust in dc.Main.Customers do
             for order in cust.``main.Orders by CustomerID`` do
             select (cust.CustomerId, order.OrderDate)
         } |> Seq.toArray
     
-    CollectionAssert.IsNotEmpty query
+    CollectionAssert.IsNotEmpty qry
     CollectionAssert.AreEquivalent(
         [|
             "VINET", new DateTime(1996,7,4)
             "TOMSP", new DateTime(1996,7,5)
             "HANAR", new DateTime(1996,7,8)
             "VICTE", new DateTime(1996,7,8)
-        |], query.[0..3])
+        |], qry.[0..3])
 
 [<Test; Ignore("Not Supported")>]
 let ``simple select query with group join``() = 
     let dc = sql.GetDataContext()
-    let query = 
+    let qry = 
         query {
             for cust in dc.Main.Customers do
             groupJoin ord in dc.Main.Orders on (cust.CustomerId = ord.CustomerId) into g
@@ -626,7 +693,7 @@ let ``simple select query with group join``() =
             select (cust.CustomerId, orderDetail.ProductId, orderDetail.Quantity)
         } |> Seq.toArray
     
-    CollectionAssert.IsNotEmpty query
+    CollectionAssert.IsNotEmpty qry
     CollectionAssert.AreEquivalent(
         [|
             "VINET", 11L, 12
@@ -637,12 +704,12 @@ let ``simple select query with group join``() =
             "HANAR", 41L, 10
             "HANAR", 51L, 35
             "HANAR", 65L, 15
-        |], query.[0..7])
+        |], qry.[0..7])
 
 [<Test >]
 let ``simple select query with multiple joins on relationships``() = 
     let dc = sql.GetDataContext()
-    let query = 
+    let qry = 
         query {
             for cust in dc.Main.Customers do
             for order in cust.``main.Orders by CustomerID`` do
@@ -650,7 +717,7 @@ let ``simple select query with multiple joins on relationships``() =
             select (cust.CustomerId, orderDetail.ProductId, orderDetail.Quantity)
         } |> Seq.toArray
     
-    CollectionAssert.IsNotEmpty query
+    CollectionAssert.IsNotEmpty qry
     CollectionAssert.AreEquivalent(
         [|
             "VINET", 11L, 12s
@@ -661,12 +728,12 @@ let ``simple select query with multiple joins on relationships``() =
             "HANAR", 41L, 10s
             "HANAR", 51L, 35s
             "HANAR", 65L, 15s
-        |], query.[0..7])
+        |], qry.[0..7])
 
 [<Test; Ignore("Not Supported")>]
 let ``simple select query with left outer join``() = 
     let dc = sql.GetDataContext()
-    let query = 
+    let qry = 
         query {
             for cust in dc.Main.Customers do
             leftOuterJoin order in dc.Main.Orders on (cust.CustomerId = order.CustomerId) into result
@@ -674,19 +741,19 @@ let ``simple select query with left outer join``() =
             select (cust.CustomerId, order.OrderDate)
         } |> Seq.toArray
     
-    CollectionAssert.IsNotEmpty query
+    CollectionAssert.IsNotEmpty qry
     CollectionAssert.AreEquivalent(
         [|
             "VINET", new DateTime(1996,7,4)
             "TOMSP", new DateTime(1996,7,5)
             "HANAR", new DateTime(1996,7,8)
             "VICTE", new DateTime(1996,7,8)
-        |], query.[0..3])
+        |], qry.[0..3])
 
 [<Test>]
 let ``simple sumBy``() = 
     let dc = sql.GetDataContext()
-    let query = 
+    let qry = 
         query {
             for od in dc.Main.OrderDetails do
             sumBy od.UnitPrice
@@ -696,7 +763,7 @@ let ``simple sumBy``() =
 [<Test>]
 let ``simple averageBy``() = 
     let dc = sql.GetDataContext()
-    let query = 
+    let qry = 
         query {
             for od in dc.Main.OrderDetails do
             averageBy od.UnitPrice
@@ -706,7 +773,7 @@ let ``simple averageBy``() =
 [<Test>]
 let ``simple averageByNullable``() = 
     let dc = sql.GetDataContext()
-    let query = 
+    let qry = 
         query {
             for od in dc.Main.OrderDetails do
             averageByNullable (System.Nullable(od.UnitPrice))
@@ -716,21 +783,21 @@ let ``simple averageByNullable``() =
 [<Test >]
 let ``simple select with distinct``() =
     let dc = sql.GetDataContext()
-    let query = 
+    let qry = 
         query {
             for cust in dc.Main.Customers do
             select cust.City
             distinct
         } |> Seq.toArray
 
-    CollectionAssert.IsNotEmpty query   
-    Assert.AreEqual(69, query.Length) 
-    CollectionAssert.AreEquivalent([|"Aachen"; "Albuquerque"; "Anchorage"|], query.[0..2])
+    CollectionAssert.IsNotEmpty qry   
+    Assert.AreEqual(69, qry.Length) 
+    CollectionAssert.AreEquivalent([|"Aachen"; "Albuquerque"; "Anchorage"|], qry.[0..2])
 
 [<Test>]
 let ``simple select with skip``() =
     let dc = sql.GetDataContext()
-    let query = 
+    let qry = 
         query {
             for cust in dc.Main.Customers do
             select cust.City
@@ -738,14 +805,14 @@ let ``simple select with skip``() =
         } 
         |> Seq.toArray
 
-    CollectionAssert.IsNotEmpty query   
-    Assert.AreEqual(86, query.Length) 
-    CollectionAssert.AreEquivalent([|"Bergamo"; "Berlin"; "Bern"|], query.[0..2])
+    CollectionAssert.IsNotEmpty qry   
+    Assert.AreEqual(86, qry.Length) 
+    CollectionAssert.AreEquivalent([|"Bergamo"; "Berlin"; "Bern"|], qry.[0..2])
 
 [<Test >]
 let ``simple select with take``() =
     let dc = sql.GetDataContext()
-    let query = 
+    let qry = 
         query {
             for cust in dc.Main.Customers do
             select cust.City
@@ -753,39 +820,39 @@ let ``simple select with take``() =
         } 
         |> Seq.toArray
 
-    CollectionAssert.IsNotEmpty query   
-    Assert.AreEqual(5, query.Length) 
-    CollectionAssert.AreEquivalent([|"Aachen"; "Albuquerque"; "Anchorage"; "Barcelona"; "Barquisimeto"|], query)  
+    CollectionAssert.IsNotEmpty qry   
+    Assert.AreEqual(5, qry.Length) 
+    CollectionAssert.AreEquivalent([|"Aachen"; "Albuquerque"; "Anchorage"; "Barcelona"; "Barquisimeto"|], qry)  
 
 [<Test>]
 let ``simple select query with all``() = 
     let dc = sql.GetDataContext()
-    let query = 
+    let qry = 
         query {
             for ord in dc.Main.OrderDetails do
             all (ord.UnitPrice > 0m)
         }   
-    Assert.IsTrue(query)
+    Assert.IsTrue(qry)
 
 [<Test>]
 let ``simple select query with all false``() = 
     let dc = sql.GetDataContext()
-    let query = 
+    let qry = 
         query {
             for ord in dc.Main.OrderDetails do
             all (ord.UnitPrice > 10m)
         }   
-    Assert.IsFalse(query)
+    Assert.IsFalse(qry)
 
 [<Test>]
 let ``simple select query with find``() = 
     let dc = sql.GetDataContext()
-    let query = 
+    let qry = 
         query {
             for ord in dc.Main.OrderDetails do
             find (ord.UnitPrice > 10m)
         }   
-    Assert.AreEqual(14m, query.UnitPrice)
+    Assert.AreEqual(14m, qry.UnitPrice)
 
 type Simple = {First : string}
 
@@ -794,24 +861,24 @@ type Dummy<'t> = D of 't
 [<Test >]
 let ``simple select into a generic type`` () =
     let dc = sql.GetDataContext()
-    let query = 
+    let qry = 
         query {
             for emp in dc.Main.Customers do
             select (D {First=emp.ContactName})
         } |> Seq.toList
 
-    CollectionAssert.IsNotEmpty query
+    CollectionAssert.IsNotEmpty qry
 
 [<Test >]
 let ``simple select into a generic type with pipe`` () =
     let dc = sql.GetDataContext()
-    let query = 
+    let qry = 
         query {
             for emp in dc.Main.Customers do
             select ({First=emp.ContactName} |> D)
         } |> Seq.toList
 
-    CollectionAssert.IsNotEmpty query
+    CollectionAssert.IsNotEmpty qry
 
 [<Test >]
 let ``simple select with bool outside query``() = 
@@ -823,7 +890,7 @@ let ``simple select with bool outside query``() =
     let myCond3 = rnd.NextDouble() > 0.5
     let myCond4 = 4
 
-    let query = 
+    let qry = 
         query {
             for cust in dc.Main.Customers do
             // Simple booleans outside queries are supported:
@@ -832,7 +899,7 @@ let ``simple select with bool outside query``() =
             select (if not(myCond3) then cust.Country else cust.Address)
         } |> Seq.toArray
     
-    CollectionAssert.IsNotEmpty query
+    CollectionAssert.IsNotEmpty qry
 
 
 [<Test >]
@@ -845,7 +912,7 @@ let ``simple select with bool outside query2``() =
     let myCond3 = rnd.NextDouble() > 0.5
     let myCond4 = 4
 
-    let query = 
+    let qry = 
         query {
             for cust in dc.Main.Customers do
             // Simple booleans outside queries are supported:
@@ -854,7 +921,7 @@ let ``simple select with bool outside query2``() =
             select (if not(myCond4=8) then cust.Country else cust.Address)
         } |> Seq.toArray
     
-    CollectionAssert.IsNotEmpty query
+    CollectionAssert.IsNotEmpty qry
 
 [<Test >]
 let ``simple select query async``() = 
@@ -876,14 +943,14 @@ type sqlOption = SqlDataProvider<Common.DatabaseProviderTypes.SQLITE, connection
 [<Test>]
 let ``simple select with contains query with where boolean option type``() =
     let dc = sqlOption.GetDataContext()
-    let query = 
+    let qry = 
         query {
             for cust in dc.Main.Customers do
             where (cust.City.IsSome)
             select cust.CustomerId
             contains "ALFKI"
         }
-    Assert.IsTrue(query)    
+    Assert.IsTrue(qry)    
 
 [<Test>]
 let ``simple union query test``() = 
@@ -923,4 +990,27 @@ let ``simple union all query test``() =
     let res2 = query1.Concat(query2) |> Seq.toArray
     Assert.IsNotEmpty(res2)
     
+[<Test>]
+let ``verify groupBy results``() = 
+    let dc = sql.GetDataContext()
+    let enumtest =
+        query {
+            for cust in dc.Main.Customers do
+            select (cust)
+        } |> Seq.toList
+    let inlogics = 
+        query {
+            for cust in enumtest do
+            groupBy cust.City into c
+            select (c.Key, c.Count())
+        } |> Seq.toArray |> Array.sortBy (fun (k,v) -> k )
 
+    let groupqry = 
+        query {
+            for cust in dc.Main.Customers do
+            groupBy cust.City into c
+            select (c.Key, c.Count())
+        } |> Seq.toArray |> Array.sortBy (fun (k,v) -> k )
+    let res = groupqry |> dict  
+
+    CollectionAssert.AreEqual(inlogics,groupqry)

--- a/tests/SqlProvider.Tests/QueryTests.fs
+++ b/tests/SqlProvider.Tests/QueryTests.fs
@@ -466,6 +466,35 @@ let ``simple select query with groupBy``() =
     Assert.IsNotEmpty(res)
     Assert.AreEqual(6, res.["London"])
     
+[<Test>]
+let ``simple select query with groupBy having count``() = 
+    let dc = sql.GetDataContext()
+    let qry = 
+        query {
+            for cust in dc.Main.Customers do
+            groupBy cust.City into c
+            where (c.Count() > 1)
+            where (c.Count() < 6)
+            select (c.Key, c.Count())
+        }
+    let res = qry |> dict  
+    Assert.IsNotEmpty(res)
+    Assert.AreEqual(3, res.["Buenos Aires"])
+
+[<Test>]
+let ``simple select query with groupBy having key``() = 
+    let dc = sql.GetDataContext()
+    let qry = 
+        query {
+            for cust in dc.Main.Customers do
+            groupBy cust.City into c
+            where (c.Key = "London") 
+            select (c.Key, c.Count()) 
+            // Not supported: select (c.Key, c.Count(fun c -> c.City = "London"))
+        }
+    let res = qry |> dict  
+    Assert.IsNotEmpty(res)
+    Assert.AreEqual(6, res.["London"])
 
 [<Test>]
 let ``simple select query with groupBy date``() = 

--- a/tests/SqlProvider.Tests/QueryTests.fs
+++ b/tests/SqlProvider.Tests/QueryTests.fs
@@ -758,7 +758,7 @@ let ``simple sumBy``() =
             for od in dc.Main.OrderDetails do
             sumBy od.UnitPrice
         }
-    Assert.That(query, Is.EqualTo(56500.91M).Within(0.001M))
+    Assert.That(qry, Is.EqualTo(56500.91M).Within(0.001M))
 
 [<Test>]
 let ``simple averageBy``() = 
@@ -768,7 +768,7 @@ let ``simple averageBy``() =
             for od in dc.Main.OrderDetails do
             averageBy od.UnitPrice
         }
-    Assert.That(query, Is.EqualTo(26.2185m).Within(0.001M))
+    Assert.That(qry, Is.EqualTo(26.2185m).Within(0.001M))
 
 [<Test>]
 let ``simple averageByNullable``() = 
@@ -778,7 +778,7 @@ let ``simple averageByNullable``() =
             for od in dc.Main.OrderDetails do
             averageByNullable (System.Nullable(od.UnitPrice))
         }
-    Assert.That(query, Is.EqualTo(26.2185m).Within(0.001M))
+    Assert.That(qry, Is.EqualTo(26.2185m).Within(0.001M))
 
 [<Test >]
 let ``simple select with distinct``() =


### PR DESCRIPTION
Simple version of group-by done. 
No join and multi-column-key-support yet.

This kind of simple group-by works:

```fsharp
[<Test>]
let ``verify groupBy results``() = 
    let dc = sql.GetDataContext()
    let enumtest =
        query {
            for cust in dc.Main.Customers do
            select (cust)
        } |> Seq.toList
    let inlogics = 
        query {
            for cust in enumtest do
            groupBy cust.City into c
            select (c.Key, c.Count())
        } |> Seq.toArray |> Array.sortBy (fun (k,v) -> k )

    let groupqry = 
        query {
            for cust in dc.Main.Customers do
            groupBy cust.City into c
            select (c.Key, c.Count())
        } |> Seq.toArray |> Array.sortBy (fun (k,v) -> k )

    CollectionAssert.AreEqual(inlogics,groupqry)
```