### PR TITLE
Support for #380

### DIFF
--- a/docs/content/core/querying.fsx
+++ b/docs/content/core/querying.fsx
@@ -122,7 +122,7 @@ thenBy	                 |X |                                                    
 thenByDescending	     |X |                                                       |   
 thenByNullable           |X |                                                       | 
 thenByNullableDescending |X |                                                       |
-where                    |x | Server side variables must be on left side and only left side of predicates (excluding parentheses, boolean database fields and LINQ-Contains) | 
+where                    |x | Server side variables must be plain without .NET operations, so you can't say where (col.Days(+1)>2)  | 
 *)
 
 (**

--- a/src/SQLProvider/Providers.MSAccess.fs
+++ b/src/SQLProvider/Providers.MSAccess.fs
@@ -357,12 +357,16 @@ type internal MSAccessProvider() =
                                         Array.iter parameters.Add innerpars
                                         (sprintf "[%s].[%s] NOT IN (%s)") alias col innersql
                                     | _ ->
-                                        parameters.Add paras.[0]
-                                        if alias="" then (sprintf "%s %s %s") col (operator.ToString()) paras.[0].ParameterName
-                                        else
-                                        (sprintf "[%s].[%s]%s %s") alias col
-                                         (operator.ToString()) paras.[0].ParameterName)
-                        )
+                                        let aliasformat = if alias<>"" then (sprintf "[%s].[%s]%s %s") alias col else (sprintf "%s %s %s") col
+                                        match data with 
+                                        | Some d when (box d :? alias * string) ->
+                                            let alias2, col2 = box d :?> (alias * string)
+                                            let alias2f = if alias2<>"" then (sprintf "[%s].[%s]") alias2 col2 else col2
+                                            aliasformat (operator.ToString()) alias2f
+                                        | _ ->
+                                            parameters.Add paras.[0]
+                                            aliasformat (operator.ToString()) paras.[0].ParameterName
+                        ))
                         // there's probably a nicer way to do this
                         let rec aux = function
                             | x::[] when preds.Length > 0 ->

--- a/src/SQLProvider/Providers.MsSqlServer.fs
+++ b/src/SQLProvider/Providers.MsSqlServer.fs
@@ -624,12 +624,16 @@ type internal MSSqlServerProvider(tableNames:string) =
                                     | FSharp.Data.Sql.NestedIn 
                                     | FSharp.Data.Sql.NestedNotIn -> operatorInQuery operator paras
                                     | _ ->
-                                        parameters.Add paras.[0]
-                                        if alias="" then (sprintf "%s %s %s") col (operator.ToString()) paras.[0].ParameterName
-                                        else
-                                        (sprintf "[%s].[%s]%s %s") alias col
-                                         (operator.ToString()) paras.[0].ParameterName)
-                        )
+                                        let aliasformat = if alias<>"" then (sprintf "[%s].[%s]%s %s") alias col else (sprintf "%s %s %s") col
+                                        match data with 
+                                        | Some d when (box d :? alias * string) ->
+                                            let alias2, col2 = box d :?> (alias * string)
+                                            let alias2f = if alias2<>"" then (sprintf "[%s].[%s]") alias2 col2 else col2
+                                            aliasformat (operator.ToString()) alias2f
+                                        | _ ->
+                                            parameters.Add paras.[0]
+                                            aliasformat (operator.ToString()) paras.[0].ParameterName
+                        ))
                         // there's probably a nicer way to do this
                         let rec aux = function
                             | x::[] when preds.Length > 0 ->

--- a/src/SQLProvider/Providers.MySql.fs
+++ b/src/SQLProvider/Providers.MySql.fs
@@ -586,12 +586,17 @@ type internal MySqlProvider(resolutionPath, owner, referencedAssemblies) as this
                                     | FSharp.Data.Sql.NestedIn 
                                     | FSharp.Data.Sql.NestedNotIn -> operatorInQuery operator paras
                                     | _ ->
-                                        parameters.Add paras.[0]
-                                        if alias="" then (sprintf "%s %s %s") col (operator.ToString()) paras.[0].ParameterName
-                                        else
-                                        (sprintf "`%s`.`%s`%s %s") alias col
-                                         (operator.ToString()) paras.[0].ParameterName)
-                        )
+
+                                        let aliasformat = if alias<>"" then (sprintf "`%s`.`%s`%s %s") alias col else (sprintf "%s %s %s") col
+                                        match data with 
+                                        | Some d when (box d :? alias * string) ->
+                                            let alias2, col2 = box d :?> (alias * string)
+                                            let alias2f = if alias2<>"" then (sprintf "`%s`.`%s`") alias2 col2 else col2
+                                            aliasformat (operator.ToString()) alias2f
+                                        | _ ->
+                                            parameters.Add paras.[0]
+                                            aliasformat (operator.ToString()) paras.[0].ParameterName
+                        ))
                         // there's probably a nicer way to do this
                         let rec aux = function
                             | x::[] when preds.Length > 0 ->

--- a/src/SQLProvider/Providers.Odbc.fs
+++ b/src/SQLProvider/Providers.Odbc.fs
@@ -353,12 +353,16 @@ type internal OdbcProvider(quotehcar : OdbcQuoteCharacter) =
                                         Array.iter parameters.Add innerpars
                                         (sprintf "%c%s%c.%c%s%c NOT IN (%s)") cOpen alias cClose cOpen col cClose innersql
                                     | _ ->
-                                        parameters.Add paras.[0]
-                                        if alias="" then (sprintf "%s %s %s") col (operator.ToString()) paras.[0].ParameterName
-                                        else
-                                        (sprintf "%c%s%c.%s %s %s") cOpen alias cClose col
-                                         (operator.ToString()) paras.[0].ParameterName)
-                        )
+                                        let aliasformat = if alias<>"" then (sprintf "%c%s%c.%s %s %s") cOpen alias cClose col else (sprintf "%s %s %s") col
+                                        match data with 
+                                        | Some d when (box d :? alias * string) ->
+                                            let alias2, col2 = box d :?> (alias * string)
+                                            let alias2f = if alias2<>"" then (sprintf "%c%s%c.%s") cOpen alias2 cClose col2 else col2
+                                            aliasformat (operator.ToString()) alias2f
+                                        | _ ->
+                                            parameters.Add paras.[0]
+                                            aliasformat (operator.ToString()) paras.[0].ParameterName
+                        ))
                         // there's probably a nicer way to do this
                         let rec aux = function
                             | x::[] when preds.Length > 0 ->

--- a/src/SQLProvider/Providers.Oracle.fs
+++ b/src/SQLProvider/Providers.Oracle.fs
@@ -674,12 +674,16 @@ type internal OracleProvider(resolutionPath, owner, referencedAssemblies, tableN
                                         Array.iter parameters.Add innerpars
                                         (sprintf "%s.%s NOT IN (%s)") alias (quoteWhiteSpace col) innersql
                                     | _ ->
-                                        parameters.Add paras.[0]
-                                        if alias="" then (sprintf "%s %s %s") (quoteWhiteSpace col) (operator.ToString()) paras.[0].ParameterName
-                                        else
-                                        (sprintf "%s.%s %s %s") alias (quoteWhiteSpace col)
-                                         (operator.ToString()) paras.[0].ParameterName)
-                        )
+                                        let aliasformat = if alias<>"" then (sprintf "%s.%s %s %s") alias (quoteWhiteSpace col) else (sprintf "%s %s %s") (quoteWhiteSpace col)
+                                        match data with 
+                                        | Some d when (box d :? alias * string) ->
+                                            let alias2, col2 = box d :?> (alias * string)
+                                            let alias2f = if alias2<>"" then (sprintf "%s.%s") alias2 (quoteWhiteSpace col2) else (quoteWhiteSpace col2)
+                                            aliasformat (operator.ToString()) alias2f
+                                        | _ ->
+                                            parameters.Add paras.[0]
+                                            aliasformat (operator.ToString()) paras.[0].ParameterName
+                        ))
                         // there's probably a nicer way to do this
                         let rec aux = function
                             | x::[] when preds.Length > 0 ->

--- a/src/SQLProvider/Providers.Postgresql.fs
+++ b/src/SQLProvider/Providers.Postgresql.fs
@@ -705,12 +705,16 @@ type internal PostgresqlProvider(resolutionPath, owner, referencedAssemblies) =
                                         Array.iter parameters.Add innerpars
                                         (sprintf "\"%s\".\"%s\" NOT IN (%s)") alias col innersql
                                     | _ ->
-                                        parameters.Add paras.[0]
-                                        if alias="" then (sprintf "%s %s %s") col (operator.ToString()) paras.[0].ParameterName
-                                        else
-                                        (sprintf "\"%s\".\"%s\" %s %s") alias col
-                                         (operator.ToString()) paras.[0].ParameterName)
-                        )
+                                        let aliasformat = if alias<>"" then (sprintf "\"%s\".\"%s\" %s %s") alias col else (sprintf "%s %s %s") col
+                                        match data with 
+                                        | Some d when (box d :? alias * string) ->
+                                            let alias2, col2 = box d :?> (alias * string)
+                                            let alias2f = if alias2<>"" then (sprintf "\"%s\".\"%s\"") alias2 col2 else col2
+                                            aliasformat (operator.ToString()) alias2f
+                                        | _ ->
+                                            parameters.Add paras.[0]
+                                            aliasformat (operator.ToString()) paras.[0].ParameterName
+                        ))
                         // there's probably a nicer way to do this
                         let rec aux = function
                             | x::[] when preds.Length > 0 ->

--- a/src/SQLProvider/Providers.SQLite.fs
+++ b/src/SQLProvider/Providers.SQLite.fs
@@ -434,12 +434,16 @@ type internal SQLiteProvider(resolutionPath, referencedAssemblies, runtimeAssemb
                                         Array.iter parameters.Add innerpars
                                         (sprintf "[%s].[%s] NOT IN (%s)") alias col innersql
                                     | _ ->
-                                        parameters.Add paras.[0]
-                                        if alias="" then (sprintf "%s %s %s") col (operator.ToString()) paras.[0].ParameterName
-                                        else
-                                        (sprintf "[%s].[%s]%s %s") alias col
-                                         (operator.ToString()) paras.[0].ParameterName)
-                        )
+                                        let aliasformat = if alias<>"" then (sprintf "[%s].[%s]%s %s") alias col else (sprintf "%s %s %s") col
+                                        match data with 
+                                        | Some d when (box d :? alias * string) ->
+                                            let alias2, col2 = box d :?> (alias * string)
+                                            let alias2f = if alias2<>"" then (sprintf "[%s].[%s]") alias2 col2 else col2
+                                            aliasformat (operator.ToString()) alias2f
+                                        | _ ->
+                                            parameters.Add paras.[0]
+                                            aliasformat (operator.ToString()) paras.[0].ParameterName
+                        ))
                         // there's probably a nicer way to do this
                         let rec aux = function
                             | x::[] when preds.Length > 0 ->

--- a/src/SQLProvider/SqlRuntime.Patterns.fs
+++ b/src/SQLProvider/SqlRuntime.Patterns.fs
@@ -171,7 +171,8 @@ let (|SqlColumnGet|_|) = function
     | OptionalFSharpOptionValue(MethodCall(Some(o),((MethodWithName "GetColumn" as meth) | (MethodWithName "GetColumnOption" as meth)),[String key])) -> 
         match o with
         | :? MemberExpression as m  -> Some(m.Member.Name,key,meth.ReturnType) 
-        | _ -> Some(String.Empty,key,meth.ReturnType) 
+        | p when p.NodeType = ExpressionType.Parameter -> Some(String.Empty,key,meth.ReturnType) 
+        | _ -> None
     | _ -> None
 
 let (|SqlGroupingColumnGet|_|) (e:Expression) = 

--- a/tests/SqlProvider.Tests/QueryTests.fs
+++ b/tests/SqlProvider.Tests/QueryTests.fs
@@ -277,6 +277,33 @@ let ``simple select where query``() =
     Assert.AreEqual("Berlin", qry.[0].City)
 
 [<Test >]
+let ``simple select where query right side``() =
+    let dc = sql.GetDataContext()
+    let qry = 
+        query {
+            for cust in dc.Main.Customers do
+            where ("ALFKI" = cust.CustomerId)
+            select cust
+        } |> Seq.toArray
+
+    CollectionAssert.IsNotEmpty qry
+    Assert.AreEqual(1, qry.Length)
+    Assert.AreEqual("Berlin", qry.[0].City)
+
+[<Test >]
+let ``simple select where query between col properties``() =
+    let dc = sql.GetDataContext()
+    let qry = 
+        query {
+            for order in dc.Main.Orders do
+            where (order.ShippedDate > order.RequiredDate)
+            select (order.ShippedDate, order.RequiredDate)
+        } |> Seq.toArray
+
+    CollectionAssert.IsNotEmpty qry
+    Assert.AreEqual(37, qry.Length)
+
+[<Test >]
 let ``simple nth query``() =
     let dc = sql.GetDataContext()
     let qry = 


### PR DESCRIPTION
Added support for SQL-columns to be non-left-hand-side.
So you can do this:
```fsharp
    let qry = 
        query {
            for item in dc.Main.Products do
            where (item.ExpiryDate > item.ShipmentDate)
            select item
        } |> Seq.toArray
```

Columns are still going as is to SQL in where.
So you still cannot do .NET operations to columns, so instead of this:
```fsharp
    let qry = 
        query {
            for item in dc.Main.Products do
            where ((item.Id+3) > 10)
            select item
        } |> Seq.toArray
```
you still have to write
```fsharp
    let qry = 
        query {
            for item in dc.Main.Products do
            where (item.Id > 13)
            select item
        } |> Seq.toArray
```
