### PR TITLE
Add GetDataContext overloads for passing in the TransactionOptions

### DIFF
--- a/src/SQLProvider/Providers.MSAccess.fs
+++ b/src/SQLProvider/Providers.MSAccess.fs
@@ -468,7 +468,7 @@ type internal MSAccessProvider() =
             let sql = sb.ToString()
             (sql,parameters)
 
-        member this.ProcessUpdates(con, entities) =
+        member this.ProcessUpdates(con, entities, transactionOptions) =
             let sb = Text.StringBuilder()
 
             entities.Keys |> Seq.iter (fun e -> printfn "entity - %A" e.ColumnValues)
@@ -520,7 +520,7 @@ type internal MSAccessProvider() =
                 ()
                 //con.Close()
 
-        member this.ProcessUpdatesAsync(con, entities) =
+        member this.ProcessUpdatesAsync(con, entities, transactionOptions) =
             let sb = Text.StringBuilder()
 
             entities.Keys |> Seq.iter (fun e -> printfn "entity - %A" e.ColumnValues)

--- a/src/SQLProvider/Providers.MsSqlServer.fs
+++ b/src/SQLProvider/Providers.MsSqlServer.fs
@@ -742,7 +742,7 @@ type internal MSSqlServerProvider(tableNames:string) =
             let sql = sb.ToString()
             (sql,parameters)
 
-        member this.ProcessUpdates(con, entities) =
+        member this.ProcessUpdates(con, entities, transactionOptions) =
             let sb = Text.StringBuilder()
 
             CommonTasks.``ensure columns have been loaded`` (this :> ISqlProvider) con entities
@@ -750,7 +750,7 @@ type internal MSSqlServerProvider(tableNames:string) =
             if entities.Count = 0 then 
                 ()
             else
-            use scope = Utilities.ensureTransaction()
+            use scope = Utilities.ensureTransaction transactionOptions
             try
                 // close the connection first otherwise it won't get enlisted into the transaction
                 if con.State = ConnectionState.Open then con.Close()
@@ -784,7 +784,7 @@ type internal MSSqlServerProvider(tableNames:string) =
             finally
                 con.Close()
 
-        member this.ProcessUpdatesAsync(con, entities) =
+        member this.ProcessUpdatesAsync(con, entities, transactionOptions) =
             let sb = Text.StringBuilder()
 
             CommonTasks.``ensure columns have been loaded`` (this :> ISqlProvider) con entities
@@ -794,7 +794,7 @@ type internal MSSqlServerProvider(tableNames:string) =
             else
 
             async {
-                use scope = Utilities.ensureTransaction()
+                use scope = Utilities.ensureTransaction transactionOptions
                 try
                     // close the connection first otherwise it won't get enlisted into the transaction
                     if con.State = ConnectionState.Open then con.Close()

--- a/src/SQLProvider/Providers.MySql.fs
+++ b/src/SQLProvider/Providers.MySql.fs
@@ -699,7 +699,7 @@ type internal MySqlProvider(resolutionPath, owner, referencedAssemblies) as this
             let sql = sb.ToString()
             (sql,parameters)
 
-        member this.ProcessUpdates(con, entities) =
+        member this.ProcessUpdates(con, entities, transactionOptions) =
             let sb = Text.StringBuilder()
 
             CommonTasks.``ensure columns have been loaded`` (this :> ISqlProvider) con entities
@@ -710,7 +710,7 @@ type internal MySqlProvider(resolutionPath, owner, referencedAssemblies) as this
 
             con.Open()
 
-            use scope = Utilities.ensureTransaction()
+            use scope = Utilities.ensureTransaction transactionOptions
             try
                 // close the connection first otherwise it won't get enlisted into the transaction
                 if con.State = ConnectionState.Open then con.Close()
@@ -745,7 +745,7 @@ type internal MySqlProvider(resolutionPath, owner, referencedAssemblies) as this
             finally
                 con.Close()
 
-        member this.ProcessUpdatesAsync(con, entities) =
+        member this.ProcessUpdatesAsync(con, entities, transactionOptions) =
             let sb = Text.StringBuilder()
 
             CommonTasks.``ensure columns have been loaded`` (this :> ISqlProvider) con entities
@@ -756,7 +756,7 @@ type internal MySqlProvider(resolutionPath, owner, referencedAssemblies) as this
 
             async {
 
-                use scope = Utilities.ensureTransaction()
+                use scope = Utilities.ensureTransaction transactionOptions
                 try
                     // close the connection first otherwise it won't get enlisted into the transaction
                     if con.State = ConnectionState.Open then con.Close()

--- a/src/SQLProvider/Providers.Odbc.fs
+++ b/src/SQLProvider/Providers.Odbc.fs
@@ -465,7 +465,7 @@ type internal OdbcProvider(quotehcar : OdbcQuoteCharacter) =
             let sql = sb.ToString()
             (sql,parameters)
 
-        member this.ProcessUpdates(con, entities) =
+        member this.ProcessUpdates(con, entities, transactionOptions) =
             let sb = Text.StringBuilder()
 
             CommonTasks.``ensure columns have been loaded`` (this :> ISqlProvider) con entities
@@ -476,7 +476,7 @@ type internal OdbcProvider(quotehcar : OdbcQuoteCharacter) =
 
             if con.State <> ConnectionState.Open then con.Open()
 
-            use scope = Utilities.ensureTransaction()
+            use scope = Utilities.ensureTransaction transactionOptions
             try
                 // close the connection first otherwise it won't get enlisted into the transaction
                 if con.State = ConnectionState.Open then con.Close()
@@ -510,7 +510,7 @@ type internal OdbcProvider(quotehcar : OdbcQuoteCharacter) =
             finally
                 con.Close()
 
-        member this.ProcessUpdatesAsync(con, entities) =
+        member this.ProcessUpdatesAsync(con, entities, transactionOptions) =
             let sb = Text.StringBuilder()
 
             CommonTasks.``ensure columns have been loaded`` (this :> ISqlProvider) con entities
@@ -520,7 +520,7 @@ type internal OdbcProvider(quotehcar : OdbcQuoteCharacter) =
             else
 
             async {
-                use scope = Utilities.ensureTransaction()
+                use scope = Utilities.ensureTransaction transactionOptions
                 try
                     // close the connection first otherwise it won't get enlisted into the transaction
                     if con.State = ConnectionState.Open then con.Close()

--- a/src/SQLProvider/Providers.Oracle.fs
+++ b/src/SQLProvider/Providers.Oracle.fs
@@ -788,7 +788,7 @@ type internal OracleProvider(resolutionPath, owner, referencedAssemblies, tableN
                 let sql = sb.ToString()
                 (sql,parameters)
 
-        member this.ProcessUpdates(con, entities) =
+        member this.ProcessUpdates(con, entities, transactionOptions) =
             let sb = Text.StringBuilder()
             let provider = this :> ISqlProvider
 
@@ -800,7 +800,7 @@ type internal OracleProvider(resolutionPath, owner, referencedAssemblies, tableN
 
             con.Open()
 
-            use scope = Utilities.ensureTransaction()
+            use scope = Utilities.ensureTransaction transactionOptions
             try
                 // close the connection first otherwise it won't get enlisted into the transaction
                 if con.State = ConnectionState.Open then con.Close()
@@ -837,7 +837,7 @@ type internal OracleProvider(resolutionPath, owner, referencedAssemblies, tableN
             finally
                 con.Close()
 
-        member this.ProcessUpdatesAsync(con, entities) =
+        member this.ProcessUpdatesAsync(con, entities, transactionOptions) =
             let sb = Text.StringBuilder()
             let provider = this :> ISqlProvider
 
@@ -848,7 +848,7 @@ type internal OracleProvider(resolutionPath, owner, referencedAssemblies, tableN
             else
 
             async {
-                use scope = Utilities.ensureTransaction()
+                use scope = Utilities.ensureTransaction transactionOptions
                 try
                     // close the connection first otherwise it won't get enlisted into the transaction
                     if con.State = ConnectionState.Open then con.Close()

--- a/src/SQLProvider/Providers.Postgresql.fs
+++ b/src/SQLProvider/Providers.Postgresql.fs
@@ -818,7 +818,7 @@ type internal PostgresqlProvider(resolutionPath, owner, referencedAssemblies) =
             let sql = sb.ToString()
             (sql,parameters)
 
-        member this.ProcessUpdates(con, entities) =
+        member this.ProcessUpdates(con, entities, transactionOptions) =
             let sb = Text.StringBuilder()
 
             CommonTasks.``ensure columns have been loaded`` (this :> ISqlProvider) con entities
@@ -829,7 +829,7 @@ type internal PostgresqlProvider(resolutionPath, owner, referencedAssemblies) =
 
             con.Open()
 
-            use scope = Utilities.ensureTransaction()
+            use scope = Utilities.ensureTransaction transactionOptions
             try
                 // close the connection first otherwise it won't get enlisted into the transaction
                 if con.State = ConnectionState.Open then con.Close()
@@ -862,7 +862,7 @@ type internal PostgresqlProvider(resolutionPath, owner, referencedAssemblies) =
             finally
                 con.Close()
 
-        member this.ProcessUpdatesAsync(con, entities) =
+        member this.ProcessUpdatesAsync(con, entities, transactionOptions) =
             let sb = Text.StringBuilder()
 
             CommonTasks.``ensure columns have been loaded`` (this :> ISqlProvider) con entities
@@ -872,7 +872,7 @@ type internal PostgresqlProvider(resolutionPath, owner, referencedAssemblies) =
             else
 
             async {
-                use scope = Utilities.ensureTransaction()
+                use scope = Utilities.ensureTransaction transactionOptions
                 try
                     // close the connection first otherwise it won't get enlisted into the transaction
                     if con.State = ConnectionState.Open then con.Close()

--- a/src/SQLProvider/Providers.SQLite.fs
+++ b/src/SQLProvider/Providers.SQLite.fs
@@ -546,7 +546,7 @@ type internal SQLiteProvider(resolutionPath, referencedAssemblies, runtimeAssemb
             let sql = sb.ToString()
             (sql,parameters)
 
-        member this.ProcessUpdates(con, entities) =
+        member this.ProcessUpdates(con, entities, transactionOptions) =
             let sb = Text.StringBuilder()
 
             CommonTasks.``ensure columns have been loaded`` (this :> ISqlProvider) con entities
@@ -557,7 +557,7 @@ type internal SQLiteProvider(resolutionPath, referencedAssemblies, runtimeAssemb
 
             con.Open()
 
-            use scope = Utilities.ensureTransaction()
+            use scope = Utilities.ensureTransaction transactionOptions
             try
                 // close the connection first otherwise it won't get enlisted into the transaction
                 if con.State = ConnectionState.Open then con.Close()
@@ -590,7 +590,7 @@ type internal SQLiteProvider(resolutionPath, referencedAssemblies, runtimeAssemb
             finally
                 con.Close()
 
-        member this.ProcessUpdatesAsync(con, entities) =
+        member this.ProcessUpdatesAsync(con, entities, transactionOptions) =
             let sb = Text.StringBuilder()
 
             CommonTasks.``ensure columns have been loaded`` (this :> ISqlProvider) con entities
@@ -600,7 +600,7 @@ type internal SQLiteProvider(resolutionPath, referencedAssemblies, runtimeAssemb
             else
 
             async {
-                use scope = Utilities.ensureTransaction()
+                use scope = Utilities.ensureTransaction transactionOptions
                 try
                     // close the connection first otherwise it won't get enlisted into the transaction
                     if con.State = ConnectionState.Open then con.Close()

--- a/src/SQLProvider/SqlRuntime.Common.fs
+++ b/src/SQLProvider/SqlRuntime.Common.fs
@@ -472,9 +472,9 @@ and internal ISqlProvider =
     /// Returns the db vendor specific SQL query to select a single row based on the table and column name specified
     abstract GetIndividualQueryText : Table * string -> string
     /// Writes all pending database changes to database
-    abstract ProcessUpdates : IDbConnection * System.Collections.Concurrent.ConcurrentDictionary<SqlEntity,DateTime> -> unit
+    abstract ProcessUpdates : IDbConnection * System.Collections.Concurrent.ConcurrentDictionary<SqlEntity,DateTime> * System.Transactions.TransactionOptions -> unit
     /// Asynchronously writes all pending database changes to database
-    abstract ProcessUpdatesAsync : System.Data.Common.DbConnection * System.Collections.Concurrent.ConcurrentDictionary<SqlEntity,DateTime> -> Async<unit>
+    abstract ProcessUpdatesAsync : System.Data.Common.DbConnection * System.Collections.Concurrent.ConcurrentDictionary<SqlEntity,DateTime> * System.Transactions.TransactionOptions -> Async<unit>
     /// Accepts a SqlQuery object and produces the SQL to execute on the server.
     /// the other parameters are the base table alias, the base table, and a dictionary containing
     /// the columns from the various table aliases that are in the SELECT projection

--- a/src/SQLProvider/Utils.fs
+++ b/src/SQLProvider/Utils.fs
@@ -55,17 +55,19 @@ module internal Utilities =
         | [] -> async { () }
 
 
-    let ensureTransaction() =
+    let ensureTransaction (transactionOptions : Transactions.TransactionOptions) =
         // Todo: Take TransactionScopeAsyncFlowOption into use when implemented in Mono.
         // Without it, transactions are not thread-safe over threads e.g. using async can be dangerous)
         // However, default option for TransactionScopeOption is Required, so you can create top level transaction
         // and this Mono-transaction will have its properties.
+        let transactionScopeOption = Transactions.TransactionScopeOption.Required
+
         let isMono = Type.GetType ("Mono.Runtime") <> null
         match isMono with
-        | true -> new Transactions.TransactionScope()
+        | true -> new Transactions.TransactionScope(transactionScopeOption, transactionOptions)
         | false ->
             // Note1: On Mono, 4.6.1 or newer is requred for compiling TransactionScopeAsyncFlowOption.
-            new Transactions.TransactionScope(System.Transactions.TransactionScopeAsyncFlowOption.Enabled)
+            new Transactions.TransactionScope(transactionScopeOption, transactionOptions, Transactions.TransactionScopeAsyncFlowOption.Enabled)
 
     let parseAggregates fieldNotation fieldNotationAlias query =
         let rec parseAggregates' fieldNotation fieldNotationAlias query (selectColumns:string list) =


### PR DESCRIPTION
Default transaction isolation level for `TransactionScope` is `Serializable`, which can easily cause transaction deadlocks. This provides option to explicitly set the `TransactionOptions` for `TransactionScope`, which is created on `SubmitChanges`.

**UPDATE:** I'm thinking if I've made a mistake by not keeping parameter order the same for added overloads and put `transactionOptions` as last one?