### PR TITLE
Removed unnecessary con.Open() statement.

### DIFF
--- a/src/SQLProvider/Providers.Oracle.fs
+++ b/src/SQLProvider/Providers.Oracle.fs
@@ -838,8 +838,6 @@ type internal OracleProvider(resolutionPath, owner, referencedAssemblies, tableN
                 ()
             else
 
-            con.Open()
-
             use scope = TransactionUtils.ensureTransaction transactionOptions
             try
                 // close the connection first otherwise it won't get enlisted into the transaction


### PR DESCRIPTION
This is my smallest PR: just removed an extra con.Open() statement from ProcessUpdates method. Tested it thoroghly with an Oracle database, works OK.