### PR TITLE
Updated doc for SQLite, due to System.Data.SQLite update

### DIFF
--- a/docs/content/core/sqlite.fsx
+++ b/docs/content/core/sqlite.fsx
@@ -24,26 +24,21 @@ let connectionString =
 (**
 ### ResolutionPath
 
-Path to search for database vendor speficic assemblies. Specify the path where `System.Data.SQLite.dll` is stored. 
+Typically, this parameter is not needed. It specifies the path to the directory where 
+`System.Data.SQLite.dll` is located. 
 If you use the System.Data.SQLite NuGet package and target .NET 4.6, the path would be something like 
 `__SOURCE_DIRECTORY__ + @"\..\packages\System.Data.SQLite.Core.<version>\lib\net46"`. 
 Both absolute and relative paths are supported.
 
-Note that `System.Data.SQLite.dll` will look for the native interop library:
+Note that `System.Data.SQLite.dll` loads a native interop library, which it looks for in the following
+directories:
 
 - on Windows: `SQLite.Interop.dll` in the `x64` and `x86` subdirectories of the resolution path.
 - on Linux: `libSQLite.Interop.so` in the resolution path directory.
+- alternatively in a directory specified in the "System.Data.SQLite.dll.config" file.
 
-The interop libraries are not properly placed afer the System.Data.SQLite NuGet package is added, so you might have to 
-manually copy the interop libraries:
-
-- on Windows: copy `x64` and `x86` subdirectories from SQLite build directory, which typically is 
- `<project root>\packages\System.Data.SQLite.Core.<version>\build\net46`.
-- on Linux: first build the `libSQLite.Interop.so` using `<srcDir>/Setup/compile-interop-assembly-release.sh` script from System.Data.SQLite
-  source distribution `sqlite-netFx-source-1.x.xxx.x.zip`. And then copy it from `<srcDir>/bin/2013/Release/bin/`.
-
-If `System.Data.SQLite.dll` is in the location where NuGet places it by default, you don't have to submit
-the ResolutionPath parameter at all, but you still need to copy the interop libraries as described above.
+When adding the System.Data.SQLite NuGet package, the default "System.Data.SQLite.dll.config" 
+file ensures that finding the native interop library "just works".
 
 *)
 


### PR DESCRIPTION
Updated doc for SQLite, to reflect changes in System.Data.SQLite ver 1.0.104.0:

The manual copying of native dll subdirectories is no longer necessary, since Joe Mistachkin kindly has added a config file setting specifically for us F# users (see https://system.data.sqlite.org/index.html/tktview/d4728aecb76adffb227e). 