### PR TITLE
SQLite: Documentation about interop libraries.

### DIFF
--- a/docs/content/core/sqlite.fsx
+++ b/docs/content/core/sqlite.fsx
@@ -29,13 +29,21 @@ If you use the System.Data.SQLite NuGet package and target .NET 4.6, the path wo
 `__SOURCE_DIRECTORY__ + @"\..\packages\System.Data.SQLite.Core.<version>\lib\net46"`. 
 Both absolute and relative paths are supported.
 
-Note that `System.Data.SQLite.dll` will look for the native `SQLite.Interop.dll` in the x64 and x86 subdirectories of
-the resolution path. These are not created when the System.Data.SQLite NuGet package is added, so you might have to 
-manually copy these subdirectories from SQLite build directory, which typically is 
-`<project root>\packages\System.Data.SQLite.Core.<version>\build\net46`.
+Note that `System.Data.SQLite.dll` will look for the native interop library:
+
+- on Windows: `SQLite.Interop.dll` in the `x64` and `x86` subdirectories of the resolution path.
+- on Linux: `libSQLite.Interop.so` in the resolution path directory.
+
+The interop libraries are not properly placed afer the System.Data.SQLite NuGet package is added, so you might have to 
+manually copy the interop libraries:
+
+- on Windows: copy `x64` and `x86` subdirectories from SQLite build directory, which typically is 
+ `<project root>\packages\System.Data.SQLite.Core.<version>\build\net46`.
+- on Linux: first build the `libSQLite.Interop.so` using `<srcDir>/Setup/compile-interop-assembly-release.sh` script from System.Data.SQLite
+  source distribution `sqlite-netFx-source-1.x.xxx.x.zip`. And then copy it from `<srcDir>/bin/2013/Release/bin/`.
 
 If `System.Data.SQLite.dll` is in the location where NuGet places it by default, you don't have to submit
-the ResolutionPath parameter at all, but you still need to copy the x64 and x86 subdirectories as described above.
+the ResolutionPath parameter at all, but you still need to copy the interop libraries as described above.
 
 *)
 


### PR DESCRIPTION
Improved documentation about how to place SQLite interop libraries correctly on Windows and Linux platforms.

The documentation helps users to avoid following build error:

> The type provider 'FSharp.Data.Sql.SqlTypeProvider' reported an error: SQLite.Interop.dll, Path: <...>

(which is particularly misleading on Linux platform, where `libSQLite.Interop.so` is needed, but not `SQLite.Interop.dll`).