### PR TITLE
Fix for #394 (ORA-00932 when deleting rows in Oracle).

### DIFF
--- a/src/SQLProvider/Providers.Oracle.fs
+++ b/src/SQLProvider/Providers.Oracle.fs
@@ -522,16 +522,13 @@ type internal OracleProvider(resolutionPath, owner, referencedAssemblies, tableN
         | [] -> ()
         | ks -> 
             ~~(sprintf "DELETE FROM %s WHERE " entity.Table.FullName)
-            ~~(String.Join(" AND ", ks |> List.mapi(fun i k -> (sprintf "%s = :id%i" k i))))
+            ~~(String.Join(" AND ", ks |> List.mapi(fun i k -> (sprintf "\"%s\" = :pk%i" k i))))
 
         let cmd = provider.CreateCommand(con, sb.ToString())
-        cmd.CommandType <- CommandType.Text
         pkValues |> List.iteri(fun i pkValue ->
-            let pkType = pkValue.GetType().ToString();
-            match Oracle.findClrType pkType with
-            | Some(m) ->
-                cmd.Parameters.Add(provider.CreateCommandParameter(QueryParameter.Create((":id"+i.ToString()),i, m), pkValue)) |> ignore
-            | None -> ())
+            let pkParam = provider.CreateCommandParameter(QueryParameter.Create((":pk"+i.ToString()),i), pkValue)
+            cmd.Parameters.Add pkParam |> ignore
+        )
         cmd
 
     do


### PR DESCRIPTION
I didn't fully understand the failing code that generated Oracle command (not sure why it had to call findClrType but obviously the type wasn't correct), but createUpdateCommand function contained perfecly working code for Oracle command generation, so I copied the part of it that was relevant for deletion and then everything worked just fine.