### PR TITLE
Avoid forcing dependency on System.Transactions

### DIFF
--- a/src/SQLProvider/Providers.MsSqlServer.fs
+++ b/src/SQLProvider/Providers.MsSqlServer.fs
@@ -6,6 +6,7 @@ open System.Collections.Generic
 open System.Data
 open System.Data.SqlClient
 open FSharp.Data.Sql
+open FSharp.Data.Sql.Transactions
 open FSharp.Data.Sql.Schema
 open FSharp.Data.Sql.Common
 
@@ -750,7 +751,7 @@ type internal MSSqlServerProvider(tableNames:string) =
             if entities.Count = 0 then 
                 ()
             else
-            use scope = Utilities.ensureTransaction transactionOptions
+            use scope = TransactionUtils.ensureTransaction transactionOptions
             try
                 // close the connection first otherwise it won't get enlisted into the transaction
                 if con.State = ConnectionState.Open then con.Close()
@@ -794,7 +795,7 @@ type internal MSSqlServerProvider(tableNames:string) =
             else
 
             async {
-                use scope = Utilities.ensureTransaction transactionOptions
+                use scope = TransactionUtils.ensureTransaction transactionOptions
                 try
                     // close the connection first otherwise it won't get enlisted into the transaction
                     if con.State = ConnectionState.Open then con.Close()

--- a/src/SQLProvider/Providers.MySql.fs
+++ b/src/SQLProvider/Providers.MySql.fs
@@ -5,6 +5,7 @@ open System.Collections.Concurrent
 open System.Collections.Generic
 open System.Data
 open FSharp.Data.Sql
+open FSharp.Data.Sql.Transactions
 open FSharp.Data.Sql.Schema
 open FSharp.Data.Sql.Common
 
@@ -710,7 +711,7 @@ type internal MySqlProvider(resolutionPath, owner, referencedAssemblies) as this
 
             con.Open()
 
-            use scope = Utilities.ensureTransaction transactionOptions
+            use scope = TransactionUtils.ensureTransaction transactionOptions
             try
                 // close the connection first otherwise it won't get enlisted into the transaction
                 if con.State = ConnectionState.Open then con.Close()
@@ -756,7 +757,7 @@ type internal MySqlProvider(resolutionPath, owner, referencedAssemblies) as this
 
             async {
 
-                use scope = Utilities.ensureTransaction transactionOptions
+                use scope = TransactionUtils.ensureTransaction transactionOptions
                 try
                     // close the connection first otherwise it won't get enlisted into the transaction
                     if con.State = ConnectionState.Open then con.Close()

--- a/src/SQLProvider/Providers.Odbc.fs
+++ b/src/SQLProvider/Providers.Odbc.fs
@@ -6,6 +6,7 @@ open System.Collections.Generic
 open System.Data
 open System.Data.Odbc
 open FSharp.Data.Sql
+open FSharp.Data.Sql.Transactions
 open FSharp.Data.Sql.Schema
 open FSharp.Data.Sql.Common
 
@@ -476,7 +477,7 @@ type internal OdbcProvider(quotehcar : OdbcQuoteCharacter) =
 
             if con.State <> ConnectionState.Open then con.Open()
 
-            use scope = Utilities.ensureTransaction transactionOptions
+            use scope = TransactionUtils.ensureTransaction transactionOptions
             try
                 // close the connection first otherwise it won't get enlisted into the transaction
                 if con.State = ConnectionState.Open then con.Close()
@@ -520,7 +521,7 @@ type internal OdbcProvider(quotehcar : OdbcQuoteCharacter) =
             else
 
             async {
-                use scope = Utilities.ensureTransaction transactionOptions
+                use scope = TransactionUtils.ensureTransaction transactionOptions
                 try
                     // close the connection first otherwise it won't get enlisted into the transaction
                     if con.State = ConnectionState.Open then con.Close()

--- a/src/SQLProvider/Providers.Oracle.fs
+++ b/src/SQLProvider/Providers.Oracle.fs
@@ -5,6 +5,7 @@ open System.Collections.Concurrent
 open System.Collections.Generic
 open System.Data
 open FSharp.Data.Sql
+open FSharp.Data.Sql.Transactions
 open FSharp.Data.Sql.Schema
 open FSharp.Data.Sql.Common
 open FSharp.Data.Sql.Common.Utilities
@@ -800,7 +801,7 @@ type internal OracleProvider(resolutionPath, owner, referencedAssemblies, tableN
 
             con.Open()
 
-            use scope = Utilities.ensureTransaction transactionOptions
+            use scope = TransactionUtils.ensureTransaction transactionOptions
             try
                 // close the connection first otherwise it won't get enlisted into the transaction
                 if con.State = ConnectionState.Open then con.Close()
@@ -848,7 +849,7 @@ type internal OracleProvider(resolutionPath, owner, referencedAssemblies, tableN
             else
 
             async {
-                use scope = Utilities.ensureTransaction transactionOptions
+                use scope = TransactionUtils.ensureTransaction transactionOptions
                 try
                     // close the connection first otherwise it won't get enlisted into the transaction
                     if con.State = ConnectionState.Open then con.Close()

--- a/src/SQLProvider/Providers.Postgresql.fs
+++ b/src/SQLProvider/Providers.Postgresql.fs
@@ -9,6 +9,7 @@ open System.Net
 open System.Net.NetworkInformation
 open System.Threading
 open FSharp.Data.Sql
+open FSharp.Data.Sql.Transactions
 open FSharp.Data.Sql.Schema
 open FSharp.Data.Sql.Common
 
@@ -829,7 +830,7 @@ type internal PostgresqlProvider(resolutionPath, owner, referencedAssemblies) =
 
             con.Open()
 
-            use scope = Utilities.ensureTransaction transactionOptions
+            use scope = TransactionUtils.ensureTransaction transactionOptions
             try
                 // close the connection first otherwise it won't get enlisted into the transaction
                 if con.State = ConnectionState.Open then con.Close()
@@ -872,7 +873,7 @@ type internal PostgresqlProvider(resolutionPath, owner, referencedAssemblies) =
             else
 
             async {
-                use scope = Utilities.ensureTransaction transactionOptions
+                use scope = TransactionUtils.ensureTransaction transactionOptions
                 try
                     // close the connection first otherwise it won't get enlisted into the transaction
                     if con.State = ConnectionState.Open then con.Close()

--- a/src/SQLProvider/Providers.SQLite.fs
+++ b/src/SQLProvider/Providers.SQLite.fs
@@ -6,6 +6,7 @@ open System.Collections.Concurrent
 open System.Collections.Generic
 open System.Data
 open FSharp.Data.Sql
+open FSharp.Data.Sql.Transactions
 open FSharp.Data.Sql.Schema
 open FSharp.Data.Sql.Common
 
@@ -557,7 +558,7 @@ type internal SQLiteProvider(resolutionPath, referencedAssemblies, runtimeAssemb
 
             con.Open()
 
-            use scope = Utilities.ensureTransaction transactionOptions
+            use scope = TransactionUtils.ensureTransaction transactionOptions
             try
                 // close the connection first otherwise it won't get enlisted into the transaction
                 if con.State = ConnectionState.Open then con.Close()
@@ -600,7 +601,7 @@ type internal SQLiteProvider(resolutionPath, referencedAssemblies, runtimeAssemb
             else
 
             async {
-                use scope = Utilities.ensureTransaction transactionOptions
+                use scope = TransactionUtils.ensureTransaction transactionOptions
                 try
                     // close the connection first otherwise it won't get enlisted into the transaction
                     if con.State = ConnectionState.Open then con.Close()

--- a/src/SQLProvider/SqlProvider.fsproj
+++ b/src/SQLProvider/SqlProvider.fsproj
@@ -68,6 +68,7 @@
     <Compile Include="DataTable.fs" />
     <Compile Include="SqlRuntime.Patterns.fs" />
     <Compile Include="QuotationHelpers.fs" />
+    <Compile Include="SqlRuntime.Transactions.fs" />
     <Compile Include="SqlRuntime.Common.fs" />
     <Compile Include="Providers.MsSqlServer.fs" />
     <Compile Include="Providers.MSAccess.fs" />

--- a/src/SQLProvider/SqlRuntime.Common.fs
+++ b/src/SQLProvider/SqlRuntime.Common.fs
@@ -9,6 +9,7 @@ open System.Linq.Expressions
 open System.Reflection
 open System.Runtime.Serialization
 open FSharp.Data.Sql
+open FSharp.Data.Sql.Transactions
 open FSharp.Data.Sql.Schema
 open Microsoft.FSharp.Reflection
 open System.Collections.Concurrent
@@ -472,9 +473,9 @@ and internal ISqlProvider =
     /// Returns the db vendor specific SQL query to select a single row based on the table and column name specified
     abstract GetIndividualQueryText : Table * string -> string
     /// Writes all pending database changes to database
-    abstract ProcessUpdates : IDbConnection * System.Collections.Concurrent.ConcurrentDictionary<SqlEntity,DateTime> * System.Transactions.TransactionOptions -> unit
+    abstract ProcessUpdates : IDbConnection * System.Collections.Concurrent.ConcurrentDictionary<SqlEntity,DateTime> * TransactionOptions -> unit
     /// Asynchronously writes all pending database changes to database
-    abstract ProcessUpdatesAsync : System.Data.Common.DbConnection * System.Collections.Concurrent.ConcurrentDictionary<SqlEntity,DateTime> * System.Transactions.TransactionOptions -> Async<unit>
+    abstract ProcessUpdatesAsync : System.Data.Common.DbConnection * System.Collections.Concurrent.ConcurrentDictionary<SqlEntity,DateTime> * TransactionOptions -> Async<unit>
     /// Accepts a SqlQuery object and produces the SQL to execute on the server.
     /// the other parameters are the base table alias, the base table, and a dictionary containing
     /// the columns from the various table aliases that are in the SELECT projection

--- a/src/SQLProvider/SqlRuntime.Transactions.fs
+++ b/src/SQLProvider/SqlRuntime.Transactions.fs
@@ -28,7 +28,7 @@ module internal TransactionUtils =
         | IsolationLevel.Snapshot -> System.Transactions.IsolationLevel.Snapshot
         | IsolationLevel.Chaos -> System.Transactions.IsolationLevel.Chaos
         | IsolationLevel.Unspecified -> System.Transactions.IsolationLevel.Unspecified
-        | _ -> failwithf "Unhandled TransactionIsolationLevel value: %A." isolationLevel
+        | _ -> failwithf "Unhandled IsolationLevel value: %A." isolationLevel
 
     let fromSystemTransactionsIsolationLevel isolationLevel =
         match isolationLevel with

--- a/src/SQLProvider/SqlRuntime.Transactions.fs
+++ b/src/SQLProvider/SqlRuntime.Transactions.fs
@@ -1,0 +1,69 @@
+﻿namespace FSharp.Data.Sql.Transactions
+
+open System
+
+/// Corresponds to the System.Transactions.IsolationLevel.
+type IsolationLevel =
+    | Serializable = 0
+    | RepeatableRead = 1
+    | ReadCommitted = 2
+    | ReadUncommitted = 3
+    | Snapshot = 4
+    | Chaos = 5
+    | Unspecified = 6
+
+/// Corresponds to the System.Transactions.TransactionOptions.
+type TransactionOptions = {
+    Timeout : TimeSpan
+    IsolationLevel : IsolationLevel
+}
+
+module internal TransactionUtils =
+    let toSystemTransactionsIsolationLevel isolationLevel =
+        match isolationLevel with
+        | IsolationLevel.Serializable -> System.Transactions.IsolationLevel.Serializable
+        | IsolationLevel.RepeatableRead -> System.Transactions.IsolationLevel.RepeatableRead
+        | IsolationLevel.ReadCommitted -> System.Transactions.IsolationLevel.ReadCommitted
+        | IsolationLevel.ReadUncommitted -> System.Transactions.IsolationLevel.ReadUncommitted
+        | IsolationLevel.Snapshot -> System.Transactions.IsolationLevel.Snapshot
+        | IsolationLevel.Chaos -> System.Transactions.IsolationLevel.Chaos
+        | IsolationLevel.Unspecified -> System.Transactions.IsolationLevel.Unspecified
+        | _ -> failwithf "Unhandled TransactionIsolationLevel value: %A." isolationLevel
+
+    let fromSystemTransactionsIsolationLevel isolationLevel =
+        match isolationLevel with
+        | System.Transactions.IsolationLevel.Serializable -> IsolationLevel.Serializable
+        | System.Transactions.IsolationLevel.RepeatableRead -> IsolationLevel.RepeatableRead
+        | System.Transactions.IsolationLevel.ReadCommitted -> IsolationLevel.ReadCommitted
+        | System.Transactions.IsolationLevel.ReadUncommitted -> IsolationLevel.ReadUncommitted
+        | System.Transactions.IsolationLevel.Snapshot -> IsolationLevel.Snapshot
+        | System.Transactions.IsolationLevel.Chaos -> IsolationLevel.Chaos
+        | System.Transactions.IsolationLevel.Unspecified -> IsolationLevel.Unspecified
+        | _ -> failwithf "Unhandled System.Transactions.IsolationLevel value: %A." isolationLevel
+
+    let ensureTransaction (transactionOptions : TransactionOptions) =
+        let transactionOptions =
+            new Transactions.TransactionOptions(
+                Timeout = transactionOptions.Timeout,
+                IsolationLevel = toSystemTransactionsIsolationLevel transactionOptions.IsolationLevel)
+        
+        let transactionScopeOption = Transactions.TransactionScopeOption.Required // Default
+
+        // Todo: Take TransactionScopeAsyncFlowOption into use when implemented in Mono.
+        // Without it, transactions are not thread-safe over threads e.g. using async can be dangerous)
+        // However, default option for TransactionScopeOption is Required, so you can create top level transaction
+        // and this Mono-transaction will have its properties.
+        let isMono = Type.GetType ("Mono.Runtime") <> null
+        match isMono with
+        | true -> new Transactions.TransactionScope(transactionScopeOption, transactionOptions)
+        | false ->
+            // Note1: On Mono, 4.6.1 or newer is requred for compiling TransactionScopeAsyncFlowOption.
+            new Transactions.TransactionScope(transactionScopeOption, transactionOptions, Transactions.TransactionScopeAsyncFlowOption.Enabled)
+
+type TransactionOptions with
+    static member Default =
+        let sysTranOpt = new System.Transactions.TransactionOptions()
+        {
+            Timeout = sysTranOpt.Timeout
+            IsolationLevel = TransactionUtils.fromSystemTransactionsIsolationLevel sysTranOpt.IsolationLevel
+        }

--- a/src/SQLProvider/Utils.fs
+++ b/src/SQLProvider/Utils.fs
@@ -54,21 +54,6 @@ module internal Utilities =
             }
         | [] -> async { () }
 
-
-    let ensureTransaction (transactionOptions : Transactions.TransactionOptions) =
-        // Todo: Take TransactionScopeAsyncFlowOption into use when implemented in Mono.
-        // Without it, transactions are not thread-safe over threads e.g. using async can be dangerous)
-        // However, default option for TransactionScopeOption is Required, so you can create top level transaction
-        // and this Mono-transaction will have its properties.
-        let transactionScopeOption = Transactions.TransactionScopeOption.Required
-
-        let isMono = Type.GetType ("Mono.Runtime") <> null
-        match isMono with
-        | true -> new Transactions.TransactionScope(transactionScopeOption, transactionOptions)
-        | false ->
-            // Note1: On Mono, 4.6.1 or newer is requred for compiling TransactionScopeAsyncFlowOption.
-            new Transactions.TransactionScope(transactionScopeOption, transactionOptions, Transactions.TransactionScopeAsyncFlowOption.Enabled)
-
     let parseAggregates fieldNotation fieldNotationAlias query =
         let rec parseAggregates' fieldNotation fieldNotationAlias query (selectColumns:string list) =
             match query with


### PR DESCRIPTION
I've created corresponding types for TransactionOptions and IsolationLevel, which are internally mapped to System.Transactions types.

Sample usage:

```fsharp
open FSharp.Data.Sql
open FSharp.Data.Sql.Transactions

type Database = SqlDataProvider<ConnectionStringName = "DB">

let options = { TransactionOptions.Default with IsolationLevel = IsolationLevel.ReadCommitted }
let context = Database.GetDataContext(options)
```

@pezipink The more I think about having these options as a mutable property on the context, the more I don't like it :(. Using the context from multiple threads (which should be avoided anyway) and setting options from those threads, can lead to really unpredictable results. By having it passed to the GetDataContext we're forcing the dev to create separate contexts if (s)he wants to have transactions hadled differently.