### PR TITLE
[WIP] Canonical functions support

### DIFF
--- a/docs/content/core/crud.fsx
+++ b/docs/content/core/crud.fsx
@@ -186,3 +186,18 @@ SQLProvider also supports async database operations:
 *)
 
 ctx.SubmitUpdatesAsync() |> Async.StartAsTask
+
+(**
+
+### Delete-query for multiple items
+
+If you want to delete many items from a database table, `DELETE FROM [dbo].[EMPLOYEES] WHERE (...)`, there is a way, although we don't recommend deleting items from a database. Instead you should consider a deletion-flag column. And you should backup your database before even trying this.
+
+*)
+
+query {
+    for c in ctx.Dbo.Employees do
+    where (...)
+} |> Seq.``delete all items from single table``  |> Async.RunSynchronously
+
+*)

--- a/docs/content/core/querying.fsx
+++ b/docs/content/core/querying.fsx
@@ -75,7 +75,9 @@ let itemAsync =
     } |> Async.StartAsTask
 
 (**
+
 ## Supported Query Expression Keywords
+
 | Keyword            | Supported  |  Notes
 | --------------------- |:-:|---------------------------------------|
 .Contains()              |X | `open System.Linq`, in where, SQL IN-clause, nested query    | 
@@ -123,6 +125,68 @@ thenByDescending	     |X |                                                      
 thenByNullable           |X |                                                       | 
 thenByNullableDescending |X |                                                       |
 where                    |x | Server side variables must be plain without .NET operations, so you can't say where (col.Days(+1)>2)  | 
+
+### Canonical Functions 
+
+Besides that, we support these .NET-functions to to transfer to SQL-clauses:
+
+#### .NET String Functions (.NET)
+
+| .NET          | MsSqlServer     | PostgreSql   | MySql      | Oracle      | SQLite | MSAccess| Odbc        |  Notes
+|---------------|-----------------|--------------|------------|-------------|--------|---------|-------------|--------------------------|
+.Substring(x)   | SUBSTRING       | SUBSTRING    | MID        | SUBSTR      | SUBSTR | Mid     | SUBSTRING   | Start position may vary. |
+.Substring(x, y)| SUBSTRING       | SUBSTRING    | MID        | SUBSTR      | SUBSTR | MID     | SUBSTRING   | (0 or 1 based.) |
+.ToUpper()      | UPPER           | UPPER        | UPPER      | UPPER       | UPPER  | UCase   | UCASE       |                 |
+.ToLower()      | LOWER           | LOWER        | LOWER      | LOWER       | LOWER  | LCase   | LCASE       |                 |
+.Trim()         | LTRIM(RTRIM)    | TRIM(BOTH...)| TRIM       | LTRIM(RTRIM)| TRIM   | Trim    | LTRIM(RTRIM)|                 |
+.Length()       | DATALENGTH      | CHAR_LENGTH  | CHAR_LENGTH| LENGTH      | LENGTH | Len     | CHARACTER_LENGTH |            |
+.Replace(a, b)  | REPLACE         | REPLACE      | REPLACE    | REPLACE     | REPLACE| Replace | REPLACE     |                 |
+.IndexOf(x)     | CHARINDEX       | STRPOS       | LOCATE     | INSTR       | INSTR  | InStr   | LOCATE      |                 |
+.IndexOf(x, i)  | CHARINDEX       |              | LOCATE     | INSTR       |        | InStr   | LOCATE      |                 |
+(+)             | `+`             | `||`         | CONCAT     | `||`        | `||`   | &       | CONCAT      |                 |
+
+In where-clauses you can also use `.Contains()`, `.StartsWith()` and `.EndsWith()`, which are translated to 
+corresponding `LIKE`-clauses (e.g. StartsWith("abc") is `LIKE ('asdf%')`
+
+#### .NET DateTime Functions
+
+| .NET         | MsSqlServer    | PostgreSql| MySql    | Oracle    | SQLite  | MSAccess  | Odbc      |  Notes
+|--------------|----------------|-----------|----------|-----------|---------|-----------|-----------|--------------------------|
+.Date          | CAST(AS DATE)  | DATE_TRUNC| DATE     | TRUNC     | STRFTIME| DateValue(Format)| CONVERT(SQL_DATE)  |   |
+.Year          | YEAR           | DATE_PART | YEAR     | EXTRACT   | STRFTIME| Year      | YEAR       |   |
+.Month         | MONTH          | DATE_PART | MONTH    | EXTRACT   | STRFTIME| Month     | MONTH      |   |
+.Day           | DAY            | DATE_PART | DAY      | EXTRACT   | STRFTIME| Day       | DAYOFMONTH |   |
+.Hour          | DATEPART HOUR  | DATE_PART | HOUR     | EXTRACT   | STRFTIME| Hour      | HOUR       |   |
+.Minute        | DATEPART MINUTE| DATE_PART | MINUTE   | EXTRACT   | STRFTIME| Minute    | MINUTE     |   |
+.Second        | DATEPART SECOND| DATE_PART | SECOND   | EXTRACT   | STRFTIME| Second    | SECOND     |   |
+.AddYears(i)   | DATEADD YEAR   | + INTERVAL| DATE_ADD | + INTERVAL| DATE    | DateAdd   |            |   |
+.AddMonths(i)  | DATEADD MONTH  | + INTERVAL| DATE_ADD | + INTERVAL| DATE    | DateAdd   |            |   |
+.AddDays(f)    | DATEADD DAY    | + INTERVAL| DATE_ADD | + INTERVAL| DATE    | DateAdd   |            | .NET has float, bus SQL may ignore decimal fraction |
+.AddHours(f)   | DATEADD HOUR   | + INTERVAL| DATE_ADD | + INTERVAL| DATE    | DateAdd   |            |   |
+.AddMinutes(f) | DATEADD MINUTE | + INTERVAL| DATE_ADD | + INTERVAL| DATE    | DateAdd   |            |   |
+.AddSeconds(f) | DATEADD SECOND | + INTERVAL| DATE_ADD | + INTERVAL| DATE    | DateAdd   |            |   |
+
+#### Numerical Functions (e.g. Microsoft.FSharp.Core.Operators)
+
+| .NET          | MsSqlServer| PostgreSql| MySql   | Oracle| SQLite     | MSAccess| Odbc    |  Notes
+|---------------|------------|-----------|---------|-------|------------|---------|---------|--------------------------|
+abs(i)          | ABS        | ABS       | ABS     | ABS   | ABS        | Abs     | ABS     |   |
+ceil(i)         | CEILING    | CEILING   | CEILING | CEIL  | CAST + 0.5 | Fix+1   | CEILING |   |
+floor(i)        | FLOOR      | FLOOR     | FLOOR   | FLOOR | CAST AS INT| Int     | FLOOR   |   |
+round(i)        | ROUND      | ROUND     | ROUND   | ROUND | ROUND      | Round   | ROUND   |   |
+Math.Round(i,x) | ROUND      | ROUND     | ROUND   | ROUND | ROUND      | Round   | ROUND   |   |
+truncate(i)     | TRUNCATE   | TRUNC     | TRUNCATE| TRUNC |            | Fix     | TRUNCATE|   |
+(+)             | +          | +         | +       | +     | +          | +       | +       |   |
+(-)             | -          | -         | -       | -     | -          | -       | -       |   |
+(*)             | *          | *         | *       | *     | *          | *       | *       |   |
+(/)             | /          | /         | /       | /     | /          | /       | /       |   |
+(%)             | %          | %         | %       | %     | %          | %       | %       |   |
+
+#### Aggregate Functions 
+
+Also you can use these on group-by clause:
+`COUNT`, `SUM`, `MIN`, `MAX`, `AVG`
+
 *)
 
 (**

--- a/docs/content/core/querying.fsx
+++ b/docs/content/core/querying.fsx
@@ -128,7 +128,9 @@ where                    |x | Server side variables must be plain without .NET o
 
 ### Canonical Functions 
 
-Besides that, we support these .NET-functions to to transfer to SQL-clauses:
+Besides that, we support these .NET-functions to to transfer to SQL-clauses.
+If you use these, remember to check your database indexes.
+Most of the operations support parameters to be either constants or other SQL-columns.
 
 #### .NET String Functions (.NET)
 
@@ -160,7 +162,7 @@ corresponding `LIKE`-clauses (e.g. StartsWith("abc") is `LIKE ('asdf%')`
 .Minute        | DATEPART MINUTE| DATE_PART | MINUTE   | EXTRACT   | STRFTIME| Minute    | MINUTE     |   |
 .Second        | DATEPART SECOND| DATE_PART | SECOND   | EXTRACT   | STRFTIME| Second    | SECOND     |   |
 .AddYears(i)   | DATEADD YEAR   | + INTERVAL| DATE_ADD | + INTERVAL| DATETIME| DateAdd   |            |   |
-.AddMonths(i)  | DATEADD MONTH  | + INTERVAL| DATE_ADD | + INTERVAL| DATETIME| DateAdd   |            |   |
+.AddMonths(i)  | DATEADD MONTH  | + INTERVAL| DATE_ADD | + INTERVAL| DATETIME| DateAdd   |            | For now most date-additions can't be other columns. |
 .AddDays(f)    | DATEADD DAY    | + INTERVAL| DATE_ADD | + INTERVAL| DATETIME| DateAdd   |            | .NET has float, bus SQL may ignore decimal fraction |
 .AddHours(f)   | DATEADD HOUR   | + INTERVAL| DATE_ADD | + INTERVAL| DATETIME| DateAdd   |            |   |
 .AddMinutes(f) | DATEADD MINUTE | + INTERVAL| DATE_ADD | + INTERVAL| DATETIME| DateAdd   |            |   |

--- a/docs/content/core/querying.fsx
+++ b/docs/content/core/querying.fsx
@@ -159,12 +159,12 @@ corresponding `LIKE`-clauses (e.g. StartsWith("abc") is `LIKE ('asdf%')`
 .Hour          | DATEPART HOUR  | DATE_PART | HOUR     | EXTRACT   | STRFTIME| Hour      | HOUR       |   |
 .Minute        | DATEPART MINUTE| DATE_PART | MINUTE   | EXTRACT   | STRFTIME| Minute    | MINUTE     |   |
 .Second        | DATEPART SECOND| DATE_PART | SECOND   | EXTRACT   | STRFTIME| Second    | SECOND     |   |
-.AddYears(i)   | DATEADD YEAR   | + INTERVAL| DATE_ADD | + INTERVAL| DATE    | DateAdd   |            |   |
-.AddMonths(i)  | DATEADD MONTH  | + INTERVAL| DATE_ADD | + INTERVAL| DATE    | DateAdd   |            |   |
-.AddDays(f)    | DATEADD DAY    | + INTERVAL| DATE_ADD | + INTERVAL| DATE    | DateAdd   |            | .NET has float, bus SQL may ignore decimal fraction |
-.AddHours(f)   | DATEADD HOUR   | + INTERVAL| DATE_ADD | + INTERVAL| DATE    | DateAdd   |            |   |
-.AddMinutes(f) | DATEADD MINUTE | + INTERVAL| DATE_ADD | + INTERVAL| DATE    | DateAdd   |            |   |
-.AddSeconds(f) | DATEADD SECOND | + INTERVAL| DATE_ADD | + INTERVAL| DATE    | DateAdd   |            |   |
+.AddYears(i)   | DATEADD YEAR   | + INTERVAL| DATE_ADD | + INTERVAL| DATETIME| DateAdd   |            |   |
+.AddMonths(i)  | DATEADD MONTH  | + INTERVAL| DATE_ADD | + INTERVAL| DATETIME| DateAdd   |            |   |
+.AddDays(f)    | DATEADD DAY    | + INTERVAL| DATE_ADD | + INTERVAL| DATETIME| DateAdd   |            | .NET has float, bus SQL may ignore decimal fraction |
+.AddHours(f)   | DATEADD HOUR   | + INTERVAL| DATE_ADD | + INTERVAL| DATETIME| DateAdd   |            |   |
+.AddMinutes(f) | DATEADD MINUTE | + INTERVAL| DATE_ADD | + INTERVAL| DATETIME| DateAdd   |            |   |
+.AddSeconds(f) | DATEADD SECOND | + INTERVAL| DATE_ADD | + INTERVAL| DATETIME| DateAdd   |            |   |
 
 #### Numerical Functions (e.g. Microsoft.FSharp.Core.Operators)
 

--- a/paket.lock
+++ b/paket.lock
@@ -42,7 +42,7 @@ GROUP SourceFiles
 
 GITHUB
   remote: fsprojects/FSharp.TypeProviders.StarterPack
-    src/ProvidedTypes.fs (c50ace31d335b7bcb83b102d2cfd0ce2007ed681)
-    src/ProvidedTypes.fsi (c50ace31d335b7bcb83b102d2cfd0ce2007ed681)
+    src/ProvidedTypes.fs (45f4d8780b3213ef61ba4fccc716cd495565c1a4)
+    src/ProvidedTypes.fsi (45f4d8780b3213ef61ba4fccc716cd495565c1a4)
   remote: Thorium/Linq.Expression.Optimizer
-    src/Code/ExpressionOptimizer.fs (2173f03990cb4702785d01f93ea42af17126d312)
+    src/Code/ExpressionOptimizer.fs (b494733a57be4988cda349b65b5089db77ba00d6)

--- a/src/SQLProvider/Operators.fs
+++ b/src/SQLProvider/Operators.fs
@@ -50,16 +50,15 @@ module ColumnSchema =
 
     type CanonicalOp =
     //String functions
-    | Substring of int
-    | SubstringWithLength of int*int
+    | Substring of SqlIntOrColumn
+    | SubstringWithLength of SqlIntOrColumn*SqlIntOrColumn
     | ToUpper
     | ToLower
     | Trim
     | Length
-    | Replace of string*string
-    | IndexOf of string
-    | IndexOfStart of string*int
-    | IndexOfColumn of string*SqlColumnType //alias, column
+    | Replace of SqlStringOrColumn*SqlStringOrColumn
+    | IndexOf of SqlStringOrColumn
+    | IndexOfStart of SqlStringOrColumn*SqlIntOrColumn
     // Date functions
     | Date
     | Year
@@ -68,9 +67,9 @@ module ColumnSchema =
     | Hour
     | Minute
     | Second
-    | AddYears of int
+    | AddYears of SqlIntOrColumn
     | AddMonths of int
-    | AddDays of float
+    | AddDays of SqlFloatOrColumn
     | AddHours of float
     | AddMinutes of float
     | AddSeconds of float
@@ -89,6 +88,20 @@ module ColumnSchema =
     | KeyColumn of string
     | CanonicalOperation of CanonicalOp * SqlColumnType
     | GroupColumn of AggregateOperation
+
+    and SqlStringOrColumn =
+    | SqlStr of string
+    | SqlStrCol of string*SqlColumnType //alias*column
+
+    // More recursion, because you mighn want to say e.g.
+    // where (x.Substring(x.IndexOf("."), (x.Length-x.IndexOf("."))
+    and SqlIntOrColumn =
+    | SqlInt of int
+    | SqlIntCol of string*SqlColumnType //alias*column
+
+    and SqlFloatOrColumn =
+    | SqlFloat of float
+    | SqlNumCol of string*SqlColumnType //alias*column
 
 // Dummy operators, these are placeholders that are replaced in the expression tree traversal with special server-side operations such as In, Like
 // The operators here are used to force the compiler to statically check against the correct types

--- a/src/SQLProvider/Operators.fs
+++ b/src/SQLProvider/Operators.fs
@@ -38,11 +38,21 @@ type ConditionOperator =
         | NestedNotIn      -> "NOT IN"
 
 type AggregateOperation = // Aggregate (column name if not default)
-| Max of string Option
-| Min of string Option
-| Sum of string Option
-| Avg of string Option
-| CountOp of string Option
+| KeyOp of string
+| MaxOp of string
+| MinOp of string
+| SumOp of string
+| AvgOp of string
+| CountOp of string
+
+type CanonicalOp =
+| Substring of int
+| SubstringWithLength of int*int
+
+type SqlColumnType =
+| KeyColumn of string
+| CanonicalOperation of CanonicalOp * SqlColumnType
+| GroupColumn of AggregateOperation
 
 // Dummy operators, these are placeholders that are replaced in the expression tree traversal with special server-side operations such as In, Like
 // The operators here are used to force the compiler to statically check against the correct types

--- a/src/SQLProvider/Operators.fs
+++ b/src/SQLProvider/Operators.fs
@@ -59,6 +59,7 @@ module ColumnSchema =
     | Replace of string*string
     | IndexOf of string
     | IndexOfStart of string*int
+    | IndexOfColumn of string*SqlColumnType //alias, column
     // Date functions
     | Date
     | Year

--- a/src/SQLProvider/Operators.fs
+++ b/src/SQLProvider/Operators.fs
@@ -45,14 +45,49 @@ type AggregateOperation = // Aggregate (column name if not default)
 | AvgOp of string
 | CountOp of string
 
-type CanonicalOp =
-| Substring of int
-| SubstringWithLength of int*int
+[<AutoOpenAttribute>]
+module ColumnSchema =
 
-type SqlColumnType =
-| KeyColumn of string
-| CanonicalOperation of CanonicalOp * SqlColumnType
-| GroupColumn of AggregateOperation
+    type CanonicalOp =
+    //String functions
+    | Substring of int
+    | SubstringWithLength of int*int
+    | ToUpper
+    | ToLower
+    | Trim
+    | Length
+    | Replace of string*string
+    | IndexOf of string
+    | IndexOfStart of string*int
+    // Date functions
+    | Date
+    | Year
+    | Month
+    | Day
+    | Hour
+    | Minute
+    | Second
+    | AddYears of int
+    | AddMonths of int
+    | AddDays of float
+    | AddHours of float
+    | AddMinutes of float
+    | AddSeconds of float
+    // Numerical functions
+    | Abs
+    | Ceil
+    | Floor
+    | Round
+    | RoundDecimals of int
+    | Truncate
+    // Other
+    | BasicMath of string*obj //operation, constant
+    | BasicMathOfColumns of string*string*SqlColumnType //operation, alias, column
+
+    and SqlColumnType =
+    | KeyColumn of string
+    | CanonicalOperation of CanonicalOp * SqlColumnType
+    | GroupColumn of AggregateOperation
 
 // Dummy operators, these are placeholders that are replaced in the expression tree traversal with special server-side operations such as In, Like
 // The operators here are used to force the compiler to statically check against the correct types

--- a/src/SQLProvider/Providers.MSAccess.fs
+++ b/src/SQLProvider/Providers.MSAccess.fs
@@ -33,13 +33,23 @@ type internal MSAccessProvider() =
             let column = fieldNotation al col
             match cf with
             // String functions
-            | Substring startPos -> sprintf "Mid(%s, %i)" column startPos
-            | SubstringWithLength(startPos,strLen) -> sprintf "Mid(%s, %i, %i)" column startPos strLen
+            | Replace(SqlStr(searchItm),SqlStrCol(al2, col2)) -> sprintf "REPLACE(%s,'%s',%s)" column searchItm (fieldNotation al2 col2)
+            | Replace(SqlStrCol(al2, col2),SqlStr(toItm)) -> sprintf "REPLACE(%s,%s,'%s')" column (fieldNotation al2 col2) toItm
+            | Replace(SqlStrCol(al2, col2),SqlStrCol(al3, col3)) -> sprintf "REPLACE(%s,%s,%s)" column (fieldNotation al2 col2) (fieldNotation al3 col3)
+            | Substring(SqlInt startPos) -> sprintf "Mid(%s, %i)" column startPos
+            | Substring(SqlIntCol(al2, col2)) -> sprintf "Mid(%s, %s)" column (fieldNotation al2 col2)
+            | SubstringWithLength(SqlInt startPos,SqlInt strLen) -> sprintf "Mid(%s, %i, %i)" column startPos strLen
+            | SubstringWithLength(SqlInt startPos,SqlIntCol(al2, col2)) -> sprintf "Mid(%s, %i, %s)" column startPos (fieldNotation al2 col2)
+            | SubstringWithLength(SqlIntCol(al2, col2),SqlInt strLen) -> sprintf "Mid(%s, %s, %i)" column (fieldNotation al2 col2) strLen
+            | SubstringWithLength(SqlIntCol(al2, col2),SqlIntCol(al3, col3)) -> sprintf "Mid(%s, %s, %s)" column (fieldNotation al2 col2) (fieldNotation al3 col3)
             | Trim -> sprintf "Trim(%s)" column
             | Length -> sprintf "Len(%s)" column
-            | IndexOf search -> sprintf "InStr('%s',%s)" search column
-            | IndexOfColumn(al2,col2) -> sprintf "InStr(%s,%s)" (fieldNotation al2 col2) column
-            | IndexOfStart(search,startPos) -> sprintf "InStr(%d,'%s',%s)" startPos search column
+            | IndexOf(SqlStr search) -> sprintf "InStr('%s',%s)" search column
+            | IndexOf(SqlStrCol(al2, col2)) -> sprintf "InStr(%s,%s)" (fieldNotation al2 col2) column
+            | IndexOfStart(SqlStr(search),(SqlInt startPos)) -> sprintf "InStr(%d,'%s',%s)" startPos search column
+            | IndexOfStart(SqlStr(search),SqlIntCol(al2, col2)) -> sprintf "InStr(%s,'%s',%s)" (fieldNotation al2 col2) search column
+            | IndexOfStart(SqlStrCol(al2, col2),(SqlInt startPos)) -> sprintf "InStr(%d,%s,%s)" startPos (fieldNotation al2 col2) column
+            | IndexOfStart(SqlStrCol(al2, col2),SqlIntCol(al3, col3)) -> sprintf "InStr(%s,%s,%s)" (fieldNotation al3 col3) (fieldNotation al2 col2) column
             | ToUpper -> sprintf "UCase(%s)" column
             | ToLower -> sprintf "LCase(%s)" column
             // Date functions
@@ -50,9 +60,11 @@ type internal MSAccessProvider() =
             | Hour -> sprintf "Hour(%s)" column
             | Minute -> sprintf "Minute(%s)" column
             | Second -> sprintf "Second(%s)" column
-            | AddYears x -> sprintf "DateAdd(\"yyyy\", %d, %s)" x column
+            | AddYears(SqlInt x) -> sprintf "DateAdd(\"yyyy\", %d, %s)" x column
+            | AddYears(SqlIntCol(al2, col2)) -> sprintf "DateAdd(\"yyyy\", %s, %s)" (fieldNotation al2 col2) column
             | AddMonths x -> sprintf "DateAdd(\"m\", %d, %s)" x column
-            | AddDays x -> sprintf "DateAdd(\"d\", %f, %s)" x column // SQL ignores decimal part :-(
+            | AddDays(SqlFloat x) -> sprintf "DateAdd(\"d\", %f, %s)" x column // SQL ignores decimal part :-(
+            | AddDays(SqlNumCol(al2, col2)) -> sprintf "DateAdd(\"d\", %s, %s)" (fieldNotation al2 col2) column
             | AddHours x -> sprintf "DateAdd(\"h\", %f, %s)" x column
             | AddMinutes x -> sprintf "DateAdd(\"n\", %f, %s)" x column
             | AddSeconds x -> sprintf "DateAdd(\"s\", %f, %s)" x column

--- a/src/SQLProvider/Providers.MSAccess.fs
+++ b/src/SQLProvider/Providers.MSAccess.fs
@@ -22,6 +22,24 @@ type internal MSAccessProvider() =
     let mutable findDbType : (string -> TypeMapping option)  = fun _ -> failwith "!"
     let mutable findDbTypeByEnum : (int -> TypeMapping option)  = fun _ -> failwith "!"
 
+    let rec fieldNotation(al:alias,c:SqlColumnType) = 
+        let colSprint =
+            match String.IsNullOrEmpty(al) with
+            | true -> sprintf "[%s]"
+            | false -> sprintf "[%s].[%s]" al
+        match c with
+        // Custom database spesific overrides for canonical function:
+        | SqlColumnType.CanonicalOperation(CanonicalOp.Substring startPos,col) -> sprintf "MID(%s, %i)" (fieldNotation(al,col)) startPos
+        | SqlColumnType.CanonicalOperation(CanonicalOp.SubstringWithLength(startPos,strLen),col) -> sprintf "MID(%s, %i, %i)" (fieldNotation(al,col)) startPos strLen
+        | _ -> Utilities.genericFieldNotation colSprint c
+
+    let fieldNotationAlias(al:alias,col:SqlColumnType) =
+        let aliasSprint =
+            match String.IsNullOrEmpty(al) with
+            | true -> sprintf "[%s]"
+            | false -> sprintf "[%s_%s]" al
+        Utilities.genericAliasNotation aliasSprint col
+
     let createTypeMappings (con:OleDbConnection) =
         if con.State <> ConnectionState.Open then con.Open()
         let dt = con.GetSchema("DataTypes")
@@ -311,19 +329,10 @@ type internal MSAccessProvider() =
             // Create sumBy, minBy, maxBy, ... field columns
             let columns =
                 let extracolumns =
-                    let fieldNotation(al:alias,col:string) =
-                        match String.IsNullOrEmpty(al) with
-                        | true -> sprintf "[%s]" col
-                        | false -> sprintf "[%s].[%s]" al col
-                    let fieldNotationAlias(al:alias,col:string) =
-                        match String.IsNullOrEmpty(al) with
-                        | true -> sprintf "['%s']" col
-                        | false -> sprintf "[-%s-%s-]" al col
-
                     match sqlQuery.Grouping with
                     | [] -> FSharp.Data.Sql.Common.Utilities.parseAggregates fieldNotation fieldNotationAlias sqlQuery.AggregateOp
                     | g  -> 
-                        let keys = g |> List.map(fst) |> List.concat |> List.map(fieldNotation)
+                        let keys = g |> List.map(fst) |> List.concat |> List.map(fun (a,c) -> fieldNotation(a,c))
                         let aggs = g |> List.map(snd) |> List.concat
                         let res2 = FSharp.Data.Sql.Common.Utilities.parseAggregates fieldNotation fieldNotationAlias aggs |> List.toSeq
                         [String.Join(", ", keys) + (match aggs with [] -> "" | _ -> ", ") + String.Join(", ", res2)] 
@@ -352,6 +361,7 @@ type internal MSAccessProvider() =
                     let build op preds (rest:Condition list option) =
                         ~~ "("
                         preds |> List.iteri( fun i (alias,col,operator,data) ->
+                                let column = fieldNotation(alias,col)
                                 let extractData data =
                                      match data with
                                      | Some(x) when (box x :? System.Linq.IQueryable) -> [||]
@@ -366,30 +376,30 @@ type internal MSAccessProvider() =
                                 let paras = extractData data
                                 ~~(sprintf "%s%s" prefix <|
                                     match operator with
-                                    | FSharp.Data.Sql.IsNull -> (sprintf "[%s].[%s] IS NULL") alias col
-                                    | FSharp.Data.Sql.NotNull -> (sprintf "[%s].[%s] IS NOT NULL") alias col
+                                    | FSharp.Data.Sql.IsNull -> sprintf "%s IS NULL" column
+                                    | FSharp.Data.Sql.NotNull -> sprintf "%s IS NOT NULL" column
                                     | FSharp.Data.Sql.In ->
                                         let text = String.Join(",",paras |> Array.map (fun p -> p.ParameterName))
                                         Array.iter parameters.Add paras
-                                        (sprintf "[%s].[%s] IN (%s)") alias col text
+                                        sprintf "%s IN (%s)" column text
                                     | FSharp.Data.Sql.NestedIn when data.IsSome ->
                                         let innersql, innerpars = data.Value |> box :?> string * IDbDataParameter[]
                                         Array.iter parameters.Add innerpars
-                                        (sprintf "[%s].[%s] IN (%s)") alias col innersql
+                                        sprintf "%s IN (%s)" column innersql
                                     | FSharp.Data.Sql.NotIn ->
                                         let text = String.Join(",",paras |> Array.map (fun p -> p.ParameterName))
                                         Array.iter parameters.Add paras
-                                        (sprintf "[%s].[%s] NOT IN (%s)") alias col text
+                                        sprintf "%s NOT IN (%s)" column text
                                     | FSharp.Data.Sql.NestedNotIn when data.IsSome ->
                                         let innersql, innerpars = data.Value |> box :?> string * IDbDataParameter[]
                                         Array.iter parameters.Add innerpars
-                                        (sprintf "[%s].[%s] NOT IN (%s)") alias col innersql
+                                        sprintf "%s NOT IN (%s)" column innersql
                                     | _ ->
-                                        let aliasformat = if alias<>"" then (sprintf "[%s].[%s]%s %s") alias col else (sprintf "%s %s %s") col
+                                        let aliasformat = sprintf "%s %s %s" column
                                         match data with 
-                                        | Some d when (box d :? alias * string) ->
-                                            let alias2, col2 = box d :?> (alias * string)
-                                            let alias2f = if alias2<>"" then (sprintf "[%s].[%s]") alias2 col2 else col2
+                                        | Some d when (box d :? alias * SqlColumnType) ->
+                                            let alias2, col2 = box d :?> (alias * SqlColumnType)
+                                            let alias2f = fieldNotation(alias2,col2)
                                             aliasformat (operator.ToString()) alias2f
                                         | _ ->
                                             parameters.Add paras.[0]
@@ -432,24 +442,23 @@ type internal MSAccessProvider() =
                     ~~  (sprintf "%s [%s] as [%s] on "
                             joinType destTable.Name destAlias)
                     ~~  (String.Join(" AND ", (List.zip data.ForeignKey data.PrimaryKey) |> List.map(fun (foreignKey,primaryKey) ->
-                        sprintf "[%s].[%s] = [%s].[%s]"
-                            (if data.RelDirection = RelationshipDirection.Parents then fromAlias else destAlias)
-                            foreignKey
-                            (if data.RelDirection = RelationshipDirection.Parents then destAlias else fromAlias)
-                            primaryKey)))
+                        sprintf "%s = %s"
+                            (fieldNotation((if data.RelDirection = RelationshipDirection.Parents then fromAlias else destAlias),foreignKey))
+                            (fieldNotation((if data.RelDirection = RelationshipDirection.Parents then destAlias else fromAlias),primaryKey))
+                            )))
                     if (numLinks > 0)  then ~~ ")")//append close paren after each JOIN, if necessary
 
             let groupByBuilder() =
                 sqlQuery.Grouping |> List.map(fst) |> List.concat
                 |> List.iteri(fun i (alias,column) ->
                     if i > 0 then ~~ ", "
-                    ~~ (sprintf "[%s].[%s]" alias column))
+                    ~~ (fieldNotation(alias,column)))
 
             let orderByBuilder() =
                 sqlQuery.Ordering
                 |> List.iteri(fun i (alias,column,desc) ->
                     if i > 0 then ~~ ", "
-                    ~~ (sprintf "[%s].[%s] %s" alias column (if not desc then "DESC" else "")))
+                    ~~ (sprintf "%s %s" (fieldNotation(alias,column)) (if not desc then "DESC" else "")))
 
             // SELECT
             if sqlQuery.Distinct then ~~(sprintf "SELECT DISTINCT %s%s " (if sqlQuery.Take.IsSome then sprintf "TOP %i " sqlQuery.Take.Value else "")   columns)
@@ -479,7 +488,7 @@ type internal MSAccessProvider() =
             if sqlQuery.HavingFilters.Length > 0 then
                 let keys = sqlQuery.Grouping |> List.map(fst) |> List.concat
 
-                let f = [And([],Some (sqlQuery.HavingFilters |> CommonTasks.parseHaving keys))]
+                let f = [And([],Some (sqlQuery.HavingFilters |> CommonTasks.parseHaving fieldNotation keys))]
                 ~~" HAVING "
                 filterBuilder f
 

--- a/src/SQLProvider/Providers.MSAccess.fs
+++ b/src/SQLProvider/Providers.MSAccess.fs
@@ -22,16 +22,47 @@ type internal MSAccessProvider() =
     let mutable findDbType : (string -> TypeMapping option)  = fun _ -> failwith "!"
     let mutable findDbTypeByEnum : (int -> TypeMapping option)  = fun _ -> failwith "!"
 
-    let rec fieldNotation(al:alias,c:SqlColumnType) = 
+    let rec fieldNotation (al:alias) (c:SqlColumnType) =
         let colSprint =
             match String.IsNullOrEmpty(al) with
             | true -> sprintf "[%s]"
             | false -> sprintf "[%s].[%s]" al
         match c with
         // Custom database spesific overrides for canonical function:
-        | SqlColumnType.CanonicalOperation(CanonicalOp.Substring startPos,col) -> sprintf "MID(%s, %i)" (fieldNotation(al,col)) startPos
-        | SqlColumnType.CanonicalOperation(CanonicalOp.SubstringWithLength(startPos,strLen),col) -> sprintf "MID(%s, %i, %i)" (fieldNotation(al,col)) startPos strLen
-        | _ -> Utilities.genericFieldNotation colSprint c
+        | SqlColumnType.CanonicalOperation(cf,col) ->
+            let column = fieldNotation al col
+            match cf with
+            // String functions
+            | Substring startPos -> sprintf "Mid(%s, %i)" column startPos
+            | SubstringWithLength(startPos,strLen) -> sprintf "Mid(%s, %i, %i)" column startPos strLen
+            | Trim -> sprintf "Trim(%s)" column
+            | Length -> sprintf "Len(%s)" column
+            | IndexOf search -> sprintf "InStr(%s,%s)" search column
+            | IndexOfStart(search,startPos) -> sprintf "InStr(%d,%s,%s)" startPos search column
+            | ToUpper -> sprintf "UCase(%s)" column
+            | ToLower -> sprintf "LCase(%s)" column
+            // Date functions
+            | Date -> sprintf "DateValue(Format(%s, \"yyyy-mm-dd\")" column
+            | Year -> sprintf "Year(%s)" column
+            | Month -> sprintf "Month(%s)" column
+            | Day -> sprintf "Day(%s)" column
+            | Hour -> sprintf "Hour(%s)" column
+            | Minute -> sprintf "Minute(%s)" column
+            | Second -> sprintf "Second(%s)" column
+            | AddYears x -> sprintf "DateAdd(\"yyyy\", %d, %s)" x column
+            | AddMonths x -> sprintf "DateAdd(\"m\", %d, %s)" x column
+            | AddDays x -> sprintf "DateAdd(\"d\", %f, %s)" x column // SQL ignores decimal part :-(
+            | AddHours x -> sprintf "DateAdd(\"h\", %f, %s)" x column
+            | AddMinutes x -> sprintf "DateAdd(\"n\", %f, %s)" x column
+            | AddSeconds x -> sprintf "DateAdd(\"s\", %f, %s)" x column
+            // Math functions
+            | Truncate -> sprintf "Fix(%s)" column
+            | Ceil -> sprintf "Fix(%s)+1" column
+            | Floor -> sprintf "Int(%s)" column
+            | BasicMathOfColumns(o, a, c) -> sprintf "(%s %s %s)" column (o.Replace("||", "&")) (fieldNotation a c)
+            | BasicMath(o, par) when (par :? String || par :? Char) -> sprintf "(%s %s '%O')" column (o.Replace("||", "&")) par
+            | _ -> Utilities.genericFieldNotation (fieldNotation al) colSprint c
+        | _ -> Utilities.genericFieldNotation (fieldNotation al) colSprint c
 
     let fieldNotationAlias(al:alias,col:SqlColumnType) =
         let aliasSprint =
@@ -332,7 +363,7 @@ type internal MSAccessProvider() =
                     match sqlQuery.Grouping with
                     | [] -> FSharp.Data.Sql.Common.Utilities.parseAggregates fieldNotation fieldNotationAlias sqlQuery.AggregateOp
                     | g  -> 
-                        let keys = g |> List.map(fst) |> List.concat |> List.map(fun (a,c) -> fieldNotation(a,c))
+                        let keys = g |> List.map(fst) |> List.concat |> List.map(fun (a,c) -> (fieldNotation a c))
                         let aggs = g |> List.map(snd) |> List.concat
                         let res2 = FSharp.Data.Sql.Common.Utilities.parseAggregates fieldNotation fieldNotationAlias aggs |> List.toSeq
                         [String.Join(", ", keys) + (match aggs with [] -> "" | _ -> ", ") + String.Join(", ", res2)] 
@@ -361,7 +392,7 @@ type internal MSAccessProvider() =
                     let build op preds (rest:Condition list option) =
                         ~~ "("
                         preds |> List.iteri( fun i (alias,col,operator,data) ->
-                                let column = fieldNotation(alias,col)
+                                let column = fieldNotation alias col
                                 let extractData data =
                                      match data with
                                      | Some(x) when (box x :? System.Linq.IQueryable) -> [||]
@@ -399,7 +430,7 @@ type internal MSAccessProvider() =
                                         match data with 
                                         | Some d when (box d :? alias * SqlColumnType) ->
                                             let alias2, col2 = box d :?> (alias * SqlColumnType)
-                                            let alias2f = fieldNotation(alias2,col2)
+                                            let alias2f = fieldNotation alias2 col2
                                             aliasformat (operator.ToString()) alias2f
                                         | _ ->
                                             parameters.Add paras.[0]
@@ -443,8 +474,8 @@ type internal MSAccessProvider() =
                             joinType destTable.Name destAlias)
                     ~~  (String.Join(" AND ", (List.zip data.ForeignKey data.PrimaryKey) |> List.map(fun (foreignKey,primaryKey) ->
                         sprintf "%s = %s"
-                            (fieldNotation((if data.RelDirection = RelationshipDirection.Parents then fromAlias else destAlias),foreignKey))
-                            (fieldNotation((if data.RelDirection = RelationshipDirection.Parents then destAlias else fromAlias),primaryKey))
+                            (fieldNotation (if data.RelDirection = RelationshipDirection.Parents then fromAlias else destAlias) foreignKey)
+                            (fieldNotation (if data.RelDirection = RelationshipDirection.Parents then destAlias else fromAlias) primaryKey)
                             )))
                     if (numLinks > 0)  then ~~ ")")//append close paren after each JOIN, if necessary
 
@@ -452,13 +483,13 @@ type internal MSAccessProvider() =
                 sqlQuery.Grouping |> List.map(fst) |> List.concat
                 |> List.iteri(fun i (alias,column) ->
                     if i > 0 then ~~ ", "
-                    ~~ (fieldNotation(alias,column)))
+                    ~~ (fieldNotation alias column))
 
             let orderByBuilder() =
                 sqlQuery.Ordering
                 |> List.iteri(fun i (alias,column,desc) ->
                     if i > 0 then ~~ ", "
-                    ~~ (sprintf "%s %s" (fieldNotation(alias,column)) (if not desc then "DESC" else "")))
+                    ~~ (sprintf "%s %s" (fieldNotation alias column) (if not desc then "DESC" else "")))
 
             // SELECT
             if sqlQuery.Distinct then ~~(sprintf "SELECT DISTINCT %s%s " (if sqlQuery.Take.IsSome then sprintf "TOP %i " sqlQuery.Take.Value else "")   columns)

--- a/src/SQLProvider/Providers.MSAccess.fs
+++ b/src/SQLProvider/Providers.MSAccess.fs
@@ -37,8 +37,9 @@ type internal MSAccessProvider() =
             | SubstringWithLength(startPos,strLen) -> sprintf "Mid(%s, %i, %i)" column startPos strLen
             | Trim -> sprintf "Trim(%s)" column
             | Length -> sprintf "Len(%s)" column
-            | IndexOf search -> sprintf "InStr(%s,%s)" search column
-            | IndexOfStart(search,startPos) -> sprintf "InStr(%d,%s,%s)" startPos search column
+            | IndexOf search -> sprintf "InStr('%s',%s)" search column
+            | IndexOfColumn(al2,col2) -> sprintf "InStr(%s,%s)" (fieldNotation al2 col2) column
+            | IndexOfStart(search,startPos) -> sprintf "InStr(%d,'%s',%s)" startPos search column
             | ToUpper -> sprintf "UCase(%s)" column
             | ToLower -> sprintf "LCase(%s)" column
             // Date functions

--- a/src/SQLProvider/Providers.MsSqlServer.fs
+++ b/src/SQLProvider/Providers.MsSqlServer.fs
@@ -280,6 +280,24 @@ type internal MSSqlServerProvider(tableNames:string) =
     let columnLookup = ConcurrentDictionary<string,ColumnLookup>()
     let relationshipLookup = ConcurrentDictionary<string,Relationship list * Relationship list>()
 
+    let rec fieldNotation(al:alias,c:SqlColumnType) = 
+        let colSprint =
+            match String.IsNullOrEmpty(al) with
+            | true -> sprintf "[%s]" 
+            | false -> sprintf "[%s].[%s]" al 
+        match c with
+        // Custom database spesific overrides for canonical function:
+        | SqlColumnType.CanonicalOperation(CanonicalOp.Substring startPos,col) -> sprintf "SUBSTRING(%s, %i)" (fieldNotation(al,col)) startPos
+        | SqlColumnType.CanonicalOperation(CanonicalOp.SubstringWithLength(startPos,strLen),col) -> sprintf "SUBSTRING(%s, %i, %i)" (fieldNotation(al,col)) startPos strLen
+        | _ -> Utilities.genericFieldNotation colSprint c
+
+    let fieldNotationAlias(al:alias,col:SqlColumnType) = 
+        let aliasSprint =
+            match String.IsNullOrEmpty(al) with
+            | true -> sprintf "'[%s]'"
+            | false -> sprintf "'[%s].[%s]'" al
+        Utilities.genericAliasNotation aliasSprint col
+
     let createInsertCommand (con:IDbConnection) (sb:Text.StringBuilder) (entity:SqlEntity) =
         let (~~) (t:string) = sb.Append t |> ignore
 
@@ -598,19 +616,10 @@ type internal MSSqlServerProvider(tableNames:string) =
             // Create sumBy, minBy, maxBy, ... field columns
             let columns =
                 let extracolumns =
-                    let fieldNotation(al:alias,col:string) = 
-                        match String.IsNullOrEmpty(al) with
-                        | true -> sprintf "[%s]" col
-                        | false -> sprintf "[%s].[%s]" al col
-                    let fieldNotationAlias(al:alias,col:string) = 
-                        match String.IsNullOrEmpty(al) with
-                        | true -> sprintf "'[%s]'" col
-                        | false -> sprintf "'[%s][%s]'" al col
-
                     match sqlQuery.Grouping with
                     | [] -> FSharp.Data.Sql.Common.Utilities.parseAggregates fieldNotation fieldNotationAlias sqlQuery.AggregateOp
                     | g  -> 
-                        let keys = g |> List.map(fst) |> List.concat |> List.map(fieldNotation)
+                        let keys = g |> List.map(fst) |> List.concat |> List.map(fun (a,c) -> fieldNotation(a,c))
                         let aggs = g |> List.map(snd) |> List.concat
                         let res2 = FSharp.Data.Sql.Common.Utilities.parseAggregates fieldNotation fieldNotationAlias aggs |> List.toSeq
                         [String.Join(", ", keys) + (match aggs with [] -> "" | _ -> ", ") + String.Join(", ", res2)] 
@@ -635,6 +644,7 @@ type internal MSSqlServerProvider(tableNames:string) =
                     let build op preds (rest:Condition list option) =
                         ~~ "("
                         preds |> List.iteri( fun i (alias,col,operator,data) ->
+                                let column = fieldNotation(alias,col)
                                 let extractData data =
                                      match data with
                                      | Some(x) when (box x :? System.Linq.IQueryable) -> [||]
@@ -655,8 +665,8 @@ type internal MSSqlServerProvider(tableNames:string) =
                                         let text = String.Join(",", array |> Array.map (fun p -> p.ParameterName))
                                         Array.iter parameters.Add array
                                         match operator with
-                                        | FSharp.Data.Sql.In -> (sprintf "[%s].[%s] IN (%s)") alias col text
-                                        | FSharp.Data.Sql.NotIn -> (sprintf "[%s].[%s] NOT IN (%s)") alias col text
+                                        | FSharp.Data.Sql.In -> sprintf "%s IN (%s)" column text
+                                        | FSharp.Data.Sql.NotIn -> sprintf "%s NOT IN (%s)" column text
                                         | _ -> failwith "Should not be called with any other operator"
 
                                 let prefix = if i>0 then (sprintf " %s " op) else ""
@@ -666,24 +676,24 @@ type internal MSSqlServerProvider(tableNames:string) =
                                     let innersql, innerpars = data.Value |> box :?> string * IDbDataParameter[]
                                     Array.iter parameters.Add innerpars
                                     match operator with
-                                    | FSharp.Data.Sql.NestedIn -> (sprintf "[%s].[%s] IN (%s)") alias col innersql
-                                    | FSharp.Data.Sql.NestedNotIn -> (sprintf "[%s].[%s] NOT IN (%s)") alias col innersql
+                                    | FSharp.Data.Sql.NestedIn -> sprintf "%s IN (%s)" column innersql
+                                    | FSharp.Data.Sql.NestedNotIn -> sprintf "%s NOT IN (%s)" column innersql
                                     | _ -> failwith "Should not be called with any other operator"
 
                                 ~~(sprintf "%s%s" prefix <|
                                     match operator with
-                                    | FSharp.Data.Sql.IsNull -> (sprintf "[%s].[%s] IS NULL") alias col
-                                    | FSharp.Data.Sql.NotNull -> (sprintf "[%s].[%s] IS NOT NULL") alias col
+                                    | FSharp.Data.Sql.IsNull -> sprintf "%s IS NULL" column
+                                    | FSharp.Data.Sql.NotNull -> sprintf "%s IS NOT NULL" column
                                     | FSharp.Data.Sql.In 
                                     | FSharp.Data.Sql.NotIn -> operatorIn operator paras
                                     | FSharp.Data.Sql.NestedIn 
                                     | FSharp.Data.Sql.NestedNotIn -> operatorInQuery operator paras
                                     | _ ->
-                                        let aliasformat = if alias<>"" then (sprintf "[%s].[%s]%s %s") alias col else (sprintf "%s %s %s") col
+                                        let aliasformat = sprintf "%s %s %s" column
                                         match data with 
-                                        | Some d when (box d :? alias * string) ->
-                                            let alias2, col2 = box d :?> (alias * string)
-                                            let alias2f = if alias2<>"" then (sprintf "[%s].[%s]") alias2 col2 else col2
+                                        | Some d when (box d :? alias * SqlColumnType) ->
+                                            let alias2, col2 = box d :?> (alias * SqlColumnType)
+                                            let alias2f = (fieldNotation(alias2,col2))
                                             aliasformat (operator.ToString()) alias2f
                                         | _ ->
                                             parameters.Add paras.[0]
@@ -725,24 +735,22 @@ type internal MSSqlServerProvider(tableNames:string) =
                     ~~  (sprintf "%s [%s].[%s] as [%s] on "
                             joinType destTable.Schema destTable.Name destAlias)
                     ~~  (String.Join(" AND ", (List.zip data.ForeignKey data.PrimaryKey) |> List.map(fun (foreignKey,primaryKey) ->
-                        sprintf "[%s].[%s] = [%s].[%s]"
-                            (if data.RelDirection = RelationshipDirection.Parents then fromAlias else destAlias)
-                            foreignKey
-                            (if data.RelDirection = RelationshipDirection.Parents then destAlias else fromAlias)
-                            primaryKey
+                        sprintf "%s = %s"
+                            (fieldNotation((if data.RelDirection = RelationshipDirection.Parents then fromAlias else destAlias),foreignKey))
+                            (fieldNotation((if data.RelDirection = RelationshipDirection.Parents then destAlias else fromAlias),primaryKey))
                         ))))
 
             let groupByBuilder() =
                 sqlQuery.Grouping |> List.map(fst) |> List.concat
                 |> List.iteri(fun i (alias,column) ->
                     if i > 0 then ~~ ", "
-                    ~~ (sprintf "[%s].[%s]" alias column))
+                    ~~ (fieldNotation(alias,column)))
 
             let orderByBuilder() =
                 sqlQuery.Ordering
                 |> List.iteri(fun i (alias,column,desc) ->
                     if i > 0 then ~~ ", "
-                    ~~ (sprintf "[%s].[%s]%s" alias column (if not desc then "DESC" else "")))
+                    ~~ (sprintf "%s %s" (fieldNotation(alias,column)) (if not desc then "DESC" else "")))
 
             // SELECT
             if sqlQuery.Distinct then ~~(sprintf "SELECT DISTINCT %s%s " (if sqlQuery.Take.IsSome then sprintf "TOP %i " sqlQuery.Take.Value else "")   columns)
@@ -771,7 +779,7 @@ type internal MSSqlServerProvider(tableNames:string) =
             if sqlQuery.HavingFilters.Length > 0 then
                 let keys = sqlQuery.Grouping |> List.map(fst) |> List.concat
 
-                let f = [And([],Some (sqlQuery.HavingFilters |> CommonTasks.parseHaving keys))]
+                let f = [And([],Some (sqlQuery.HavingFilters |> CommonTasks.parseHaving fieldNotation keys))]
                 ~~" HAVING "
                 filterBuilder f
 

--- a/src/SQLProvider/Providers.MsSqlServer.fs
+++ b/src/SQLProvider/Providers.MsSqlServer.fs
@@ -292,13 +292,23 @@ type internal MSSqlServerProvider(tableNames:string) =
             let column = fieldNotation al col
             match cf with
             // String functions
-            | Substring(startPos) -> sprintf "SUBSTRING(%s, %i)" column startPos
-            | SubstringWithLength(startPos,strLen) -> sprintf "SUBSTRING(%s, %i, %i)" column startPos strLen
+            | Replace(SqlStr(searchItm),SqlStrCol(al2, col2)) -> sprintf "REPLACE(%s,'%s',%s)" column searchItm (fieldNotation al2 col2)
+            | Replace(SqlStrCol(al2, col2),SqlStr(toItm)) -> sprintf "REPLACE(%s,%s,'%s')" column (fieldNotation al2 col2) toItm
+            | Replace(SqlStrCol(al2, col2),SqlStrCol(al3, col3)) -> sprintf "REPLACE(%s,%s,%s)" column (fieldNotation al2 col2) (fieldNotation al3 col3)
+            | Substring(SqlInt startPos) -> sprintf "SUBSTRING(%s, %i)" column startPos
+            | Substring(SqlIntCol(al2, col2)) -> sprintf "SUBSTRING(%s, %s)" column (fieldNotation al2 col2)
+            | SubstringWithLength(SqlInt startPos,SqlInt strLen) -> sprintf "SUBSTRING(%s, %i, %i)" column startPos strLen
+            | SubstringWithLength(SqlInt startPos,SqlIntCol(al2, col2)) -> sprintf "SUBSTRING(%s, %i, %s)" column startPos (fieldNotation al2 col2)
+            | SubstringWithLength(SqlIntCol(al2, col2),SqlInt strLen) -> sprintf "SUBSTRING(%s, %s, %i)" column (fieldNotation al2 col2) strLen
+            | SubstringWithLength(SqlIntCol(al2, col2),SqlIntCol(al3, col3)) -> sprintf "SUBSTRING(%s, %s, %s)" column (fieldNotation al2 col2) (fieldNotation al3 col3)
             | Trim -> sprintf "LTRIM(RTRIM(%s))" column
             | Length -> sprintf "DATALENGTH(%s)" column
-            | IndexOf search -> sprintf "CHARINDEX('%s',%s)" search column
-            | IndexOfColumn(al2,col2) -> sprintf "CHARINDEX(%s,%s)" (fieldNotation al2 col2) column
-            | IndexOfStart(search,startPos) -> sprintf "CHARINDEX('%s',%s,%d)" search column startPos
+            | IndexOf(SqlStr search) -> sprintf "CHARINDEX('%s',%s)" search column
+            | IndexOf(SqlStrCol(al2, col2)) -> sprintf "CHARINDEX(%s,%s)" (fieldNotation al2 col2) column
+            | IndexOfStart(SqlStr(search),(SqlInt startPos)) -> sprintf "CHARINDEX('%s',%s,%d)" search column startPos
+            | IndexOfStart(SqlStr(search),SqlIntCol(al2, col2)) -> sprintf "CHARINDEX('%s',%s,%s)" search column (fieldNotation al2 col2)
+            | IndexOfStart(SqlStrCol(al2, col2),(SqlInt startPos)) -> sprintf "CHARINDEX(%s,%s,%d)" (fieldNotation al2 col2) column startPos
+            | IndexOfStart(SqlStrCol(al2, col2),SqlIntCol(al3, col3)) -> sprintf "CHARINDEX(%s,%s,%s)" (fieldNotation al2 col2) column (fieldNotation al3 col3)
             // Date functions
             | Date -> sprintf "CAST(%s AS DATE)" column
             | Year -> sprintf "YEAR(%s)" column
@@ -307,9 +317,11 @@ type internal MSSqlServerProvider(tableNames:string) =
             | Hour -> sprintf "DATEPART(HOUR, %s)" column
             | Minute -> sprintf "DATEPART(MINUTE, %s)" column
             | Second -> sprintf "DATEPART(SECOND, %s)" column
-            | AddYears x -> sprintf "DATEADD(YEAR, %d, %s)" x column
+            | AddYears(SqlInt x) -> sprintf "DATEADD(YEAR, %d, %s)" x column
+            | AddYears(SqlIntCol(al2, col2)) -> sprintf "DATEADD(YEAR, %s, %s)" (fieldNotation al2 col2) column
             | AddMonths x -> sprintf "DATEADD(MONTH, %d, %s)" x column
-            | AddDays x -> sprintf "DATEADD(DAY, %f, %s)" x column // SQL ignores decimal part :-(
+            | AddDays(SqlFloat x) -> sprintf "DATEADD(DAY, %f, %s)" x column // SQL ignores decimal part :-(
+            | AddDays(SqlNumCol(al2, col2)) -> sprintf "DATEADD(DAY, %s, %s)" (fieldNotation al2 col2) column
             | AddHours x -> sprintf "DATEADD(HOUR, %f, %s)" x column
             | AddMinutes x -> sprintf "DATEADD(MINUTE, %f, %s)" x column
             | AddSeconds x -> sprintf "DATEADD(SECOND, %f, %s)" x column

--- a/src/SQLProvider/Providers.MsSqlServer.fs
+++ b/src/SQLProvider/Providers.MsSqlServer.fs
@@ -296,8 +296,9 @@ type internal MSSqlServerProvider(tableNames:string) =
             | SubstringWithLength(startPos,strLen) -> sprintf "SUBSTRING(%s, %i, %i)" column startPos strLen
             | Trim -> sprintf "LTRIM(RTRIM(%s))" column
             | Length -> sprintf "DATALENGTH(%s)" column
-            | IndexOf search -> sprintf "CHARINDEX(%s,%s)" search column
-            | IndexOfStart(search,startPos) -> sprintf "CHARINDEX(%s,%s,%d)" search column startPos
+            | IndexOf search -> sprintf "CHARINDEX('%s',%s)" search column
+            | IndexOfColumn(al2,col2) -> sprintf "CHARINDEX(%s,%s)" (fieldNotation al2 col2) column
+            | IndexOfStart(search,startPos) -> sprintf "CHARINDEX('%s',%s,%d)" search column startPos
             // Date functions
             | Date -> sprintf "CAST(%s AS DATE)" column
             | Year -> sprintf "YEAR(%s)" column

--- a/src/SQLProvider/Providers.MySql.fs
+++ b/src/SQLProvider/Providers.MySql.fs
@@ -65,8 +65,9 @@ module MySql =
             | SubstringWithLength(startPos,strLen) -> sprintf "MID(%s, %i, %i)" column startPos strLen
             | Trim -> sprintf "TRIM(%s)" column
             | Length -> sprintf "CHAR_LENGTH(%s)" column
-            | IndexOf search -> sprintf "LOCATE(%s,%s)" search column
-            | IndexOfStart(search,startPos) -> sprintf "LOCATE(%s,%s,%d)" search column startPos
+            | IndexOf search -> sprintf "LOCATE('%s',%s)" search column
+            | IndexOfColumn(al2,col2) -> sprintf "LOCATE(%s,%s)" (fieldNotation al2 col2) column
+            | IndexOfStart(search,startPos) -> sprintf "LOCATE('%s',%s,%d)" search column startPos
             // Date functions
             | Date -> sprintf "DATE(%s)" column
             | Year -> sprintf "YEAR(%s)" column

--- a/src/SQLProvider/Providers.MySql.fs
+++ b/src/SQLProvider/Providers.MySql.fs
@@ -61,13 +61,23 @@ module MySql =
             let column = fieldNotation al col
             match cf with
             // String functions
-            | Substring startPos -> sprintf "MID(%s, %i)" column startPos
-            | SubstringWithLength(startPos,strLen) -> sprintf "MID(%s, %i, %i)" column startPos strLen
+            | Replace(SqlStr(searchItm),SqlStrCol(al2, col2)) -> sprintf "REPLACE(%s,'%s',%s)" column searchItm (fieldNotation al2 col2)
+            | Replace(SqlStrCol(al2, col2),SqlStr(toItm)) -> sprintf "REPLACE(%s,%s,'%s')" column (fieldNotation al2 col2) toItm
+            | Replace(SqlStrCol(al2, col2),SqlStrCol(al3, col3)) -> sprintf "REPLACE(%s,%s,%s)" column (fieldNotation al2 col2) (fieldNotation al3 col3)
+            | Substring(SqlInt startPos) -> sprintf "MID(%s, %i)" column startPos
+            | Substring(SqlIntCol(al2, col2)) -> sprintf "MID(%s, %s)" column (fieldNotation al2 col2)
+            | SubstringWithLength(SqlInt startPos,SqlInt strLen) -> sprintf "MID(%s, %i, %i)" column startPos strLen
+            | SubstringWithLength(SqlInt startPos,SqlIntCol(al2, col2)) -> sprintf "MID(%s, %i, %s)" column startPos (fieldNotation al2 col2)
+            | SubstringWithLength(SqlIntCol(al2, col2),SqlInt strLen) -> sprintf "MID(%s, %s, %i)" column (fieldNotation al2 col2) strLen
+            | SubstringWithLength(SqlIntCol(al2, col2),SqlIntCol(al3, col3)) -> sprintf "MID(%s, %s, %s)" column (fieldNotation al2 col2) (fieldNotation al3 col3)
             | Trim -> sprintf "TRIM(%s)" column
             | Length -> sprintf "CHAR_LENGTH(%s)" column
-            | IndexOf search -> sprintf "LOCATE('%s',%s)" search column
-            | IndexOfColumn(al2,col2) -> sprintf "LOCATE(%s,%s)" (fieldNotation al2 col2) column
-            | IndexOfStart(search,startPos) -> sprintf "LOCATE('%s',%s,%d)" search column startPos
+            | IndexOf(SqlStr search) -> sprintf "LOCATE('%s',%s)" search column
+            | IndexOf(SqlStrCol(al2, col2)) -> sprintf "LOCATE(%s,%s)" (fieldNotation al2 col2) column
+            | IndexOfStart(SqlStr(search),(SqlInt startPos)) -> sprintf "LOCATE('%s',%s,%d)" search column startPos
+            | IndexOfStart(SqlStr(search),SqlIntCol(al2, col2)) -> sprintf "LOCATE('%s',%s,%s)" search column (fieldNotation al2 col2)
+            | IndexOfStart(SqlStrCol(al2, col2),(SqlInt startPos)) -> sprintf "LOCATE(%s,%s,%d)" (fieldNotation al2 col2) column startPos
+            | IndexOfStart(SqlStrCol(al2, col2),SqlIntCol(al3, col3)) -> sprintf "LOCATE(%s,%s,%s)" (fieldNotation al2 col2) column (fieldNotation al3 col3)
             // Date functions
             | Date -> sprintf "DATE(%s)" column
             | Year -> sprintf "YEAR(%s)" column
@@ -76,9 +86,11 @@ module MySql =
             | Hour -> sprintf "HOUR(%s)" column
             | Minute -> sprintf "MINUTE(%s)" column
             | Second -> sprintf "SECOND(%s)" column
-            | AddYears x -> sprintf "DATE_ADD(%s, INTERVAL %d YEAR)" column x
+            | AddYears(SqlInt x) -> sprintf "DATE_ADD(%s, INTERVAL %d YEAR)" column x
+            | AddYears(SqlIntCol(al2, col2)) -> sprintf "DATE_ADD(%s, INTERVAL %s YEAR)" column (fieldNotation al2 col2)
             | AddMonths x -> sprintf "DATE_ADD(%s, INTERVAL %d MONTH)" column x
-            | AddDays x -> sprintf "DATE_ADD(%s, INTERVAL %f DAY)" column x // SQL ignores decimal part :-(
+            | AddDays(SqlFloat x) -> sprintf "DATE_ADD(%s, INTERVAL %f DAY)" column x // SQL ignores decimal part :-(
+            | AddDays(SqlNumCol(al2, col2)) -> sprintf "DATE_ADD(%s, INTERVAL %s DAY)" column (fieldNotation al2 col2)
             | AddHours x -> sprintf "DATE_ADD(%s, INTERVAL %f HOUR)" column x
             | AddMinutes x -> sprintf "DATE_ADD(%s, INTERVAL %f MINUTE)" column x
             | AddSeconds x -> sprintf "DATE_ADD(%s, INTERVAL %f SECOND)" column x

--- a/src/SQLProvider/Providers.MySql.fs
+++ b/src/SQLProvider/Providers.MySql.fs
@@ -50,16 +50,43 @@ module MySql =
     let mutable findClrType : (string -> TypeMapping option)  = fun _ -> failwith "!"
     let mutable findDbType : (string -> TypeMapping option)  = fun _ -> failwith "!"
 
-    let rec fieldNotation(al:alias,c:SqlColumnType) = 
+    let rec fieldNotation (al:alias) (c:SqlColumnType) =
         let colSprint =
             match String.IsNullOrEmpty(al) with
             | true -> sprintf "`%s`"
             | false -> sprintf "`%s`.`%s`" al
         match c with
-        // Custom database spesific overrides for canonical function:
-        | SqlColumnType.CanonicalOperation(CanonicalOp.Substring startPos,col) -> sprintf "MID(%s, %i)" (fieldNotation(al,col)) startPos
-        | SqlColumnType.CanonicalOperation(CanonicalOp.SubstringWithLength(startPos,strLen),col) -> sprintf "MID(%s, %i, %i)" (fieldNotation(al,col)) startPos strLen
-        | _ -> Utilities.genericFieldNotation colSprint c
+        // Custom database spesific overrides for canonical functions:
+        | SqlColumnType.CanonicalOperation(cf,col) ->
+            let column = fieldNotation al col
+            match cf with
+            // String functions
+            | Substring startPos -> sprintf "MID(%s, %i)" column startPos
+            | SubstringWithLength(startPos,strLen) -> sprintf "MID(%s, %i, %i)" column startPos strLen
+            | Trim -> sprintf "TRIM(%s)" column
+            | Length -> sprintf "CHAR_LENGTH(%s)" column
+            | IndexOf search -> sprintf "LOCATE(%s,%s)" search column
+            | IndexOfStart(search,startPos) -> sprintf "LOCATE(%s,%s,%d)" search column startPos
+            // Date functions
+            | Date -> sprintf "DATE(%s)" column
+            | Year -> sprintf "YEAR(%s)" column
+            | Month -> sprintf "MONTH(%s)" column
+            | Day -> sprintf "DAY(%s)" column
+            | Hour -> sprintf "HOUR(%s)" column
+            | Minute -> sprintf "MINUTE(%s)" column
+            | Second -> sprintf "SECOND(%s)" column
+            | AddYears x -> sprintf "DATE_ADD(%s + INTERVAL %d YEAR)" column x
+            | AddMonths x -> sprintf "DATE_ADD(%s + INTERVAL %d MONTH)" column x
+            | AddDays x -> sprintf "DATE_ADD(%s + INTERVAL %f DAY)" column x // SQL ignores decimal part :-(
+            | AddHours x -> sprintf "DATE_ADD(%s + INTERVAL %f HOUR)" column x
+            | AddMinutes x -> sprintf "DATE_ADD(%s + INTERVAL %f MINUTE)" column x
+            | AddSeconds x -> sprintf "DATE_ADD(%s + INTERVAL %f SECOND)" column x
+            // Math functions
+            | Truncate -> sprintf "TRUNCATE(%s)" column
+            | BasicMathOfColumns(o, a, c) when o="||" -> sprintf "(CONCAT(%s, %s))" column (fieldNotation a c)
+            | BasicMath(o, par) when (par :? String || par :? Char) -> sprintf "(CONCAT(%s, '%O')" column par
+            | _ -> Utilities.genericFieldNotation (fieldNotation al) colSprint c
+        | _ -> Utilities.genericFieldNotation (fieldNotation al) colSprint c
 
     let fieldNotationAlias(al:alias,col:SqlColumnType) =
         let aliasSprint =
@@ -567,7 +594,7 @@ type internal MySqlProvider(resolutionPath, owner, referencedAssemblies) as this
                     match sqlQuery.Grouping with
                     | [] -> FSharp.Data.Sql.Common.Utilities.parseAggregates MySql.fieldNotation MySql.fieldNotationAlias sqlQuery.AggregateOp
                     | g  -> 
-                        let keys = g |> List.map(fst) |> List.concat |> List.map(fun (a,c) -> MySql.fieldNotation(a,c))
+                        let keys = g |> List.map(fst) |> List.concat |> List.map(fun (a,c) -> MySql.fieldNotation a c)
                         let aggs = g |> List.map(snd) |> List.concat
                         let res2 = FSharp.Data.Sql.Common.Utilities.parseAggregates MySql.fieldNotation MySql.fieldNotationAlias aggs |> List.toSeq
                         [String.Join(", ", keys) + (match aggs with [] -> "" | _ -> ", ") + String.Join(", ", res2)] 
@@ -593,7 +620,7 @@ type internal MySqlProvider(resolutionPath, owner, referencedAssemblies) as this
                     let build op preds (rest:Condition list option) =
                         ~~ "("
                         preds |> List.iteri( fun i (alias,col,operator,data) ->
-                                let column = MySql.fieldNotation(alias,col)
+                                let column = MySql.fieldNotation alias col
                                 let extractData data =
                                      match data with
                                      | Some(x) when (box x :? System.Linq.IQueryable) -> [||]
@@ -643,7 +670,7 @@ type internal MySqlProvider(resolutionPath, owner, referencedAssemblies) as this
                                         match data with 
                                         | Some d when (box d :? alias * SqlColumnType) ->
                                             let alias2, col2 = box d :?> (alias * SqlColumnType)
-                                            let alias2f = (MySql.fieldNotation(alias2,col2))
+                                            let alias2f = MySql.fieldNotation alias2 col2
                                             aliasformat (operator.ToString()) alias2f
                                         | _ ->
                                             parameters.Add paras.[0]
@@ -687,21 +714,21 @@ type internal MySqlProvider(resolutionPath, owner, referencedAssemblies) as this
                             joinType destTable.Schema destTable.Name destAlias)
                     ~~  (String.Join(" AND ", (List.zip data.ForeignKey data.PrimaryKey) |> List.map(fun (foreignKey,primaryKey) ->
                         sprintf "%s = %s" 
-                            (MySql.fieldNotation((if data.RelDirection = RelationshipDirection.Parents then fromAlias else destAlias),foreignKey))
-                            (MySql.fieldNotation((if data.RelDirection = RelationshipDirection.Parents then destAlias else fromAlias),primaryKey))
+                            (MySql.fieldNotation (if data.RelDirection = RelationshipDirection.Parents then fromAlias else destAlias) foreignKey)
+                            (MySql.fieldNotation (if data.RelDirection = RelationshipDirection.Parents then destAlias else fromAlias) primaryKey)
                             ))))
 
             let groupByBuilder() =
                 sqlQuery.Grouping |> List.map(fst) |> List.concat
                 |> List.iteri(fun i (alias,column) ->
                     if i > 0 then ~~ ", "
-                    ~~ (MySql.fieldNotation(alias,column)))
+                    ~~ (MySql.fieldNotation alias column))
 
             let orderByBuilder() =
                 sqlQuery.Ordering
                 |> List.iteri(fun i (alias,column,desc) ->
                     if i > 0 then ~~ ", "
-                    ~~ (sprintf "%s %s" (MySql.fieldNotation(alias,column)) (if not desc then "DESC" else "")))
+                    ~~ (sprintf "%s %s" (MySql.fieldNotation alias column) (if not desc then "DESC" else "")))
 
             // SELECT
             if sqlQuery.Distinct then ~~(sprintf "SELECT DISTINCT %s " columns)

--- a/src/SQLProvider/Providers.MySql.fs
+++ b/src/SQLProvider/Providers.MySql.fs
@@ -75,16 +75,16 @@ module MySql =
             | Hour -> sprintf "HOUR(%s)" column
             | Minute -> sprintf "MINUTE(%s)" column
             | Second -> sprintf "SECOND(%s)" column
-            | AddYears x -> sprintf "DATE_ADD(%s + INTERVAL %d YEAR)" column x
-            | AddMonths x -> sprintf "DATE_ADD(%s + INTERVAL %d MONTH)" column x
-            | AddDays x -> sprintf "DATE_ADD(%s + INTERVAL %f DAY)" column x // SQL ignores decimal part :-(
-            | AddHours x -> sprintf "DATE_ADD(%s + INTERVAL %f HOUR)" column x
-            | AddMinutes x -> sprintf "DATE_ADD(%s + INTERVAL %f MINUTE)" column x
-            | AddSeconds x -> sprintf "DATE_ADD(%s + INTERVAL %f SECOND)" column x
+            | AddYears x -> sprintf "DATE_ADD(%s, INTERVAL %d YEAR)" column x
+            | AddMonths x -> sprintf "DATE_ADD(%s, INTERVAL %d MONTH)" column x
+            | AddDays x -> sprintf "DATE_ADD(%s, INTERVAL %f DAY)" column x // SQL ignores decimal part :-(
+            | AddHours x -> sprintf "DATE_ADD(%s, INTERVAL %f HOUR)" column x
+            | AddMinutes x -> sprintf "DATE_ADD(%s, INTERVAL %f MINUTE)" column x
+            | AddSeconds x -> sprintf "DATE_ADD(%s, INTERVAL %f SECOND)" column x
             // Math functions
             | Truncate -> sprintf "TRUNCATE(%s)" column
-            | BasicMathOfColumns(o, a, c) when o="||" -> sprintf "(CONCAT(%s, %s))" column (fieldNotation a c)
-            | BasicMath(o, par) when (par :? String || par :? Char) -> sprintf "(CONCAT(%s, '%O')" column par
+            | BasicMathOfColumns(o, a, c) when o="||" -> sprintf "CONCAT(%s, %s)" column (fieldNotation a c)
+            | BasicMath(o, par) when (par :? String || par :? Char) -> sprintf "CONCAT(%s, '%O')" column par
             | _ -> Utilities.genericFieldNotation (fieldNotation al) colSprint c
         | _ -> Utilities.genericFieldNotation (fieldNotation al) colSprint c
 

--- a/src/SQLProvider/Providers.Odbc.fs
+++ b/src/SQLProvider/Providers.Odbc.fs
@@ -320,8 +320,9 @@ type internal OdbcProvider(quotehcar : OdbcQuoteCharacter) =
                     | Trim -> sprintf "LTRIM(RTRIM(%s))" column
                     | Length -> sprintf "LENGTH(%s)" column // ODBC 1.0, works with strings only
                     //| Length -> sprintf "CHARACTER_LENGTH(%s)" column // ODBC 3.0, works with all columns
-                    | IndexOf search -> sprintf "LOCATE(%s,%s)" search column
-                    | IndexOfStart(search,startPos) -> sprintf "LOCATE(%s,%s,%d)" search column startPos
+                    | IndexOf search -> sprintf "LOCATE('%s',%s)" search column
+                    | IndexOfColumn(al2,col2) -> sprintf "LOCATE(%s,%s)" (fieldNotation al2 col2) column
+                    | IndexOfStart(search,startPos) -> sprintf "LOCATE('%s',%s,%d)" search column startPos
                     | ToUpper -> sprintf "UCASE(%s)" column
                     | ToLower -> sprintf "LCASE(%s)" column
                     // Date functions

--- a/src/SQLProvider/Providers.Odbc.fs
+++ b/src/SQLProvider/Providers.Odbc.fs
@@ -318,8 +318,8 @@ type internal OdbcProvider(quotehcar : OdbcQuoteCharacter) =
                     | Substring startPos -> sprintf "SUBSTRING(%s, %i)" column startPos
                     | SubstringWithLength(startPos,strLen) -> sprintf "SUBSTRING(%s, %i, %i)" column startPos strLen
                     | Trim -> sprintf "LTRIM(RTRIM(%s))" column
-                    //| Length -> sprintf "LENGTH(%s)" column // ODBC 1.0, works with strings only
-                    | Length -> sprintf "CHARACTER_LENGTH(%s)" column // ODBC 3.0, works with all columns
+                    | Length -> sprintf "LENGTH(%s)" column // ODBC 1.0, works with strings only
+                    //| Length -> sprintf "CHARACTER_LENGTH(%s)" column // ODBC 3.0, works with all columns
                     | IndexOf search -> sprintf "LOCATE(%s,%s)" search column
                     | IndexOfStart(search,startPos) -> sprintf "LOCATE(%s,%s,%d)" search column startPos
                     | ToUpper -> sprintf "UCASE(%s)" column
@@ -335,9 +335,9 @@ type internal OdbcProvider(quotehcar : OdbcQuoteCharacter) =
                     // Date additions not supported by standard ODBC
                     // Math functions
                     | Truncate -> sprintf "TRUNCATE(%s)" column
-                    | BasicMathOfColumns(o, a, c) when o="||" -> sprintf "(CONCAT(%s, %s))" column (fieldNotation a c)
+                    | BasicMathOfColumns(o, a, c) when o="||" -> sprintf "CONCAT(%s, %s)" column (fieldNotation a c)
                     | BasicMathOfColumns(o, a, c) -> sprintf "(%s %s %s)" column o (fieldNotation a c)
-                    | BasicMath(o, par) when (par :? String || par :? Char) -> sprintf "(CONCAT(%s, '%O')" column par
+                    | BasicMath(o, par) when (par :? String || par :? Char) -> sprintf "CONCAT(%s, '%O')" column par
                     | _ -> Utilities.genericFieldNotation (fieldNotation al) colSprint c
                 | _ -> Utilities.genericFieldNotation (fieldNotation al) colSprint c
 

--- a/src/SQLProvider/Providers.Odbc.fs
+++ b/src/SQLProvider/Providers.Odbc.fs
@@ -304,16 +304,42 @@ type internal OdbcProvider(quotehcar : OdbcQuoteCharacter) =
         member __.GenerateQueryText(sqlQuery,baseAlias,baseTable,projectionColumns) =
             let separator = (sprintf "%c.%c" cClose cOpen).Trim()
 
-            let rec fieldNotation(al:alias,c:SqlColumnType) = 
+            let rec fieldNotation (al:alias) (c:SqlColumnType) =
                 let colSprint =
                     match String.IsNullOrEmpty(al) with
                     | true -> fun col -> sprintf "%c%s%c" cOpen col cClose
                     | false -> fun col -> sprintf "%c%s%s%s%c" cOpen al separator col cClose
                 match c with
                 // Custom database spesific overrides for canonical function:
-                | SqlColumnType.CanonicalOperation(CanonicalOp.Substring startPos,col) -> sprintf "SUBSTRING(%s, %i)" (fieldNotation(al,col)) startPos
-                | SqlColumnType.CanonicalOperation(CanonicalOp.SubstringWithLength(startPos,strLen),col) -> sprintf "SUBSTRING(%s, %i, %i)" (fieldNotation(al,col)) startPos strLen
-                | _ -> Utilities.genericFieldNotation colSprint c
+                | SqlColumnType.CanonicalOperation(cf,col) ->
+                    let column = fieldNotation al col
+                    match cf with
+                    // String functions
+                    | Substring startPos -> sprintf "SUBSTRING(%s, %i)" column startPos
+                    | SubstringWithLength(startPos,strLen) -> sprintf "SUBSTRING(%s, %i, %i)" column startPos strLen
+                    | Trim -> sprintf "LTRIM(RTRIM(%s))" column
+                    //| Length -> sprintf "LENGTH(%s)" column // ODBC 1.0, works with strings only
+                    | Length -> sprintf "CHARACTER_LENGTH(%s)" column // ODBC 3.0, works with all columns
+                    | IndexOf search -> sprintf "LOCATE(%s,%s)" search column
+                    | IndexOfStart(search,startPos) -> sprintf "LOCATE(%s,%s,%d)" search column startPos
+                    | ToUpper -> sprintf "UCASE(%s)" column
+                    | ToLower -> sprintf "LCASE(%s)" column
+                    // Date functions
+                    | Date -> sprintf "CONVERT(%s, SQL_DATE)" column
+                    | Year -> sprintf "YEAR(%s)" column
+                    | Month -> sprintf "MONTH(%s)" column
+                    | Day -> sprintf "DAYOFMONTH(%s)" column
+                    | Hour -> sprintf "HOUR(%s)" column
+                    | Minute -> sprintf "MINUTE(%s)" column
+                    | Second -> sprintf "SECOND(%s)" column
+                    // Date additions not supported by standard ODBC
+                    // Math functions
+                    | Truncate -> sprintf "TRUNCATE(%s)" column
+                    | BasicMathOfColumns(o, a, c) when o="||" -> sprintf "(CONCAT(%s, %s))" column (fieldNotation a c)
+                    | BasicMathOfColumns(o, a, c) -> sprintf "(%s %s %s)" column o (fieldNotation a c)
+                    | BasicMath(o, par) when (par :? String || par :? Char) -> sprintf "(CONCAT(%s, '%O')" column par
+                    | _ -> Utilities.genericFieldNotation (fieldNotation al) colSprint c
+                | _ -> Utilities.genericFieldNotation (fieldNotation al) colSprint c
 
 
             let fieldNotationAlias(al:alias,col:SqlColumnType) =
@@ -355,7 +381,7 @@ type internal OdbcProvider(quotehcar : OdbcQuoteCharacter) =
                     match sqlQuery.Grouping with
                     | [] -> FSharp.Data.Sql.Common.Utilities.parseAggregates fieldNotation fieldNotationAlias sqlQuery.AggregateOp
                     | g  -> 
-                        let keys = g |> List.map(fst) |> List.concat |> List.map(fun (a,c) -> fieldNotation(a,c))
+                        let keys = g |> List.map(fst) |> List.concat |> List.map(fun (a,c) -> (fieldNotation a c))
                         let aggs = g |> List.map(snd) |> List.concat
                         let res2 = FSharp.Data.Sql.Common.Utilities.parseAggregates fieldNotation fieldNotationAlias aggs |> List.toSeq
                         [String.Join(", ", keys) + (match aggs with [] -> "" | _ -> ", ") + String.Join(", ", res2)] 
@@ -376,7 +402,7 @@ type internal OdbcProvider(quotehcar : OdbcQuoteCharacter) =
                     let build op preds (rest:Condition list option) =
                         ~~ "("
                         preds |> List.iteri( fun i (alias,col,operator,data) ->
-                                let column = fieldNotation(alias,col)
+                                let column = fieldNotation alias col
                                 let extractData data =
                                      match data with
                                      | Some(x) when (box x :? System.Linq.IQueryable) -> [||]
@@ -414,7 +440,7 @@ type internal OdbcProvider(quotehcar : OdbcQuoteCharacter) =
                                         match data with 
                                         | Some d when (box d :? alias * SqlColumnType) ->
                                             let alias2, col2 = box d :?> (alias * SqlColumnType)
-                                            let alias2f = (fieldNotation(alias2,col2))
+                                            let alias2f = fieldNotation alias2 col2
                                             aliasformat (operator.ToString()) alias2f
                                         | _ ->
                                             parameters.Add paras.[0]
@@ -458,21 +484,21 @@ type internal OdbcProvider(quotehcar : OdbcQuoteCharacter) =
                             joinType cOpen destTable.Name cClose cOpen destAlias cClose)
                     ~~  (String.Join(" AND ", (List.zip data.ForeignKey data.PrimaryKey) |> List.map(fun (foreignKey,primaryKey) ->
                         sprintf "%s = %s "
-                            (fieldNotation((if data.RelDirection = RelationshipDirection.Parents then fromAlias else destAlias),foreignKey))
-                            (fieldNotation((if data.RelDirection = RelationshipDirection.Parents then destAlias else fromAlias),primaryKey))
+                            (fieldNotation (if data.RelDirection = RelationshipDirection.Parents then fromAlias else destAlias) foreignKey)
+                            (fieldNotation (if data.RelDirection = RelationshipDirection.Parents then destAlias else fromAlias) primaryKey)
                             ))))
 
             let groupByBuilder() =
                 sqlQuery.Grouping |> List.map(fst) |> List.concat
                 |> List.iteri(fun i (alias,column) ->
                     if i > 0 then ~~ ", "
-                    ~~ (fieldNotation(alias,column)))
+                    ~~ (fieldNotation alias column))
 
             let orderByBuilder() =
                 sqlQuery.Ordering
                 |> List.iteri(fun i (alias,column,desc) ->
                     if i > 0 then ~~ ", "
-                    ~~ (sprintf "%s %s" (fieldNotation(alias,column)) (if not desc then "DESC" else "")))
+                    ~~ (sprintf "%s %s" (fieldNotation alias column) (if not desc then "DESC" else "")))
 
             // Certain ODBC drivers (excel) don't like special characters in aliases, so we need to strip them
             // or else it will fail

--- a/src/SQLProvider/Providers.Odbc.fs
+++ b/src/SQLProvider/Providers.Odbc.fs
@@ -303,6 +303,26 @@ type internal OdbcProvider(quotehcar : OdbcQuoteCharacter) =
 
         member __.GenerateQueryText(sqlQuery,baseAlias,baseTable,projectionColumns) =
             let separator = (sprintf "%c.%c" cClose cOpen).Trim()
+
+            let rec fieldNotation(al:alias,c:SqlColumnType) = 
+                let colSprint =
+                    match String.IsNullOrEmpty(al) with
+                    | true -> fun col -> sprintf "%c%s%c" cOpen col cClose
+                    | false -> fun col -> sprintf "%c%s%s%s%c" cOpen al separator col cClose
+                match c with
+                // Custom database spesific overrides for canonical function:
+                | SqlColumnType.CanonicalOperation(CanonicalOp.Substring startPos,col) -> sprintf "SUBSTRING(%s, %i)" (fieldNotation(al,col)) startPos
+                | SqlColumnType.CanonicalOperation(CanonicalOp.SubstringWithLength(startPos,strLen),col) -> sprintf "SUBSTRING(%s, %i, %i)" (fieldNotation(al,col)) startPos strLen
+                | _ -> Utilities.genericFieldNotation colSprint c
+
+
+            let fieldNotationAlias(al:alias,col:SqlColumnType) =
+                let aliasSprint =
+                    match String.IsNullOrEmpty(al) with
+                    | true -> fun c -> sprintf "%c%s%c" cOpen c cClose
+                    | false -> fun c -> sprintf "%c%s_%s%c" cOpen al c cClose
+                Utilities.genericAliasNotation aliasSprint col
+
             let sb = System.Text.StringBuilder()
             let parameters = ResizeArray<_>()
             let (~~) (t:string) = sb.Append t |> ignore
@@ -332,19 +352,10 @@ type internal OdbcProvider(quotehcar : OdbcQuoteCharacter) =
             // Create sumBy, minBy, maxBy, ... field columns
             let columns =
                 let extracolumns =
-                    let fieldNotation(al:alias,col:string) =
-                        match String.IsNullOrEmpty(al) with
-                        | true -> sprintf "%c%s%c" cOpen col cClose
-                        | false -> sprintf "%c%s%s%s%c" cOpen al separator col cClose
-                    let fieldNotationAlias(al:alias,col:string) =
-                        match String.IsNullOrEmpty(al) with
-                        | true -> sprintf "%c[%s]%c" cOpen col cClose
-                        | false -> sprintf "%c[%s][%s]%c" cOpen al col cClose
-
                     match sqlQuery.Grouping with
                     | [] -> FSharp.Data.Sql.Common.Utilities.parseAggregates fieldNotation fieldNotationAlias sqlQuery.AggregateOp
                     | g  -> 
-                        let keys = g |> List.map(fst) |> List.concat |> List.map(fieldNotation)
+                        let keys = g |> List.map(fst) |> List.concat |> List.map(fun (a,c) -> fieldNotation(a,c))
                         let aggs = g |> List.map(snd) |> List.concat
                         let res2 = FSharp.Data.Sql.Common.Utilities.parseAggregates fieldNotation fieldNotationAlias aggs |> List.toSeq
                         [String.Join(", ", keys) + (match aggs with [] -> "" | _ -> ", ") + String.Join(", ", res2)] 
@@ -365,6 +376,7 @@ type internal OdbcProvider(quotehcar : OdbcQuoteCharacter) =
                     let build op preds (rest:Condition list option) =
                         ~~ "("
                         preds |> List.iteri( fun i (alias,col,operator,data) ->
+                                let column = fieldNotation(alias,col)
                                 let extractData data =
                                      match data with
                                      | Some(x) when (box x :? System.Linq.IQueryable) -> [||]
@@ -379,30 +391,30 @@ type internal OdbcProvider(quotehcar : OdbcQuoteCharacter) =
                                 let paras = extractData data
                                 ~~(sprintf "%s%s" prefix <|
                                     match operator with
-                                    | FSharp.Data.Sql.IsNull -> (sprintf "%c%s%s%s%c IS NULL") cOpen alias separator col cClose
-                                    | FSharp.Data.Sql.NotNull -> (sprintf "%c%s%s%s%c IS NOT NULL") cOpen alias separator col cClose
+                                    | FSharp.Data.Sql.IsNull -> sprintf "%s IS NULL" column
+                                    | FSharp.Data.Sql.NotNull -> sprintf "%s IS NOT NULL" column
                                     | FSharp.Data.Sql.In ->
                                         let text = String.Join(",",paras |> Array.map (fun p -> p.ParameterName))
                                         Array.iter parameters.Add paras
-                                        (sprintf "%c%s%s%s%c IN (%s)") cOpen alias separator col cClose text
+                                        sprintf "%s IN (%s)" column text
                                     | FSharp.Data.Sql.NestedIn when data.IsSome ->
                                         let innersql, innerpars = data.Value |> box :?> string * IDbDataParameter[]
                                         Array.iter parameters.Add innerpars
-                                        (sprintf "%c%s%s%s%c IN (%s)") cOpen alias separator col cClose innersql
+                                        sprintf "%s IN (%s)" column innersql
                                     | FSharp.Data.Sql.NotIn ->
                                         let text = String.Join(",",paras |> Array.map (fun p -> p.ParameterName))
                                         Array.iter parameters.Add paras
-                                        (sprintf "%c%s%s%s%c NOT IN (%s)") cOpen alias separator col cClose text
+                                        sprintf "%s NOT IN (%s)" column text
                                     | FSharp.Data.Sql.NestedNotIn when data.IsSome ->
                                         let innersql, innerpars = data.Value |> box :?> string * IDbDataParameter[]
                                         Array.iter parameters.Add innerpars
-                                        (sprintf "%c%s%s%s%c NOT IN (%s)") cOpen alias separator col cClose innersql
+                                        sprintf "%s NOT IN (%s)" column innersql
                                     | _ ->
-                                        let aliasformat = if alias<>"" then (sprintf "%c%s%c.%s %s %s") cOpen alias cClose col else (sprintf "%s %s %s") col
+                                        let aliasformat = sprintf "%s %s %s" column
                                         match data with 
-                                        | Some d when (box d :? alias * string) ->
-                                            let alias2, col2 = box d :?> (alias * string)
-                                            let alias2f = if alias2<>"" then (sprintf "%c%s%c.%s") cOpen alias2 cClose col2 else col2
+                                        | Some d when (box d :? alias * SqlColumnType) ->
+                                            let alias2, col2 = box d :?> (alias * SqlColumnType)
+                                            let alias2f = (fieldNotation(alias2,col2))
                                             aliasformat (operator.ToString()) alias2f
                                         | _ ->
                                             parameters.Add paras.[0]
@@ -445,24 +457,22 @@ type internal OdbcProvider(quotehcar : OdbcQuoteCharacter) =
                     ~~  (sprintf "%s %c%s%c as %c%s%c on "
                             joinType cOpen destTable.Name cClose cOpen destAlias cClose)
                     ~~  (String.Join(" AND ", (List.zip data.ForeignKey data.PrimaryKey) |> List.map(fun (foreignKey,primaryKey) ->
-                        sprintf "%c%s%s%s%c = %c%s%s%s%c "
-                            cOpen
-                            (if data.RelDirection = RelationshipDirection.Parents then fromAlias else destAlias)
-                            separator foreignKey cClose cOpen
-                            (if data.RelDirection = RelationshipDirection.Parents then destAlias else fromAlias)
-                            separator primaryKey cClose))))
+                        sprintf "%s = %s "
+                            (fieldNotation((if data.RelDirection = RelationshipDirection.Parents then fromAlias else destAlias),foreignKey))
+                            (fieldNotation((if data.RelDirection = RelationshipDirection.Parents then destAlias else fromAlias),primaryKey))
+                            ))))
 
             let groupByBuilder() =
                 sqlQuery.Grouping |> List.map(fst) |> List.concat
                 |> List.iteri(fun i (alias,column) ->
                     if i > 0 then ~~ ", "
-                    ~~ (sprintf "%c%s%s%s%c" cOpen alias separator column cClose ))
+                    ~~ (fieldNotation(alias,column)))
 
             let orderByBuilder() =
                 sqlQuery.Ordering
                 |> List.iteri(fun i (alias,column,desc) ->
                     if i > 0 then ~~ ", "
-                    ~~ (sprintf "%c%s%s%s%c %s" cOpen alias separator column cClose (if not desc then "DESC" else "")))
+                    ~~ (sprintf "%s %s" (fieldNotation(alias,column)) (if not desc then "DESC" else "")))
 
             // Certain ODBC drivers (excel) don't like special characters in aliases, so we need to strip them
             // or else it will fail
@@ -494,7 +504,7 @@ type internal OdbcProvider(quotehcar : OdbcQuoteCharacter) =
             if sqlQuery.HavingFilters.Length > 0 then
                 let keys = sqlQuery.Grouping |> List.map(fst) |> List.concat
 
-                let f = [And([],Some (sqlQuery.HavingFilters |> CommonTasks.parseHaving keys))]
+                let f = [And([],Some (sqlQuery.HavingFilters |> CommonTasks.parseHaving fieldNotation keys))]
                 ~~" HAVING "
                 filterBuilder f
 

--- a/src/SQLProvider/Providers.Odbc.fs
+++ b/src/SQLProvider/Providers.Odbc.fs
@@ -315,14 +315,24 @@ type internal OdbcProvider(quotehcar : OdbcQuoteCharacter) =
                     let column = fieldNotation al col
                     match cf with
                     // String functions
-                    | Substring startPos -> sprintf "SUBSTRING(%s, %i)" column startPos
-                    | SubstringWithLength(startPos,strLen) -> sprintf "SUBSTRING(%s, %i, %i)" column startPos strLen
+                    | Replace(SqlStr(searchItm),SqlStrCol(al2, col2)) -> sprintf "REPLACE(%s,'%s',%s)" column searchItm (fieldNotation al2 col2)
+                    | Replace(SqlStrCol(al2, col2),SqlStr(toItm)) -> sprintf "REPLACE(%s,%s,'%s')" column (fieldNotation al2 col2) toItm
+                    | Replace(SqlStrCol(al2, col2),SqlStrCol(al3, col3)) -> sprintf "REPLACE(%s,%s,%s)" column (fieldNotation al2 col2) (fieldNotation al3 col3)
+                    | Substring(SqlInt startPos) -> sprintf "SUBSTRING(%s, %i)" column startPos
+                    | Substring(SqlIntCol(al2, col2)) -> sprintf "SUBSTRING(%s, %s)" column (fieldNotation al2 col2)
+                    | SubstringWithLength(SqlInt startPos,SqlInt strLen) -> sprintf "SUBSTRING(%s, %i, %i)" column startPos strLen
+                    | SubstringWithLength(SqlInt startPos,SqlIntCol(al2, col2)) -> sprintf "SUBSTRING(%s, %i, %s)" column startPos (fieldNotation al2 col2)
+                    | SubstringWithLength(SqlIntCol(al2, col2),SqlInt strLen) -> sprintf "SUBSTRING(%s, %s, %i)" column (fieldNotation al2 col2) strLen
+                    | SubstringWithLength(SqlIntCol(al2, col2),SqlIntCol(al3, col3)) -> sprintf "SUBSTRING(%s, %s, %s)" column (fieldNotation al2 col2) (fieldNotation al3 col3)
                     | Trim -> sprintf "LTRIM(RTRIM(%s))" column
                     | Length -> sprintf "LENGTH(%s)" column // ODBC 1.0, works with strings only
                     //| Length -> sprintf "CHARACTER_LENGTH(%s)" column // ODBC 3.0, works with all columns
-                    | IndexOf search -> sprintf "LOCATE('%s',%s)" search column
-                    | IndexOfColumn(al2,col2) -> sprintf "LOCATE(%s,%s)" (fieldNotation al2 col2) column
-                    | IndexOfStart(search,startPos) -> sprintf "LOCATE('%s',%s,%d)" search column startPos
+                    | IndexOf(SqlStr search) -> sprintf "LOCATE('%s',%s)" search column
+                    | IndexOf(SqlStrCol(al2, col2)) -> sprintf "LOCATE(%s,%s)" (fieldNotation al2 col2) column
+                    | IndexOfStart(SqlStr(search),(SqlInt startPos)) -> sprintf "LOCATE('%s',%s,%d)" search column startPos
+                    | IndexOfStart(SqlStr(search),SqlIntCol(al2, col2)) -> sprintf "LOCATE('%s',%s,%s)" search column (fieldNotation al2 col2)
+                    | IndexOfStart(SqlStrCol(al2, col2),(SqlInt startPos)) -> sprintf "LOCATE(%s,%s,%d)" (fieldNotation al2 col2) column startPos
+                    | IndexOfStart(SqlStrCol(al2, col2),SqlIntCol(al3, col3)) -> sprintf "LOCATE(%s,%s,%s)" (fieldNotation al2 col2) column (fieldNotation al3 col3)
                     | ToUpper -> sprintf "UCASE(%s)" column
                     | ToLower -> sprintf "LCASE(%s)" column
                     // Date functions

--- a/src/SQLProvider/Providers.Oracle.fs
+++ b/src/SQLProvider/Providers.Oracle.fs
@@ -70,13 +70,23 @@ module internal Oracle =
             let column = fieldNotation al col
             match cf with
             // String functions
-            | Substring startPos -> sprintf "SUBSTR(%s, %i)" column startPos
-            | SubstringWithLength(startPos,strLen) -> sprintf "SUBSTR(%s, %i, %i)" column startPos strLen
+            | Replace(SqlStr(searchItm),SqlStrCol(al2, col2)) -> sprintf "REPLACE(%s,'%s',%s)" column searchItm (fieldNotation al2 col2)
+            | Replace(SqlStrCol(al2, col2),SqlStr(toItm)) -> sprintf "REPLACE(%s,%s,'%s')" column (fieldNotation al2 col2) toItm
+            | Replace(SqlStrCol(al2, col2),SqlStrCol(al3, col3)) -> sprintf "REPLACE(%s,%s,%s)" column (fieldNotation al2 col2) (fieldNotation al3 col3)
+            | Substring(SqlInt startPos) -> sprintf "SUBSTR(%s, %i)" column startPos
+            | Substring(SqlIntCol(al2, col2)) -> sprintf "SUBSTR(%s, %s)" column (fieldNotation al2 col2)
+            | SubstringWithLength(SqlInt startPos,SqlInt strLen) -> sprintf "SUBSTR(%s, %i, %i)" column startPos strLen
+            | SubstringWithLength(SqlInt startPos,SqlIntCol(al2, col2)) -> sprintf "SUBSTR(%s, %i, %s)" column startPos (fieldNotation al2 col2)
+            | SubstringWithLength(SqlIntCol(al2, col2),SqlInt strLen) -> sprintf "SUBSTR(%s, %s, %i)" column (fieldNotation al2 col2) strLen
+            | SubstringWithLength(SqlIntCol(al2, col2),SqlIntCol(al3, col3)) -> sprintf "SUBSTR(%s, %s, %s)" column (fieldNotation al2 col2) (fieldNotation al3 col3)
             | Trim -> sprintf "LTRIM(RTRIM((%s))" column
             | Length -> sprintf "CHAR_LENGTH(%s)" column
-            | IndexOf search -> sprintf "INSTR(%s,'%s')" column search
-            | IndexOfColumn(al2,col2) -> sprintf "LOCATE(%s,%s)" column (fieldNotation al2 col2)
-            | IndexOfStart(search,startPos) -> sprintf "INSTR(%s,'%s',%d)" column search startPos
+            | IndexOf(SqlStr search) -> sprintf "INSTR(%s,'%s')" column search
+            | IndexOf(SqlStrCol(al2, col2)) -> sprintf "INSTR(%s,%s)" column (fieldNotation al2 col2)
+            | IndexOfStart(SqlStr(search),(SqlInt startPos)) -> sprintf "INSTR(%s,'%s',%d)" column search startPos
+            | IndexOfStart(SqlStr(search), SqlIntCol(al2, col2)) -> sprintf "INSTR(%s,'%s',%s)" column search (fieldNotation al2 col2)
+            | IndexOfStart(SqlStrCol(al2, col2),(SqlInt startPos)) -> sprintf "INSTR(%s,%s,%d)" column (fieldNotation al2 col2) startPos
+            | IndexOfStart(SqlStrCol(al2, col2),SqlIntCol(al3, col3)) -> sprintf "INSTR(%s,%s,%s)" column (fieldNotation al2 col2) (fieldNotation al3 col3)
             // Date functions
             | Date -> sprintf "TRUNC(%s)" column
             | Year -> sprintf "EXTRACT(YEAR FROM %s)" column
@@ -85,9 +95,11 @@ module internal Oracle =
             | Hour -> sprintf "EXTRACT(HOUR FROM %s)" column
             | Minute -> sprintf "EXTRACT(MINUTE FROM %s)" column
             | Second -> sprintf "EXTRACT(SECOND FROM %s)" column
-            | AddYears x -> sprintf "(%s + INTERVAL '%d' YEAR)" column x
+            | AddYears(SqlInt x) -> sprintf "(%s + INTERVAL '%d' YEAR)" column x
+            | AddYears(SqlIntCol(al2, col2)) -> sprintf "(%s + INTERVAL %s YEAR)" column (fieldNotation al2 col2)
             | AddMonths x -> sprintf "(%s + INTERVAL '%d' MONTH)" column x
-            | AddDays x -> sprintf "(%s + INTERVAL '%f' DAY)" column x // SQL ignores decimal part :-(
+            | AddDays(SqlFloat x) -> sprintf "(%s + INTERVAL '%f' DAY)" column x // SQL ignores decimal part :-(
+            | AddDays(SqlNumCol(al2, col2)) -> sprintf "(%s + INTERVAL %s DAY)" column (fieldNotation al2 col2)
             | AddHours x -> sprintf "(%s + INTERVAL '%f' HOUR)" column x
             | AddMinutes x -> sprintf "(%s + INTERVAL '%f' MINUTE)" column x
             | AddSeconds x -> sprintf "(%s + INTERVAL '%f' SECOND)" column x

--- a/src/SQLProvider/Providers.Oracle.fs
+++ b/src/SQLProvider/Providers.Oracle.fs
@@ -74,8 +74,9 @@ module internal Oracle =
             | SubstringWithLength(startPos,strLen) -> sprintf "SUBSTR(%s, %i, %i)" column startPos strLen
             | Trim -> sprintf "LTRIM(RTRIM((%s))" column
             | Length -> sprintf "CHAR_LENGTH(%s)" column
-            | IndexOf search -> sprintf "INSTR(%s,%s)" column search
-            | IndexOfStart(search,startPos) -> sprintf "INSTR(%s,%s,%d)" column search startPos
+            | IndexOf search -> sprintf "INSTR(%s,'%s')" column search
+            | IndexOfColumn(al2,col2) -> sprintf "LOCATE(%s,%s)" column (fieldNotation al2 col2)
+            | IndexOfStart(search,startPos) -> sprintf "INSTR(%s,'%s',%d)" column search startPos
             // Date functions
             | Date -> sprintf "TRUNC(%s)" column
             | Year -> sprintf "EXTRACT(YEAR FROM %s)" column

--- a/src/SQLProvider/Providers.Oracle.fs
+++ b/src/SQLProvider/Providers.Oracle.fs
@@ -59,6 +59,24 @@ module internal Oracle =
     let mutable findClrType : (string -> TypeMapping option)  = fun _ -> failwith "!"
     let mutable findDbType : (string -> TypeMapping option)  = fun _ -> failwith "!"
 
+    let rec fieldNotation(al:alias,c:SqlColumnType) = 
+        let colSprint =
+            match String.IsNullOrEmpty(al) with
+            | true -> fun col -> quoteWhiteSpace col
+            | false -> fun col -> sprintf "%s.%s" al (quoteWhiteSpace col)
+        match c with
+        // Custom database spesific overrides for canonical function:
+        | SqlColumnType.CanonicalOperation(CanonicalOp.Substring startPos,col) -> sprintf "SUBSTR(%s, %i)" (fieldNotation(al,col)) startPos
+        | SqlColumnType.CanonicalOperation(CanonicalOp.SubstringWithLength(startPos,strLen),col) -> sprintf "SUBSTR(%s, %i, %i)" (fieldNotation(al,col)) startPos strLen
+        | _ -> Utilities.genericFieldNotation colSprint c
+
+    let fieldNotationAlias(al:alias,col:SqlColumnType) =
+        let aliasSprint =
+            match String.IsNullOrEmpty(al) with
+            | true -> fun c -> sprintf "\"%s\"" c
+            | false -> fun c -> sprintf "\"%s.%s\"" al c
+        Utilities.genericAliasNotation aliasSprint col
+
     let createTypeMappings con =
         let getDbType(providerType) =
             let p = Activator.CreateInstance(parameterType.Value,[||]) :?> IDbDataParameter
@@ -643,21 +661,12 @@ type internal OracleProvider(resolutionPath, owner, referencedAssemblies, tableN
             // Create sumBy, minBy, maxBy, ... field columns
             let columns =
                 let extracolumns =
-                    let fieldNotation(al:alias,col:string) =
-                        match String.IsNullOrEmpty(al) with
-                        | true -> sprintf "%s" col
-                        | false -> sprintf "%s.%s" al col
-                    let fieldNotationAlias(al:alias,col:string) =
-                        match String.IsNullOrEmpty(al) with
-                        | true -> sprintf "\"[%s]\"" col
-                        | false -> sprintf "\"[%s][%s]\"" al col
-
                     match sqlQuery.Grouping with
-                    | [] -> FSharp.Data.Sql.Common.Utilities.parseAggregates fieldNotation fieldNotationAlias sqlQuery.AggregateOp
+                    | [] -> FSharp.Data.Sql.Common.Utilities.parseAggregates Oracle.fieldNotation Oracle.fieldNotationAlias sqlQuery.AggregateOp
                     | g  -> 
-                        let keys = g |> List.map(fst) |> List.concat |> List.map(fieldNotation)
+                        let keys = g |> List.map(fst) |> List.concat |> List.map(fun (a,c) -> Oracle.fieldNotation(a,c))
                         let aggs = g |> List.map(snd) |> List.concat
-                        let res2 = FSharp.Data.Sql.Common.Utilities.parseAggregates fieldNotation fieldNotationAlias aggs |> List.toSeq
+                        let res2 = FSharp.Data.Sql.Common.Utilities.parseAggregates Oracle.fieldNotation Oracle.fieldNotationAlias aggs |> List.toSeq
                         [String.Join(", ", keys) + (match aggs with [] -> "" | _ -> ", ") + String.Join(", ", res2)] 
                 match extracolumns with
                 | [] -> selectcolumns
@@ -681,6 +690,7 @@ type internal OracleProvider(resolutionPath, owner, referencedAssemblies, tableN
                     let build op preds (rest:Condition list option) =
                         ~~ "("
                         preds |> List.iteri( fun i (alias,col,operator,data) ->
+                                let column = Oracle.fieldNotation(alias,col)
                                 let extractData data =
                                      match data with
                                      | Some(x) when (box x :? System.Linq.IQueryable) -> [||]
@@ -695,30 +705,30 @@ type internal OracleProvider(resolutionPath, owner, referencedAssemblies, tableN
                                 let paras = extractData data
                                 ~~(sprintf "%s%s" prefix <|
                                     match operator with
-                                    | FSharp.Data.Sql.IsNull -> (sprintf "%s.%s IS NULL") alias (quoteWhiteSpace col)
-                                    | FSharp.Data.Sql.NotNull -> (sprintf "%s.%s IS NOT NULL") alias (quoteWhiteSpace col)
+                                    | FSharp.Data.Sql.IsNull -> sprintf "%s IS NULL" column
+                                    | FSharp.Data.Sql.NotNull -> sprintf "%s IS NOT NULL" column
                                     | FSharp.Data.Sql.In ->
                                         let text = String.Join(",",paras |> Array.map (fun p -> p.ParameterName))
                                         Array.iter parameters.Add paras
-                                        (sprintf "%s.%s IN (%s)") alias (quoteWhiteSpace col) text
+                                        sprintf "%s IN (%s)" column text
                                     | FSharp.Data.Sql.NestedIn ->
                                         let innersql, innerpars = data.Value |> box :?> string * IDbDataParameter[]
                                         Array.iter parameters.Add innerpars
-                                        (sprintf "%s.%s IN (%s)") alias (quoteWhiteSpace col) innersql
+                                        sprintf "%s IN (%s)" column innersql
                                     | FSharp.Data.Sql.NotIn ->
                                         let text = String.Join(",",paras |> Array.map (fun p -> p.ParameterName))
                                         Array.iter parameters.Add paras
-                                        (sprintf "%s.%s NOT IN (%s)") alias (quoteWhiteSpace col) text
+                                        sprintf "%s NOT IN (%s)" column text
                                     | FSharp.Data.Sql.NestedNotIn ->
                                         let innersql, innerpars = data.Value |> box :?> string * IDbDataParameter[]
                                         Array.iter parameters.Add innerpars
-                                        (sprintf "%s.%s NOT IN (%s)") alias (quoteWhiteSpace col) innersql
+                                        sprintf "%s NOT IN (%s)" column innersql
                                     | _ ->
-                                        let aliasformat = if alias<>"" then (sprintf "%s.%s %s %s") alias (quoteWhiteSpace col) else (sprintf "%s %s %s") (quoteWhiteSpace col)
+                                        let aliasformat = sprintf "%s %s %s" column
                                         match data with 
-                                        | Some d when (box d :? alias * string) ->
-                                            let alias2, col2 = box d :?> (alias * string)
-                                            let alias2f = if alias2<>"" then (sprintf "%s.%s") alias2 (quoteWhiteSpace col2) else (quoteWhiteSpace col2)
+                                        | Some d when (box d :? alias * SqlColumnType) ->
+                                            let alias2, col2 = box d :?> (alias * SqlColumnType)
+                                            let alias2f = Oracle.fieldNotation(alias2,col2)
                                             aliasformat (operator.ToString()) alias2f
                                         | _ ->
                                             parameters.Add paras.[0]
@@ -761,23 +771,22 @@ type internal OracleProvider(resolutionPath, owner, referencedAssemblies, tableN
                     ~~  (sprintf "%s %s %s on "
                             joinType destTable.FullName destAlias)
                     ~~  (String.Join(" AND ", (List.zip data.ForeignKey data.PrimaryKey) |> List.map(fun (foreignKey,primaryKey) ->
-                        sprintf "%s.%s = %s.%s "
-                            (if data.RelDirection = RelationshipDirection.Parents then fromAlias else destAlias)
-                            foreignKey
-                            (if data.RelDirection = RelationshipDirection.Parents then destAlias else fromAlias)
-                            primaryKey))))
+                        sprintf "%s = %s "
+                            (Oracle.fieldNotation((if data.RelDirection = RelationshipDirection.Parents then fromAlias else destAlias),foreignKey))
+                            (Oracle.fieldNotation((if data.RelDirection = RelationshipDirection.Parents then destAlias else fromAlias),primaryKey))
+                            ))))
 
             let groupByBuilder() =
                 sqlQuery.Grouping |> List.map(fst) |> List.concat
                 |> List.iteri(fun i (alias,column) ->
                     if i > 0 then ~~ ", "
-                    ~~ (sprintf "%s.%s" alias (quoteWhiteSpace column)))
+                    ~~ (Oracle.fieldNotation(alias,column)))
 
             let orderByBuilder() =
                 sqlQuery.Ordering
                 |> List.iteri(fun i (alias,column,desc) ->
                     if i > 0 then ~~ ", "
-                    ~~ (sprintf "%s.%s%s" alias (quoteWhiteSpace column) (if not desc then " DESC NULLS LAST" else " ASC NULLS FIRST")))
+                    ~~ (sprintf "%s %s" (Oracle.fieldNotation(alias,column)) (if not desc then " DESC NULLS LAST" else " ASC NULLS FIRST")))
 
             // SELECT
             if sqlQuery.Distinct then ~~(sprintf "SELECT DISTINCT %s " columns)
@@ -803,7 +812,7 @@ type internal OracleProvider(resolutionPath, owner, referencedAssemblies, tableN
             if sqlQuery.HavingFilters.Length > 0 then
                 let keys = sqlQuery.Grouping |> List.map(fst) |> List.concat
 
-                let f = [And([],Some (sqlQuery.HavingFilters |> CommonTasks.parseHaving keys))]
+                let f = [And([],Some (sqlQuery.HavingFilters |> CommonTasks.parseHaving Oracle.fieldNotation keys))]
                 ~~" HAVING "
                 filterBuilder f
 

--- a/src/SQLProvider/Providers.Postgresql.fs
+++ b/src/SQLProvider/Providers.Postgresql.fs
@@ -62,6 +62,24 @@ module PostgreSQL =
     let typemap<'t> = List.tryPick (parseDbType typeof<'t>)
     let namemap name dbTypes = findType name |> Option.bind (fun ty -> dbTypes |> List.tryPick (parseDbType ty))
 
+    let rec fieldNotation(al:alias,c:SqlColumnType) = 
+        let colSprint =
+            match String.IsNullOrEmpty(al) with
+            | true -> sprintf "\"%s\""
+            | false -> sprintf "\"%s\".\"%s\"" al
+        match c with
+        // Custom database spesific overrides for canonical function:
+        | SqlColumnType.CanonicalOperation(CanonicalOp.Substring startPos,col) -> sprintf "SUBSTRING(%s, %i)" (fieldNotation(al,col)) startPos
+        | SqlColumnType.CanonicalOperation(CanonicalOp.SubstringWithLength(startPos,strLen),col) -> sprintf "SUBSTRING(%s, %i, %i)" (fieldNotation(al,col)) startPos strLen
+        | _ -> Utilities.genericFieldNotation colSprint c
+        
+    let fieldNotationAlias(al:alias,col:SqlColumnType) =
+        let aliasSprint =
+            match String.IsNullOrEmpty(al) with
+            | true -> sprintf "\"%s\""
+            | false -> sprintf "\"%s.%s\"" al
+        Utilities.genericAliasNotation aliasSprint col
+
     let createTypeMappings () =
         // http://www.npgsql.org/doc/2.2/
         // http://www.npgsql.org/doc/3.0/types.html
@@ -681,21 +699,12 @@ type internal PostgresqlProvider(resolutionPath, owner, referencedAssemblies) =
             // Create sumBy, minBy, maxBy, ... field columns
             let columns =
                 let extracolumns =
-                    let fieldNotation(al:alias,col:string) =
-                        match String.IsNullOrEmpty(al) with
-                        | true -> sprintf "\"%s\"" col
-                        | false -> sprintf "\"%s\".\"%s\"" al col
-                    let fieldNotationAlias(al:alias,col:string) =
-                        match String.IsNullOrEmpty(al) with
-                        | true -> sprintf "\"[%s]\"" col
-                        | false -> sprintf "\"[%s][%s]\"" al col
-
                     match sqlQuery.Grouping with
-                    | [] -> FSharp.Data.Sql.Common.Utilities.parseAggregates fieldNotation fieldNotationAlias sqlQuery.AggregateOp
+                    | [] -> FSharp.Data.Sql.Common.Utilities.parseAggregates PostgreSQL.fieldNotation PostgreSQL.fieldNotationAlias sqlQuery.AggregateOp
                     | g  -> 
-                        let keys = g |> List.map(fst) |> List.concat |> List.map(fieldNotation)
+                        let keys = g |> List.map(fst) |> List.concat |> List.map(fun (a,c) -> PostgreSQL.fieldNotation(a,c))
                         let aggs = g |> List.map(snd) |> List.concat
-                        let res2 = FSharp.Data.Sql.Common.Utilities.parseAggregates fieldNotation fieldNotationAlias aggs |> List.toSeq
+                        let res2 = FSharp.Data.Sql.Common.Utilities.parseAggregates PostgreSQL.fieldNotation PostgreSQL.fieldNotationAlias aggs |> List.toSeq
                         [String.Join(", ", keys) + (match aggs with [] -> "" | _ -> ", ") + String.Join(", ", res2)] 
                 match extracolumns with
                 | [] -> selectcolumns
@@ -718,6 +727,7 @@ type internal PostgresqlProvider(resolutionPath, owner, referencedAssemblies) =
                     let build op preds (rest:Condition list option) =
                         ~~ "("
                         preds |> List.iteri( fun i (alias,col,operator,data) ->
+                                let column = PostgreSQL.fieldNotation(alias,col)
                                 let extractData data =
                                      match data with
                                      | Some(x) when (box x :? System.Linq.IQueryable) -> [||]
@@ -732,30 +742,30 @@ type internal PostgresqlProvider(resolutionPath, owner, referencedAssemblies) =
                                 let paras = extractData data
                                 ~~(sprintf "%s%s" prefix <|
                                     match operator with
-                                    | FSharp.Data.Sql.IsNull -> (sprintf "\"%s\".\"%s\" IS NULL") alias col
-                                    | FSharp.Data.Sql.NotNull -> (sprintf "\"%s\".\"%s\" IS NOT NULL") alias col
+                                    | FSharp.Data.Sql.IsNull -> sprintf "%s IS NULL" column
+                                    | FSharp.Data.Sql.NotNull -> sprintf "%s IS NOT NULL" column
                                     | FSharp.Data.Sql.In ->
                                         let text = String.Join(",",paras |> Array.map (fun p -> p.ParameterName))
                                         Array.iter parameters.Add paras
-                                        (sprintf "\"%s\".\"%s\" IN (%s)") alias col text
+                                        sprintf "%s IN (%s)" column text
                                     | FSharp.Data.Sql.NestedIn ->
                                         let innersql, innerpars = data.Value |> box :?> string * IDbDataParameter[]
                                         Array.iter parameters.Add innerpars
-                                        (sprintf "\"%s\".\"%s\" IN (%s)") alias col innersql
+                                        sprintf "%s IN (%s)" column innersql
                                     | FSharp.Data.Sql.NotIn ->
                                         let text = String.Join(",",paras |> Array.map (fun p -> p.ParameterName))
                                         Array.iter parameters.Add paras
-                                        (sprintf "\"%s\".\"%s\" NOT IN (%s)") alias col text
+                                        sprintf "%s NOT IN (%s)" column text
                                     | FSharp.Data.Sql.NestedNotIn ->
                                         let innersql, innerpars = data.Value |> box :?> string * IDbDataParameter[]
                                         Array.iter parameters.Add innerpars
-                                        (sprintf "\"%s\".\"%s\" NOT IN (%s)") alias col innersql
+                                        sprintf "%s NOT IN (%s)" column innersql
                                     | _ ->
-                                        let aliasformat = if alias<>"" then (sprintf "\"%s\".\"%s\" %s %s") alias col else (sprintf "%s %s %s") col
+                                        let aliasformat = sprintf "%s %s %s" column
                                         match data with 
-                                        | Some d when (box d :? alias * string) ->
-                                            let alias2, col2 = box d :?> (alias * string)
-                                            let alias2f = if alias2<>"" then (sprintf "\"%s\".\"%s\"") alias2 col2 else col2
+                                        | Some d when (box d :? alias * SqlColumnType) ->
+                                            let alias2, col2 = box d :?> (alias * SqlColumnType)
+                                            let alias2f = PostgreSQL.fieldNotation(alias2,col2)
                                             aliasformat (operator.ToString()) alias2f
                                         | _ ->
                                             parameters.Add paras.[0]
@@ -798,23 +808,22 @@ type internal PostgresqlProvider(resolutionPath, owner, referencedAssemblies) =
                     ~~  (sprintf "%s \"%s\".\"%s\" as \"%s\" on "
                             joinType destTable.Schema destTable.Name destAlias)
                     ~~  (String.Join(" AND ", (List.zip data.ForeignKey data.PrimaryKey) |> List.map(fun (foreignKey,primaryKey) ->
-                        sprintf "\"%s\".\"%s\" = \"%s\".\"%s\" "
-                            (if data.RelDirection = RelationshipDirection.Parents then fromAlias else destAlias)
-                            foreignKey
-                            (if data.RelDirection = RelationshipDirection.Parents then destAlias else fromAlias)
-                            primaryKey))))
+                        sprintf "%s = %s "
+                            (PostgreSQL.fieldNotation((if data.RelDirection = RelationshipDirection.Parents then fromAlias else destAlias),foreignKey))
+                            (PostgreSQL.fieldNotation((if data.RelDirection = RelationshipDirection.Parents then destAlias else fromAlias),primaryKey))
+                            ))))
 
             let groupByBuilder() =
                 sqlQuery.Grouping |> List.map(fst) |> List.concat
                 |> List.iteri(fun i (alias,column) ->
                     if i > 0 then ~~ ", "
-                    ~~ (sprintf "\"%s\".\"%s\"" alias column))
+                    ~~ (PostgreSQL.fieldNotation(alias,column)))
 
             let orderByBuilder() =
                 sqlQuery.Ordering
                 |> List.iteri(fun i (alias,column,desc) ->
                     if i > 0 then ~~ ", "
-                    ~~ (sprintf "\"%s\".\"%s\" %s" alias column (if not desc then "DESC" else "")))
+                    ~~ (sprintf "%s %s" (PostgreSQL.fieldNotation(alias,column)) (if not desc then "DESC" else "")))
 
             // SELECT
             if sqlQuery.Distinct then ~~(sprintf "SELECT DISTINCT %s " columns)
@@ -841,7 +850,7 @@ type internal PostgresqlProvider(resolutionPath, owner, referencedAssemblies) =
             if sqlQuery.HavingFilters.Length > 0 then
                 let keys = sqlQuery.Grouping |> List.map(fst) |> List.concat
 
-                let f = [And([],Some (sqlQuery.HavingFilters |> CommonTasks.parseHaving keys))]
+                let f = [And([],Some (sqlQuery.HavingFilters |> CommonTasks.parseHaving PostgreSQL.fieldNotation keys))]
                 ~~" HAVING "
                 filterBuilder f
 

--- a/src/SQLProvider/Providers.Postgresql.fs
+++ b/src/SQLProvider/Providers.Postgresql.fs
@@ -77,7 +77,8 @@ module PostgreSQL =
             | SubstringWithLength(startPos,strLen) -> sprintf "SUBSTRING(%s from %i for %i)" column startPos strLen
             | Trim -> sprintf "TRIM(BOTH ' ' FROM %s)" column
             | Length -> sprintf "CHAR_LENGTH(%s)" column
-            | IndexOf search -> sprintf "STRPOS(%s,%s)" search column
+            | IndexOf search -> sprintf "STRPOS('%s',%s)" search column
+            | IndexOfColumn(al2,col2) -> sprintf "STRPOS(%s,%s)" (fieldNotation al2 col2) column
             // Date functions
             | Date -> sprintf "DATE_TRUNC('day', %s)" column
             | Year -> sprintf "DATE_PART('year', %s)" column

--- a/src/SQLProvider/Providers.Postgresql.fs
+++ b/src/SQLProvider/Providers.Postgresql.fs
@@ -73,12 +73,19 @@ module PostgreSQL =
             let column = fieldNotation al col
             match cf with
             // String functions
-            | Substring startPos -> sprintf "SUBSTRING(%s from %i)" column startPos
-            | SubstringWithLength(startPos,strLen) -> sprintf "SUBSTRING(%s from %i for %i)" column startPos strLen
+            | Replace(SqlStr(searchItm),SqlStrCol(al2, col2)) -> sprintf "REPLACE(%s,'%s',%s)" column searchItm (fieldNotation al2 col2)
+            | Replace(SqlStrCol(al2, col2),SqlStr(toItm)) -> sprintf "REPLACE(%s,%s,'%s')" column (fieldNotation al2 col2) toItm
+            | Replace(SqlStrCol(al2, col2),SqlStrCol(al3, col3)) -> sprintf "REPLACE(%s,%s,%s)" column (fieldNotation al2 col2) (fieldNotation al3 col3)
+            | Substring(SqlInt startPos) -> sprintf "SUBSTRING(%s from %i)" column startPos
+            | Substring(SqlIntCol(al2, col2)) -> sprintf "SUBSTRING(%s from %s)" column (fieldNotation al2 col2)
+            | SubstringWithLength(SqlInt startPos,SqlInt strLen) -> sprintf "SUBSTRING(%s from %i for %i)" column startPos strLen
+            | SubstringWithLength(SqlInt startPos,SqlIntCol(al2, col2)) -> sprintf "SUBSTRING(%s from %i for %s)" column startPos (fieldNotation al2 col2)
+            | SubstringWithLength(SqlIntCol(al2, col2),SqlInt strLen) -> sprintf "SUBSTRING(%s from %s for %i)" column (fieldNotation al2 col2) strLen
+            | SubstringWithLength(SqlIntCol(al2, col2),SqlIntCol(al3, col3)) -> sprintf "SUBSTRING(%s from %s for %s)" column (fieldNotation al2 col2) (fieldNotation al3 col3)
             | Trim -> sprintf "TRIM(BOTH ' ' FROM %s)" column
             | Length -> sprintf "CHAR_LENGTH(%s)" column
-            | IndexOf search -> sprintf "STRPOS('%s',%s)" search column
-            | IndexOfColumn(al2,col2) -> sprintf "STRPOS(%s,%s)" (fieldNotation al2 col2) column
+            | IndexOf(SqlStr search) -> sprintf "STRPOS('%s',%s)" search column
+            | IndexOf(SqlStrCol(al2, col2)) -> sprintf "STRPOS(%s,%s)" (fieldNotation al2 col2) column
             // Date functions
             | Date -> sprintf "DATE_TRUNC('day', %s)" column
             | Year -> sprintf "DATE_PART('year', %s)" column
@@ -87,9 +94,11 @@ module PostgreSQL =
             | Hour -> sprintf "DATE_PART('hour', %s)" column
             | Minute -> sprintf "DATE_PART('minute', %s)" column
             | Second -> sprintf "DATE_PART('second', %s)" column
-            | AddYears x -> sprintf "(%s + INTERVAL '1 year' * %d)" column x
+            | AddYears(SqlInt x) -> sprintf "(%s + INTERVAL '1 year' * %d)" column x
+            | AddYears(SqlIntCol(al2, col2)) -> sprintf "(%s + INTERVAL '1 year' * %s)" column (fieldNotation al2 col2)
             | AddMonths x -> sprintf "(%s + INTERVAL '1 month' * %d)" column x
-            | AddDays x -> sprintf "(%s + INTERVAL '1 day' * %f)" column x // SQL ignores decimal part :-(
+            | AddDays(SqlFloat x) -> sprintf "(%s + INTERVAL '1 day' * %f)" column x // SQL ignores decimal part :-(
+            | AddDays(SqlNumCol(al2, col2)) -> sprintf "(%s + INTERVAL '1 day' * %s)" column (fieldNotation al2 col2)
             | AddHours x -> sprintf "(%s + INTERVAL '1 hour' * %f)" column x
             | AddMinutes x -> sprintf "(%s + INTERVAL '1 minute' * %f)" column x
             | AddSeconds x -> sprintf "(%s + INTERVAL '1 second' * %f)" column x

--- a/src/SQLProvider/Providers.SQLite.fs
+++ b/src/SQLProvider/Providers.SQLite.fs
@@ -68,7 +68,8 @@ type internal SQLiteProvider(resolutionPath, referencedAssemblies, runtimeAssemb
             | SubstringWithLength(startPos,strLen) -> sprintf "SUBSTR(%s, %i, %i)" column startPos strLen
             | Trim -> sprintf "TRIM(%s)" column
             | Length -> sprintf "LENGTH(%s)" column
-            | IndexOf search -> sprintf "INSTR(%s,%s)" column search
+            | IndexOf search -> sprintf "INSTR(%s,'%s')" column search
+            | IndexOfColumn(al2,col2) -> sprintf "INSTR(%s,%s)" column (fieldNotation al2 col2)
             // Date functions
             | Date -> sprintf "DATE(%s)" column
             | Year -> sprintf "CAST(STRFTIME('%%Y', %s) as INTEGER)" column

--- a/src/SQLProvider/Providers.SQLite.fs
+++ b/src/SQLProvider/Providers.SQLite.fs
@@ -64,12 +64,19 @@ type internal SQLiteProvider(resolutionPath, referencedAssemblies, runtimeAssemb
         | SqlColumnType.CanonicalOperation(cf,col) ->
             let column = fieldNotation al col
             match cf with
-            | Substring startPos -> sprintf "SUBSTR(%s, %i)" column startPos
-            | SubstringWithLength(startPos,strLen) -> sprintf "SUBSTR(%s, %i, %i)" column startPos strLen
+            | Replace(SqlStr(searchItm),SqlStrCol(al2, col2)) -> sprintf "REPLACE(%s,'%s',%s)" column searchItm (fieldNotation al2 col2)
+            | Replace(SqlStrCol(al2, col2),SqlStr(toItm)) -> sprintf "REPLACE(%s,%s,'%s')" column (fieldNotation al2 col2) toItm
+            | Replace(SqlStrCol(al2, col2),SqlStrCol(al3, col3)) -> sprintf "REPLACE(%s,%s,%s)" column (fieldNotation al2 col2) (fieldNotation al3 col3)
+            | Substring(SqlInt startPos) -> sprintf "SUBSTR(%s, %i)" column startPos
+            | Substring(SqlIntCol(al2, col2)) -> sprintf "SUBSTR(%s, %s)" column (fieldNotation al2 col2)
+            | SubstringWithLength(SqlInt startPos,SqlInt strLen) -> sprintf "SUBSTR(%s, %i, %i)" column startPos strLen
+            | SubstringWithLength(SqlInt startPos,SqlIntCol(al2, col2)) -> sprintf "SUBSTR(%s, %i, %s)" column startPos (fieldNotation al2 col2)
+            | SubstringWithLength(SqlIntCol(al2, col2),SqlInt strLen) -> sprintf "SUBSTR(%s, %s, %i)" column (fieldNotation al2 col2) strLen
+            | SubstringWithLength(SqlIntCol(al2, col2),SqlIntCol(al3, col3)) -> sprintf "SUBSTR(%s, %s, %s)" column (fieldNotation al2 col2) (fieldNotation al3 col3)
             | Trim -> sprintf "TRIM(%s)" column
             | Length -> sprintf "LENGTH(%s)" column
-            | IndexOf search -> sprintf "INSTR(%s,'%s')" column search
-            | IndexOfColumn(al2,col2) -> sprintf "INSTR(%s,%s)" column (fieldNotation al2 col2)
+            | IndexOf(SqlStr search) -> sprintf "INSTR(%s,'%s')" column search
+            | IndexOf(SqlStrCol(al2, col2)) -> sprintf "INSTR(%s,%s)" column (fieldNotation al2 col2)
             // Date functions
             | Date -> sprintf "DATE(%s)" column
             | Year -> sprintf "CAST(STRFTIME('%%Y', %s) as INTEGER)" column
@@ -78,9 +85,9 @@ type internal SQLiteProvider(resolutionPath, referencedAssemblies, runtimeAssemb
             | Hour -> sprintf "CAST(STRFTIME('%%H', %s) as INTEGER)" column
             | Minute -> sprintf "CAST(STRFTIME('%%M', %s) as INTEGER)" column
             | Second -> sprintf "CAST(STRFTIME('%%S', %s) as INTEGER)" column
-            | AddYears x -> sprintf "DATETIME(%s, '+%d year')" column x
+            | AddYears(SqlInt x) -> sprintf "DATETIME(%s, '+%d year')" column x
             | AddMonths x -> sprintf "DATETIME(%s, '+%d month')" column x
-            | AddDays x -> sprintf "DATETIME(%s, '+%f day')" column x // SQL ignores decimal part :-(
+            | AddDays(SqlFloat x) -> sprintf "DATETIME(%s, '+%f day')" column x // SQL ignores decimal part :-(
             | AddHours x -> sprintf "DATETIME(%s, '+%f hour')" column x
             | AddMinutes x -> sprintf "DATETIME(%s, '+%f minute')" column x
             | AddSeconds x -> sprintf "DATETIME(%s, '+%f second')" column x

--- a/src/SQLProvider/Providers.SQLite.fs
+++ b/src/SQLProvider/Providers.SQLite.fs
@@ -70,19 +70,19 @@ type internal SQLiteProvider(resolutionPath, referencedAssemblies, runtimeAssemb
             | Length -> sprintf "LENGTH(%s)" column
             | IndexOf search -> sprintf "INSTR(%s,%s)" column search
             // Date functions
-            | Date -> sprintf "STRFTIME('%%Y-%%m-%%dT00:00:00', %s)" column
-            | Year -> sprintf "STRFTIME('%%Y', %s)" column
-            | Month -> sprintf "STRFTIME('%%m', %s)" column
-            | Day -> sprintf "STRFTIME('%%d', %s)" column
-            | Hour -> sprintf "STRFTIME('%%H', %s)" column
-            | Minute -> sprintf "STRFTIME('%%M', %s)" column
-            | Second -> sprintf "STRFTIME('%%S', %s)" column
-            | AddYears x -> sprintf "DATE(%s, '+%d year')" column x
-            | AddMonths x -> sprintf "DATE(%s, '+%d month')" column x
-            | AddDays x -> sprintf "DATE(%s, '+%f day')" column x // SQL ignores decimal part :-(
-            | AddHours x -> sprintf "DATE(%s, '+%f hour')" column x
-            | AddMinutes x -> sprintf "DATE(%s, '+%f minute')" column x
-            | AddSeconds x -> sprintf "DATE(%s, '+%f second')" column x
+            | Date -> sprintf "DATE(%s)" column
+            | Year -> sprintf "CAST(STRFTIME('%%Y', %s) as INTEGER)" column
+            | Month -> sprintf "CAST(STRFTIME('%%m', %s) as INTEGER)" column
+            | Day -> sprintf "CAST(STRFTIME('%%d', %s) as INTEGER)" column
+            | Hour -> sprintf "CAST(STRFTIME('%%H', %s) as INTEGER)" column
+            | Minute -> sprintf "CAST(STRFTIME('%%M', %s) as INTEGER)" column
+            | Second -> sprintf "CAST(STRFTIME('%%S', %s) as INTEGER)" column
+            | AddYears x -> sprintf "DATETIME(%s, '+%d year')" column x
+            | AddMonths x -> sprintf "DATETIME(%s, '+%d month')" column x
+            | AddDays x -> sprintf "DATETIME(%s, '+%f day')" column x // SQL ignores decimal part :-(
+            | AddHours x -> sprintf "DATETIME(%s, '+%f hour')" column x
+            | AddMinutes x -> sprintf "DATETIME(%s, '+%f minute')" column x
+            | AddSeconds x -> sprintf "DATETIME(%s, '+%f second')" column x
             // Math functions
             | Truncate -> sprintf "SUBSTR(%s, 1, INSTR(%s, '.') + 1)" column column
             | Ceil -> sprintf "CAST(%s + 0.5 AS INT)" column // Ceil not supported, this will do

--- a/src/SQLProvider/SqlDesignTime.fs
+++ b/src/SQLProvider/SqlDesignTime.fs
@@ -250,7 +250,7 @@ type SqlTypeProvider(config: TypeProviderConfig) as this =
                             let pk = r.PrimaryKey
                             let ft = r.ForeignTable
                             let fk = r.ForeignKey
-                            <@@ (%%args.[0] : SqlEntity).DataContext.CreateRelated((%%args.[0] : SqlEntity),constraintName,pt,pk,ft,fk,RelationshipDirection.Parents) @@> )
+                            <@@ (%%args.[0] : SqlEntity).DataContext.CreateRelated((%%args.[0] : SqlEntity),constraintName,pt, pk,ft, fk,RelationshipDirection.Parents) @@> )
                         prop.AddXmlDoc(sprintf "Related %s entities from the primary side of the relationship, where the primary key is %s and the foreign key is %s. Constraint: %s" r.PrimaryTable r.PrimaryKey r.ForeignKey constraintName)
                         yield prop ]
                 attProps @ relProps)

--- a/src/SQLProvider/SqlRuntime.DataContext.fs
+++ b/src/SQLProvider/SqlRuntime.DataContext.fs
@@ -75,15 +75,16 @@ type public SqlDataContext (typeName, connectionString:string, providerType, res
             }
 
         member this.CreateRelated(inst:SqlEntity,_,pe,pk,fe,fk,direction) : IQueryable<SqlEntity> =
+            let parseKey k = KeyColumn k
             if direction = RelationshipDirection.Children then
                 QueryImplementation.SqlQueryable<_>(this,provider,
                     FilterClause(
-                        Condition.And(["__base__",fk,ConditionOperator.Equal, Some(inst.GetColumn pk)],None),
+                        Condition.And(["__base__",(parseKey fk),ConditionOperator.Equal, Some(inst.GetColumn pk)],None),
                         BaseTable("__base__",Table.FromFullName fe)),ResizeArray<_>()) :> IQueryable<_>
             else
                 QueryImplementation.SqlQueryable<_>(this,provider,
                     FilterClause(
-                        Condition.And(["__base__",pk,ConditionOperator.Equal, Some(box<|inst.GetColumn fk)],None),
+                        Condition.And(["__base__",(parseKey pk),ConditionOperator.Equal, Some(box<|inst.GetColumn fk)],None),
                         BaseTable("__base__",Table.FromFullName pe)),ResizeArray<_>()) :> IQueryable<_>
 
         member this.CreateEntities(table:string) : IQueryable<SqlEntity> =

--- a/src/SQLProvider/SqlRuntime.Linq.fs
+++ b/src/SQLProvider/SqlRuntime.Linq.fs
@@ -385,8 +385,9 @@ module internal QueryImplementation =
                             else
 
                             // the following case can happen with multiple where clauses when only a single entity is selected
-                            if paramNames.First() = "" || source.TupleIndex.Count = 0 then FilterClause(filter,current)
-                            else FilterClause(filter,current)
+                            //if (paramNames.Length > 0 && paramNames.First() = "") || source.TupleIndex.Count = 0 then FilterClause(filter,current)
+                            //else 
+                            FilterClause(filter,current)
 
                     let ty = typedefof<SqlQueryable<_>>.MakeGenericType(meth.GetGenericArguments().[0])
                     ty.GetConstructors().[0].Invoke [| source.DataContext; source.Provider; sqlExpression; source.TupleIndex; |] :?> IQueryable<_>

--- a/src/SQLProvider/SqlRuntime.Linq.fs
+++ b/src/SQLProvider/SqlRuntime.Linq.fs
@@ -53,7 +53,10 @@ module internal QueryImplementation =
                         let tyo = typedefof<GroupResultItems<_>>.MakeGenericType(kt)
                         tyo.GetConstructors())
 
-                let getval (key:obj) idx = Utilities.convertTypes key keyType.Value.GenericTypeArguments.[idx]
+                let getval (key:obj) idx = 
+                    if keyType.Value.IsGenericType then
+                        Utilities.convertTypes key keyType.Value.GenericTypeArguments.[idx]
+                    else key
                 
                 let tup2, tup3 = 
                     let genArg idx = 
@@ -69,9 +72,8 @@ module internal QueryImplementation =
                 // do group-read
                 let collected = 
                     results |> Array.map(fun (e:SqlEntity) ->
-                        // We support two possible alias syntax (because of Access), mainly alias is '[Column][Sum]'
-                        let aggregates = [|"[COUNT]"; "[MIN]"; "[MAX]"; "[SUM]"; "[AVG]";
-                                           "-COUNT-"; "-MIN-"; "-MAX-"; "-SUM-"; "-AVG-"|]
+                        // Alias is '[Sum_Column]'
+                        let aggregates = [|"COUNT_"; "MIN_"; "MAX_"; "SUM_"; "AVG_";|]
                         let data = 
                             e.ColumnValues |> Seq.toArray |> Array.filter(fun (key, _) -> aggregates |> Array.exists (key.Contains) |> not)
                         match data with
@@ -339,36 +341,6 @@ module internal QueryImplementation =
                         Some(ti,key,ConditionOperator.Equal, Some(true |> box))
                     | _ -> None
 
-                let (|HavingCondition|_|) exp =
-                    // IMPORTANT : for now it is always assumed that the table column being checked on the server side is on the left hand side of the condition expression.
-                    match exp with
-                    | OptionIsSome(SqlGroupingColumnGet(ti,key,_)) ->
-                        paramNames.Add(ti) |> ignore
-                        Some(ti,key,ConditionOperator.NotNull,None)
-                    | OptionIsNone(SqlGroupingColumnGet(ti,key,_))
-                    | SqlCondOp(ConditionOperator.Equal,(SqlGroupingColumnGet(ti,key,_)),OptionNone) 
-                    | SqlNegativeCondOp(ConditionOperator.Equal,(SqlGroupingColumnGet(ti,key,_)),OptionNone) ->
-                        paramNames.Add(ti) |> ignore
-                        Some(ti,key,ConditionOperator.IsNull,None)
-                    | SqlCondOp(ConditionOperator.NotEqual,(SqlGroupingColumnGet(ti,key,_)),OptionNone) 
-                    | SqlNegativeCondOp(ConditionOperator.NotEqual,(SqlGroupingColumnGet(ti,key,_)),OptionNone) ->
-                        paramNames.Add(ti) |> ignore
-                        Some(ti,key,ConditionOperator.NotNull,None)
-                    // matches column to constant with any operator eg c.name = "john", c.age > 42
-                    | SqlCondOp(op,(OptionalConvertOrTypeAs(SqlGroupingColumnGet(ti,key,_))),OptionalConvertOrTypeAs(OptionalFSharpOptionValue(ConstantOrNullableConstant(c)))) 
-                    | SqlNegativeCondOp(op,(OptionalConvertOrTypeAs(SqlGroupingColumnGet(ti,key,_))),OptionalConvertOrTypeAs(OptionalFSharpOptionValue(ConstantOrNullableConstant(c)))) ->
-                        paramNames.Add(ti) |> ignore
-                        Some(ti,key,op,c)
-                    // matches to another property getter, method call or new expression
-                    | SqlCondOp(op,OptionalConvertOrTypeAs(SqlGroupingColumnGet(ti,key,_)),OptionalConvertOrTypeAs(OptionalFSharpOptionValue((((:? MemberExpression) | (:? MethodCallExpression) | (:? NewExpression)) as meth))))
-                    | SqlNegativeCondOp(op,OptionalConvertOrTypeAs(SqlGroupingColumnGet(ti,key,_)),OptionalConvertOrTypeAs(OptionalFSharpOptionValue((((:? MemberExpression) | (:? MethodCallExpression) | (:? NewExpression)) as meth)))) ->
-                        paramNames.Add(ti) |> ignore
-                        Some(ti,key,op,Some(Expression.Lambda(meth).Compile().DynamicInvoke()))
-                    | SqlGroupingColumnGet(ti,key,ret) when exp.Type.FullName = "System.Boolean" -> 
-                        paramNames.Add(ti) |> ignore
-                        Some(ti,key,ConditionOperator.Equal, Some(true |> box))
-                    | _ -> None
-
                 let rec filterExpression (exp:Expression)  =
                     let extendFilter conditions nextFilter =
                         match exp with
@@ -394,11 +366,6 @@ module internal QueryImplementation =
                     | Bool(b) when b -> Condition.ConstantTrue
                     | Bool(b) when not(b) -> Condition.ConstantFalse
                     | _ -> 
-                        if isHaving then
-                            match exp with
-                            | HavingCondition(cond) -> Condition.And([cond],None)
-                            | _ -> failwith ("Unsupported group having expression. " + exp.ToString())
-                        else
                         failwith ("Unsupported expression. Ensure all server-side objects won't have any .NET-operators/methods that can't be converted to SQL. The In and Not In operators only support the inline array syntax. " + exp.ToString())
 
                 match qual with
@@ -673,12 +640,15 @@ module internal QueryImplementation =
                                                 OuterJoin = false; RelDirection = RelationshipDirection.Parents }
                                 SelectMany(sourceAlias,destAlias,LinkQuery(data),outExp)
                             | OptionalOuterJoin(outerJoin,MethodCall(Some(_),(MethodWithName "CreateRelated"), [param; _; String PE; String PK; String FE; String FK; RelDirection dir;])) ->
+                                
+                                let parseKey itm =
+                                    SqlColumnType.KeyColumn itm
                                 let fromAlias =
                                     match param with
                                     | ParamName x -> x
                                     | PropertyGet(_,p) -> Utilities.resolveTuplePropertyName p.Name source.TupleIndex
                                     | _ -> failwith "unsupported parameter expression in CreatedRelated method call"
-                                let data = { PrimaryKey = [PK]; PrimaryTable = Table.FromFullName PE; ForeignKey = [FK]; ForeignTable = Table.FromFullName FE; OuterJoin = outerJoin; RelDirection = dir  }
+                                let data = { PrimaryKey = [parseKey PK]; PrimaryTable = Table.FromFullName PE; ForeignKey = [parseKey FK]; ForeignTable = Table.FromFullName FE; OuterJoin = outerJoin; RelDirection = dir  }
                                 let sqlExpression =
                                     match outExp with
                                     | BaseTable(alias,entity) when alias = "" ->
@@ -817,7 +787,7 @@ module internal QueryImplementation =
                         let res = parseWhere meth limitedSource qual
                         res |> Seq.head |> box :?> 'T
                     | MethodCall(None, (MethodWithName "Average" | MethodWithName "Sum" | MethodWithName "Max" | MethodWithName "Min" as meth), [SourceWithQueryData source; 
-                             OptionalQuote (Lambda([ParamName param], OptionalConvertOrTypeAs(SqlColumnGet(entity,key,_)))) 
+                             OptionalQuote (Lambda([ParamName param], OptionalConvertOrTypeAs(SqlColumnGet(entity, KeyColumn key,_)))) 
                              ]) ->
                         let alias =
                              match entity with
@@ -827,14 +797,16 @@ module internal QueryImplementation =
                         let sqlExpression =
                                
                                match meth.Name, source.SqlExpression with
-                               | "Sum", BaseTable("",entity)  -> AggregateOp(Sum(None),"",key,BaseTable(alias,entity))
-                               | "Sum", _ ->  AggregateOp(Sum(None),alias,key,source.SqlExpression)
-                               | "Max", BaseTable("",entity)  -> AggregateOp(Max(None),"",key,BaseTable(alias,entity))
-                               | "Max", _ ->  AggregateOp(Max(None),alias,key,source.SqlExpression)
-                               | "Min", BaseTable("",entity)  -> AggregateOp(Min(None),"",key,BaseTable(alias,entity))
-                               | "Min", _ ->  AggregateOp(Min(None),alias,key,source.SqlExpression)
-                               | "Average", BaseTable("",entity)  -> AggregateOp(Avg(None),"",key,BaseTable(alias,entity))
-                               | "Average", _ ->  AggregateOp(Avg(None),alias,key,source.SqlExpression)
+                               | "Sum", BaseTable("",entity)  -> AggregateOp("",GroupColumn(SumOp(key)),BaseTable(alias,entity))
+                               | "Sum", _ ->  AggregateOp(alias,GroupColumn(SumOp(key)),source.SqlExpression)
+                               | "Max", BaseTable("",entity)  -> AggregateOp("",GroupColumn(MaxOp(key)),BaseTable(alias,entity))
+                               | "Max", _ ->  AggregateOp(alias,GroupColumn(MaxOp(key)),source.SqlExpression)
+                               | "Count", BaseTable("",entity)  -> AggregateOp("",GroupColumn(CountOp(key)),BaseTable(alias,entity))
+                               | "Count", _ ->  AggregateOp(alias,GroupColumn(CountOp(key)),source.SqlExpression)
+                               | "Min", BaseTable("",entity)  -> AggregateOp("",GroupColumn(MinOp(key)),BaseTable(alias,entity))
+                               | "Min", _ ->  AggregateOp(alias,GroupColumn(MinOp(key)),source.SqlExpression)
+                               | "Average", BaseTable("",entity)  -> AggregateOp("",GroupColumn(AvgOp(key)),BaseTable(alias,entity))
+                               | "Average", _ ->  AggregateOp(alias,GroupColumn(AvgOp(key)),source.SqlExpression)
                                | _ -> failwithf "Unsupported aggregation `%s` in execution expression `%s`" meth.Name (e.ToString())
                         let res = executeQueryScalar source.DataContext source.Provider sqlExpression source.TupleIndex 
                         if res = box(DBNull.Value) then Unchecked.defaultof<'T> else

--- a/src/SQLProvider/SqlRuntime.Patterns.fs
+++ b/src/SQLProvider/SqlRuntime.Patterns.fs
@@ -223,10 +223,10 @@ let rec (|SqlColumnGet|_|) (e:Expression) =
         | t when t = typeof<System.String> || t= typeof<Option<System.String>> -> // String functions
             match meth.Name, par with
             | "Substring", [Int startPos] -> Some(alias, CanonicalOperation(CanonicalOp.Substring(SqlInt(startPos)), col), typ)
-            | "Substring", [SqlColumnGet(al2,col2,typ)] when integerTypes |> Seq.exists(fun t -> t = typ) -> Some(alias, CanonicalOperation(CanonicalOp.Substring(SqlIntCol(al2,col2)), col), typ)
+            | "Substring", [SqlColumnGet(al2,col2,typ2)] when integerTypes |> Seq.exists(fun t -> t = typ2) -> Some(alias, CanonicalOperation(CanonicalOp.Substring(SqlIntCol(al2,col2)), col), typ)
             | "Substring", [Int startPos; Int strLen] -> Some(alias, CanonicalOperation(CanonicalOp.SubstringWithLength(SqlInt(startPos),SqlInt(strLen)), col), typ)
-            | "Substring", [SqlColumnGet(al2,col2,typ); Int strLen] when integerTypes |> Seq.exists(fun t -> t = typ) -> Some(alias, CanonicalOperation(CanonicalOp.SubstringWithLength(SqlIntCol(al2,col2),SqlInt(strLen)), col), typ)
-            | "Substring", [Int startPos; SqlColumnGet(al2,col2,typ)] when integerTypes |> Seq.exists(fun t -> t = typ) -> Some(alias, CanonicalOperation(CanonicalOp.SubstringWithLength(SqlInt(startPos),SqlIntCol(al2,col2)), col), typ)
+            | "Substring", [SqlColumnGet(al2,col2,typ2); Int strLen] when integerTypes |> Seq.exists(fun t -> t = typ2) -> Some(alias, CanonicalOperation(CanonicalOp.SubstringWithLength(SqlIntCol(al2,col2),SqlInt(strLen)), col), typ)
+            | "Substring", [Int startPos; SqlColumnGet(al2,col2,typ2)] when integerTypes |> Seq.exists(fun t -> t = typ2) -> Some(alias, CanonicalOperation(CanonicalOp.SubstringWithLength(SqlInt(startPos),SqlIntCol(al2,col2)), col), typ)
             | "Substring", [SqlColumnGet(al2,col2,ty2); SqlColumnGet(al3,col3,ty3)]  when integerTypes |> Seq.exists(fun t -> t = ty2) && integerTypes |> Seq.exists(fun t -> t = ty3) -> Some(alias, CanonicalOperation(CanonicalOp.SubstringWithLength(SqlIntCol(al2,col2),SqlIntCol(al3,col3)), col), typ)
             | "ToUpper", []
             | "ToUpperInvariant", [] -> Some(alias, CanonicalOperation(CanonicalOp.ToUpper, col), typ)
@@ -241,17 +241,17 @@ let rec (|SqlColumnGet|_|) (e:Expression) =
             | "IndexOf", [String search] when not(search.Contains("'")) -> Some(alias, CanonicalOperation(CanonicalOp.IndexOf(SqlStr(search)), col), intType typ)
             | "IndexOf", [SqlColumnGet(al2,col2,_)] -> Some(alias, CanonicalOperation(CanonicalOp.IndexOf(SqlStrCol(al2,col2)), col), intType typ)
             | "IndexOf", [String search; Int startPos] when not(search.Contains("'")) -> Some(alias, CanonicalOperation(CanonicalOp.IndexOfStart(SqlStr(search), SqlInt(startPos)), col), intType typ)
-            | "IndexOf", [SqlColumnGet(al2,col2,typ2); Int startPos] -> Some(alias, CanonicalOperation(CanonicalOp.IndexOfStart(SqlStrCol(al2,col2), SqlInt(startPos)), col), intType typ)
-            | "IndexOf", [String search; SqlColumnGet(al2,col2,typ)] when not(search.Contains("'")) && integerTypes |> Seq.exists(fun t -> t = typ) -> Some(alias, CanonicalOperation(CanonicalOp.IndexOfStart(SqlStr(search), SqlIntCol(al2,col2)), col), intType typ)
-            | "IndexOf", [SqlColumnGet(al2,col2,_); SqlColumnGet(al3,col3,typ)] when integerTypes |> Seq.exists(fun t -> t = typ) -> Some(alias, CanonicalOperation(CanonicalOp.IndexOfStart(SqlStrCol(al2,col2), SqlIntCol(al3,col3)), col), intType typ)
+            | "IndexOf", [SqlColumnGet(al2,col2,_); Int startPos] -> Some(alias, CanonicalOperation(CanonicalOp.IndexOfStart(SqlStrCol(al2,col2), SqlInt(startPos)), col), intType typ)
+            | "IndexOf", [String search; SqlColumnGet(al2,col2,typ2)] when not(search.Contains("'")) && integerTypes |> Seq.exists(fun t -> t = typ2) -> Some(alias, CanonicalOperation(CanonicalOp.IndexOfStart(SqlStr(search), SqlIntCol(al2,col2)), col), intType typ)
+            | "IndexOf", [SqlColumnGet(al2,col2,_); SqlColumnGet(al3,col3,typ2)] when integerTypes |> Seq.exists(fun t -> t = typ2) -> Some(alias, CanonicalOperation(CanonicalOp.IndexOfStart(SqlStrCol(al2,col2), SqlIntCol(al3,col3)), col), intType typ)
             | _ -> None
         | t when t = typeof<System.DateTime> || t = typeof<Option<System.DateTime>> -> // DateTime functions
             match meth.Name, par with
             | "AddYears", [Int x] -> Some(alias, CanonicalOperation(CanonicalOp.AddYears(SqlInt(x)), col), typ)
-            | "AddYears", [SqlColumnGet(al2,col2,typ)] when integerTypes |> Seq.exists(fun t -> t = typ) -> Some(alias, CanonicalOperation(CanonicalOp.AddYears(SqlIntCol(al2,col2)), col), typ)
+            | "AddYears", [SqlColumnGet(al2,col2,typ2)] when integerTypes |> Seq.exists(fun t -> t = typ2) -> Some(alias, CanonicalOperation(CanonicalOp.AddYears(SqlIntCol(al2,col2)), col), typ)
             | "AddMonths", [Int x] -> Some(alias, CanonicalOperation(CanonicalOp.AddMonths(x), col), typ)
             | "AddDays", [Float x] -> Some(alias, CanonicalOperation(CanonicalOp.AddDays(SqlFloat(x)), col), typ)
-            | "AddDays", [SqlColumnGet(al2,col2,typ)] when integerTypes |> Seq.exists(fun t -> t = typ) || decimalTypes |> Seq.exists(fun t -> t = typ)  -> Some(alias, CanonicalOperation(CanonicalOp.AddDays(SqlNumCol(al2,col2)), col), typ)
+            | "AddDays", [SqlColumnGet(al2,col2,typ2)] when integerTypes |> Seq.exists(fun t -> t = typ2) || decimalTypes |> Seq.exists(fun t -> t = typ2)  -> Some(alias, CanonicalOperation(CanonicalOp.AddDays(SqlNumCol(al2,col2)), col), typ)
             | "AddHours", [Float x] -> Some(alias, CanonicalOperation(CanonicalOp.AddHours(x), col), typ)
             | "AddMinutes", [Float x] -> Some(alias, CanonicalOperation(CanonicalOp.AddMinutes(x), col), typ)
             | "AddSeconds", [Float x] -> Some(alias, CanonicalOperation(CanonicalOp.AddSeconds(x), col), typ)

--- a/src/SQLProvider/SqlRuntime.Patterns.fs
+++ b/src/SQLProvider/SqlRuntime.Patterns.fs
@@ -230,9 +230,10 @@ let rec (|SqlColumnGet|_|) (e:Expression) =
             | "ToLowerInvariant", [] -> Some(alias, CanonicalOperation(CanonicalOp.ToLower, col), typ)
             | "Trim", [] -> Some(alias, CanonicalOperation(CanonicalOp.Trim, col), typ)
             | "Length", [] -> Some(alias, CanonicalOperation(CanonicalOp.Length, col), intType typ)
-            | "Replace", [String itm1; String itm2] -> Some(alias, CanonicalOperation(CanonicalOp.Replace(itm1, itm2), col), typ)
-            | "IndexOf", [String search] -> Some(alias, CanonicalOperation(CanonicalOp.IndexOf(search), col), intType typ)
-            | "IndexOf", [String search; Int startPos] -> Some(alias, CanonicalOperation(CanonicalOp.IndexOfStart(search, startPos), col), intType typ)
+            | "Replace", [String itm1; String itm2] when not(itm1.Contains("'") || itm2.Contains("'"))  -> Some(alias, CanonicalOperation(CanonicalOp.Replace(itm1, itm2), col), typ)
+            | "IndexOf", [String search] when not(search.Contains("'")) -> Some(alias, CanonicalOperation(CanonicalOp.IndexOf(search), col), intType typ)
+            | "IndexOf", [String search; Int startPos] when not(search.Contains("'")) -> Some(alias, CanonicalOperation(CanonicalOp.IndexOfStart(search, startPos), col), intType typ)
+            | "IndexOf", [SqlColumnGet(al2,col2,typ2)] -> Some(alias, CanonicalOperation(CanonicalOp.IndexOfColumn(al2,col2), col), intType typ)
             | _ -> None
         | t when t = typeof<System.DateTime> || t = typeof<Option<System.DateTime>> -> // DateTime functions
             match meth.Name, par with

--- a/src/SQLProvider/SqlRuntime.QueryExpression.fs
+++ b/src/SQLProvider/SqlRuntime.QueryExpression.fs
@@ -426,12 +426,19 @@ module internal QueryExpressionTransformer =
         // This resolves aliases on canonical multi-column functions
         let rec resolveC = function
             | CanonicalOperation(BasicMathOfColumns(op,al,col2), col1) -> 
-                CanonicalOperation(BasicMathOfColumns(op,resolve al, resolveC col2), col1)
+                CanonicalOperation(BasicMathOfColumns(op,resolve al, resolveC col2), resolveC col1)
+            | CanonicalOperation(IndexOfColumn(al, col2), col1) ->
+                CanonicalOperation(IndexOfColumn(resolve al, resolveC col2), resolveC col1)
             | x -> x
 
+        let tryResolveC : Option<obj>->Option<obj> = Option.map(function
+            | :? (alias * SqlColumnType) as a ->
+                (resolve (fst a), resolveC (snd a)) :> obj
+            | x -> x)
+
         let rec resolveFilterList = function
-            | And(xs,y) -> And(xs|>List.map(fun (a,b,c,d) -> resolve a,resolveC b,c,d),Option.map (List.map resolveFilterList) y)
-            | Or(xs,y) -> Or(xs|>List.map(fun (a,b,c,d) -> resolve a,resolveC b,c,d),Option.map (List.map resolveFilterList) y)
+            | And(xs,y) -> And(xs|>List.map(fun (a,b,c,d) -> resolve a,resolveC b,c,tryResolveC d),Option.map (List.map resolveFilterList) y)
+            | Or(xs,y) -> Or(xs|>List.map(fun (a,b,c,d) -> resolve a,resolveC b,c,tryResolveC d),Option.map (List.map resolveFilterList) y)
             | ConstantTrue -> ConstantTrue
             | ConstantFalse -> ConstantFalse
             
@@ -443,9 +450,11 @@ module internal QueryExpressionTransformer =
         // its possible to do this when converting the expression but its
         // much easier at this stage once we have knowledge of the whole query
         let sqlQuery = { sqlQuery with Filters = List.map resolveFilterList sqlQuery.Filters
-                                       Ordering = List.map(function ("",b,c) -> (resolve "",resolveC b,c) | x -> x) sqlQuery.Ordering 
+                                       Ordering = List.map(function 
+                                                            |("",b,c) -> (resolve "",resolveC b,c) 
+                                                            | a,c,b -> a, resolveC c,b) sqlQuery.Ordering 
                                        // Resolve other canonical function columns also:
-                                       Links = sqlQuery.Links |> List.map (fun (a1,ld,a2) -> a1, {ld with PrimaryKey = ld.PrimaryKey |> List.map(resolveC)}, a2)
+                                       Links = sqlQuery.Links |> List.map (fun (a1,ld,a2) -> a1, {ld with ForeignKey = ld.ForeignKey |> List.map(resolveC)}, a2)
                                        Grouping = sqlQuery.Grouping |> List.map(fun (g,a) -> g|>List.map(fun (ga, gk) -> ga, resolveC gk), a|>List.map(fun(ag,aa)->ag,resolveC aa)) 
                        }
 

--- a/src/SQLProvider/SqlRuntime.QueryExpression.fs
+++ b/src/SQLProvider/SqlRuntime.QueryExpression.fs
@@ -425,10 +425,25 @@ module internal QueryExpressionTransformer =
         
         // This resolves aliases on canonical multi-column functions
         let rec resolveC = function
-            | CanonicalOperation(BasicMathOfColumns(op,al,col2), col1) -> 
-                CanonicalOperation(BasicMathOfColumns(op,resolve al, resolveC col2), resolveC col1)
-            | CanonicalOperation(IndexOfColumn(al, col2), col1) ->
-                CanonicalOperation(IndexOfColumn(resolve al, resolveC col2), resolveC col1)
+            | CanonicalOperation(BasicMathOfColumns(op,al,col2), col1) -> CanonicalOperation(BasicMathOfColumns(op,resolve al, resolveC col2), resolveC col1)
+            | CanonicalOperation(Substring(SqlIntCol(al, col2)), col1) -> CanonicalOperation(Substring(SqlIntCol(resolve al, resolveC col2)), resolveC col1)
+
+            | CanonicalOperation(SubstringWithLength(SqlIntCol(al2, col2),SqlIntCol(al3, col3)), col1) -> CanonicalOperation(SubstringWithLength(SqlIntCol(resolve al2, resolveC col2),SqlIntCol(resolve al3, resolveC col3)), resolveC col1)
+            | CanonicalOperation(SubstringWithLength(x,SqlIntCol(al3, col3)), col1) -> CanonicalOperation(SubstringWithLength(x,SqlIntCol(resolve al3, resolveC col3)), resolveC col1)
+            | CanonicalOperation(SubstringWithLength(SqlIntCol(al2, col2),x), col1) -> CanonicalOperation(SubstringWithLength(SqlIntCol(resolve al2, resolveC col2),x), resolveC col1)
+
+            | CanonicalOperation(Replace(SqlStrCol(al2, col2),SqlStrCol(al3, col3)), col1) -> CanonicalOperation(Replace(SqlStrCol(resolve al2, resolveC col2),SqlStrCol(resolve al3, resolveC col3)), resolveC col1)
+            | CanonicalOperation(Replace(x,SqlStrCol(al3, col3)), col1) -> CanonicalOperation(Replace(x,SqlStrCol(resolve al3, resolveC col3)), resolveC col1)
+            | CanonicalOperation(Replace(SqlStrCol(al2, col2),x), col1) -> CanonicalOperation(Replace(SqlStrCol(resolve al2, resolveC col2),x), resolveC col1)
+
+            | CanonicalOperation(IndexOfStart(SqlStrCol(al2, col2),SqlIntCol(al3, col3)), col1) -> CanonicalOperation(IndexOfStart(SqlStrCol(resolve al2, resolveC col2),SqlIntCol(resolve al3, resolveC col3)), resolveC col1)
+            | CanonicalOperation(IndexOfStart(x,SqlIntCol(al3, col3)), col1) -> CanonicalOperation(IndexOfStart(x,SqlIntCol(resolve al3, resolveC col3)), resolveC col1)
+            | CanonicalOperation(IndexOfStart(SqlStrCol(al2, col2),x), col1) -> CanonicalOperation(IndexOfStart(SqlStrCol(resolve al2, resolveC col2),x), resolveC col1)
+
+            | CanonicalOperation(IndexOf(SqlStrCol(al, col2)), col1) -> CanonicalOperation(IndexOf(SqlStrCol(resolve al, resolveC col2)), resolveC col1)
+
+            | CanonicalOperation(AddYears(SqlIntCol(al, col2)), col1) -> CanonicalOperation(AddYears(SqlIntCol(resolve al, resolveC col2)), resolveC col1)
+            | CanonicalOperation(AddDays(SqlNumCol(al, col2)), col1) -> CanonicalOperation(AddDays(SqlNumCol(resolve al, resolveC col2)), resolveC col1)
             | x -> x
 
         let tryResolveC : Option<obj>->Option<obj> = Option.map(function

--- a/src/SQLProvider/Utils.fs
+++ b/src/SQLProvider/Utils.fs
@@ -105,7 +105,7 @@ module internal Utilities =
             match op with // These are very standard:
             | ToUpper -> sprintf "UPPER(%s)" column
             | ToLower -> sprintf "LOWER(%s)" column
-            | Replace(searchItm,toItm) -> sprintf "REPLACE(%s,%s,%s)" column searchItm toItm
+            | Replace(searchItm,toItm) -> sprintf "REPLACE(%s,'%s','%s')" column searchItm toItm
             | Abs -> sprintf "ABS(%s)" column
             | Ceil -> sprintf "CEILING(%s)" column
             | Floor -> sprintf "FLOOR(%s)" column

--- a/src/SQLProvider/Utils.fs
+++ b/src/SQLProvider/Utils.fs
@@ -105,7 +105,7 @@ module internal Utilities =
             match op with // These are very standard:
             | ToUpper -> sprintf "UPPER(%s)" column
             | ToLower -> sprintf "LOWER(%s)" column
-            | Replace(searchItm,toItm) -> sprintf "REPLACE(%s,'%s','%s')" column searchItm toItm
+            | Replace(SqlStr(searchItm),SqlStr(toItm)) -> sprintf "REPLACE(%s,'%s','%s')" column searchItm toItm
             | Abs -> sprintf "ABS(%s)" column
             | Ceil -> sprintf "CEILING(%s)" column
             | Floor -> sprintf "FLOOR(%s)" column

--- a/tests/SqlProvider.Tests/QueryTests.fs
+++ b/tests/SqlProvider.Tests/QueryTests.fs
@@ -1100,13 +1100,17 @@ let ``simple canonical operations query``() =
             // Silly query not hitting indexes, so testing purposes only...
             for cust in dc.Main.Customers do
             join emp in dc.Main.Employees on (cust.City.Trim() + "x" = emp.City.Trim() + "x")
+            // This is not yet working:
+            //join emp in dc.Main.Employees on (cust.City.Trim() + "x" + cust.Country = emp.City.Trim() + "x" + emp.Country)
             where (
-                abs(emp.EmployeeId)+1L > 4L 
+                cust.City + emp.City + cust.City + emp.City + cust.City = cust.City + emp.City + cust.City + emp.City + cust.City
+                && abs(emp.EmployeeId)+1L > 4L 
                 && cust.City.Length > 1  
                 && cust.City + "L" = "LondonL" 
+                && cust.City.IndexOf("n")>0 && cust.City.IndexOf(cust.City.Substring(1,2))>0
                 && emp.BirthDate.Date.AddYears(3).Month + 1 > 3
             )
-            sortBy emp.BirthDate.Day
+            sortBy (emp.BirthDate.Day * emp.BirthDate.Day)
             select (cust.CustomerId, cust.City, emp.BirthDate)
         } |> Seq.toArray
 

--- a/tests/SqlProvider.Tests/QueryTests.fs
+++ b/tests/SqlProvider.Tests/QueryTests.fs
@@ -1096,6 +1096,7 @@ let ``simple canonical operations query``() =
     let dc = sql.GetDataContext()
 
     let qry = 
+        let L = "L"
         query {
             // Silly query not hitting indexes, so testing purposes only...
             for cust in dc.Main.Customers do
@@ -1106,7 +1107,7 @@ let ``simple canonical operations query``() =
                 cust.City + emp.City + cust.City + emp.City + cust.City = cust.City + emp.City + cust.City + emp.City + cust.City
                 && abs(emp.EmployeeId)+1L > 4L 
                 && cust.City.Length + secondCust.City.Length + emp.City.Length = 3 * cust.City.Length
-                && cust.City.Replace("on","on") + "L" = "LondonL" 
+                && (cust.City.Replace("on","xx") + L).Replace("xx","on") + ("O" + L) = "London" + "LOL" 
                 && cust.City.IndexOf("n")>0 && cust.City.IndexOf(cust.City.Substring(1,cust.City.Length-1))>0
                 && emp.BirthDate.Date.AddYears(3).Month + 1 > 3
             )

--- a/tests/SqlProvider.Tests/QueryTests.fs
+++ b/tests/SqlProvider.Tests/QueryTests.fs
@@ -345,7 +345,6 @@ let ``simple select where in query``() =
     Assert.IsTrue(qry.Contains("ANATR"))
 
     
-    
 [<Test >]
 let ``simple select where not-in query``() =
     let dc = sql.GetDataContext()
@@ -504,7 +503,7 @@ let ``simple select query with groupBy``() =
     Assert.IsNotEmpty(res)
     Assert.AreEqual(6, res.["London"])
 
-[<Test; Ignore("Not Supported")>]
+[<Test>]
 let ``simple select query with groupBy multiple columns``() = 
     let dc = sql.GetDataContext()
     let qry = 
@@ -1075,6 +1074,22 @@ let ``simple select with contains query with where boolean option type``() =
             contains "ALFKI"
         }
     Assert.IsTrue(qry)    
+
+
+[<Test >]
+let ``simple canonical operation substing query``() =
+    let dc = sql.GetDataContext()
+    let qry = 
+        query {
+            for cust in dc.Main.Customers do
+            // Database spesific warning here: Substring of SQLite starts from 1.
+            where (cust.CustomerId.Substring(2,3)="NAT")
+            select cust.CustomerId
+        } |> Seq.toArray
+
+    CollectionAssert.IsNotEmpty qry
+    Assert.AreEqual(1, qry.Length)
+    Assert.IsTrue(qry.Contains("ANATR"))
 
 [<Test>]
 let ``simple union query test``() = 

--- a/tests/SqlProvider.Tests/QueryTests.fs
+++ b/tests/SqlProvider.Tests/QueryTests.fs
@@ -1099,19 +1099,20 @@ let ``simple canonical operations query``() =
         query {
             // Silly query not hitting indexes, so testing purposes only...
             for cust in dc.Main.Customers do
-            join emp in dc.Main.Employees on (cust.City.Trim() + "x" = emp.City.Trim() + "x")
             // This is not yet working:
-            //join emp in dc.Main.Employees on (cust.City.Trim() + "x" + cust.Country = emp.City.Trim() + "x" + emp.Country)
+            join emp in dc.Main.Employees on (cust.City.Trim() + "x" + cust.Country = emp.City.Trim() + "x" + emp.Country)
+            join secondCust in dc.Main.Customers on (cust.City + emp.City + "A" = secondCust.City + secondCust.City + "A")
             where (
                 cust.City + emp.City + cust.City + emp.City + cust.City = cust.City + emp.City + cust.City + emp.City + cust.City
                 && abs(emp.EmployeeId)+1L > 4L 
-                && cust.City.Length > 1  
-                && cust.City + "L" = "LondonL" 
-                && cust.City.IndexOf("n")>0 && cust.City.IndexOf(cust.City.Substring(1,2))>0
+                && cust.City.Length + secondCust.City.Length + emp.City.Length = 3 * cust.City.Length
+                && cust.City.Replace("on","on") + "L" = "LondonL" 
+                && cust.City.IndexOf("n")>0 && cust.City.IndexOf(cust.City.Substring(1,cust.City.Length-1))>0
                 && emp.BirthDate.Date.AddYears(3).Month + 1 > 3
             )
-            sortBy (emp.BirthDate.Day * emp.BirthDate.Day)
+            sortBy (abs(abs(emp.BirthDate.Day * emp.BirthDate.Day)))
             select (cust.CustomerId, cust.City, emp.BirthDate)
+            distinct
         } |> Seq.toArray
 
     CollectionAssert.IsNotEmpty qry

--- a/tests/SqlProvider.Tests/scripts/MSAccessTests.fsx
+++ b/tests/SqlProvider.Tests/scripts/MSAccessTests.fsx
@@ -94,7 +94,7 @@ let canoncicalOpTest =
             abs(emp.EmployeeId)+1 > 4
             && cust.City.Value.Length > 1  
             && cust.City.IsSome && cust.City.Value + "L" = "LondonL" 
-            && emp.BirthDate.Value.AddYears(3).Month + 1 > 3
+            && emp.BirthDate.Value.AddYears(3).Year + 1 > 1960
         )
         sortBy emp.BirthDate.Value.Day
         select (cust.CustomerId, cust.City, emp.BirthDate)

--- a/tests/SqlProvider.Tests/scripts/MSAccessTests.fsx
+++ b/tests/SqlProvider.Tests/scripts/MSAccessTests.fsx
@@ -84,3 +84,18 @@ let asyncContainsQuery =
         } |> Async.StartAsTask
     r.Wait()
     r.Result
+
+let canoncicalOpTest = 
+    query {
+        // Silly query not hitting indexes, so testing purposes only...
+        for cust in ctx.Northwind.Customers do
+        join emp in ctx.Northwind.Employees on (cust.City.Value.Trim() + "x" = emp.City.Value.Trim() + "x")
+        where (
+            abs(emp.EmployeeId)+1 > 4
+            && cust.City.Value.Length > 1  
+            && cust.City.IsSome && cust.City.Value + "L" = "LondonL" 
+            && emp.BirthDate.Value.AddYears(3).Month + 1 > 3
+        )
+        sortBy emp.BirthDate.Value.Day
+        select (cust.CustomerId, cust.City, emp.BirthDate)
+    } |> Seq.toArray

--- a/tests/SqlProvider.Tests/scripts/MySqlTests.fsx
+++ b/tests/SqlProvider.Tests/scripts/MySqlTests.fsx
@@ -237,3 +237,17 @@ let taskarray =
     ) |> Seq.toArray |> Tasks.Task.WaitAll
 
 ctx.GetUpdates()
+
+let canoncicalOpTest = 
+    query {
+        // Silly query not hitting indexes, so testing purposes only...
+        for job in ctx.Hr.Jobs do
+        join emp in ctx.Hr.Employees on (job.JobId  = emp.JobId )
+        where (
+            floor(job.MaxSalary)+1m > 4m
+            && emp.Email.Length > 1  
+            && emp.HireDate.Date.Year + 1 > 1997
+        )
+        //sortBy emp.HireDate.Day
+        select (emp.HireDate, emp.Email, job.MaxSalary)
+    } |> Seq.toArray

--- a/tests/SqlProvider.Tests/scripts/MySqlTests.fsx
+++ b/tests/SqlProvider.Tests/scripts/MySqlTests.fsx
@@ -129,7 +129,19 @@ let qry =
         select (p.Key, p.Sum(fun f -> f.Salary))
     } |> Seq.toList
     
-
+let canoncicalOpTest = 
+    query {
+        // Silly query not hitting indexes, so testing purposes only...
+        for job in ctx.Hr.Jobs do
+        join emp in ctx.Hr.Employees on (job.JobId.Trim() + "x" = emp.JobId.Trim() + "x")
+        where (
+            floor(job.MaxSalary)+1m > 4m
+            && emp.Email.Length > 2
+            && emp.HireDate.Date.AddYears(-3).Year + 1 > 1997
+        )
+        sortBy emp.HireDate.Day
+        select (emp.HireDate, emp.Email, job.MaxSalary)
+    } |> Seq.toArray
 
 //************************ CRUD *************************//
 
@@ -237,17 +249,3 @@ let taskarray =
     ) |> Seq.toArray |> Tasks.Task.WaitAll
 
 ctx.GetUpdates()
-
-let canoncicalOpTest = 
-    query {
-        // Silly query not hitting indexes, so testing purposes only...
-        for job in ctx.Hr.Jobs do
-        join emp in ctx.Hr.Employees on (job.JobId  = emp.JobId )
-        where (
-            floor(job.MaxSalary)+1m > 4m
-            && emp.Email.Length > 1  
-            && emp.HireDate.Date.Year + 1 > 1997
-        )
-        //sortBy emp.HireDate.Day
-        select (emp.HireDate, emp.Email, job.MaxSalary)
-    } |> Seq.toArray

--- a/tests/SqlProvider.Tests/scripts/OdbcTests.fsx
+++ b/tests/SqlProvider.Tests/scripts/OdbcTests.fsx
@@ -99,6 +99,21 @@ let asyncContainsQuery =
     r.Wait()
     r.Result
 
+let canoncicalOpTest = 
+    query {
+        // Access doesn't support many ODBC functions.
+        // Silly query not hitting indexes, so testing purposes only...
+        for cust in odbcaContext.Dbo.Customers do
+        join emp in odbcaContext.Dbo.Employees on (cust.City.Value.Trim() = emp.City.Value.Trim())
+        where (
+            abs(emp.EmployeeId)+1 > 4
+            && emp.BirthDate.Value.Month + 1 > 3
+        )
+        sortBy emp.BirthDate.Value.Year
+        select (cust.CustomerId, cust.City, emp.BirthDate)
+    } |> Seq.toArray
+
+
 // ----------------------------------------------------------------
 // SQL Server connection
 // Database: http://pastebin.com/5W3PPVaD

--- a/tests/SqlProvider.Tests/scripts/OracleTests.fsx
+++ b/tests/SqlProvider.Tests/scripts/OracleTests.fsx
@@ -68,6 +68,21 @@ let employeesJob =
             select (emp.FirstName, emp.LastName, manager.FirstName, manager.LastName )
     } |> Seq.toList
 
+// TODO: Test if you have Oracle.
+//let canonicalTest =
+//    query {
+//            for emp in ctx.Hr.Employees do
+//            join d in ctx.Hr.Departments on (emp.DepartmentId+1 = d.DepartmentId+1)
+//            where (abs(d.DepartmentId) > 1
+//                && emp.FirstName + "D" = "DavidD"
+//                && emp.LastName.Length > 3
+//                && emp.HireDate.Date.AddYears(-10).Year < 1990
+//            )
+//            select (d.DepartmentName, emp.FirstName, emp.LastName, emp.HireDate)
+//    } |> Seq.toList
+    
+
+
 //Can select from views
 let empDetails =
     query {

--- a/tests/SqlProvider.Tests/scripts/PostgreSQLTests.fsx
+++ b/tests/SqlProvider.Tests/scripts/PostgreSQLTests.fsx
@@ -123,6 +123,19 @@ let topSales5ByCommission =
     |> Seq.map (fun e -> e.MapTo<Employee>())
     |> Seq.toList
 
+let canonicalTest =
+    query {
+            for emp in ctx.Public.Employees do
+            join d in ctx.Public.Departments on (emp.DepartmentId.Value+1 = d.DepartmentId+1)
+            where (abs(d.LocationId.Value) > 1//.value
+                && emp.FirstName.Value + "D" = "DavidD"
+                && emp.LastName.Length > 6
+                && emp.HireDate.Date.AddYears(-10).Year < 1990
+            )
+            select (d.DepartmentName, emp.FirstName, emp.LastName, emp.HireDate)
+    } |> Seq.toList
+
+
 #r @"../../../packages/scripts/Newtonsoft.Json/lib/net45/Newtonsoft.Json.dll"
 
 open Newtonsoft.Json

--- a/tests/SqlProvider.Tests/scripts/SqlServerTests.fsx
+++ b/tests/SqlProvider.Tests/scripts/SqlServerTests.fsx
@@ -149,6 +149,21 @@ let nestedQueryTest =
     } |> Seq.toArray
 
 
+
+let canoncicalOpTest = 
+    query {
+        // Silly query not hitting indexes, so testing purposes only...
+        for job in ctx.Dbo.Jobs do
+        join emp in ctx.Dbo.Employees on (job.JobId.Trim() + "z" = emp.JobId.Trim() + "z")
+        where (
+            floor(job.MaxSalary)+1m > 4m
+            && emp.Email.Length > 1  
+            && emp.HireDate.Date.AddYears(-3).Year + 1 > 1997
+        )
+        sortBy emp.HireDate.Day
+        select (emp.HireDate, emp.Email, job.MaxSalary)
+    } |> Seq.toArray
+
 //************************ CRUD *************************//
 
 


### PR DESCRIPTION
*Canonical functions are SQL-specific functions to each database. We translate .NET-functions to native database functions.*

Done some refactoring for easier implementation. 

How to implement a new function:
1. Add function to SqlRuntime.Patterns (near comment `// These are canonical functions`)
2. Add provider spesific implementations for each providers `fieldNotation`-function
3. Add unit tests :-)

Currently support for:
- For strings: 
   - [x] Substring, 
   - [x] Concat,
   - [x] toUpper, toLower
   - [x] Trim
- For numerics: 
   - [x] Abs, 
   - [x] Basic arithmetics (add,substract,multiply,divide)
   - [x] Somekind of rounding for decimals 
- For dates (needs more testing): 
   - [x] Day,Month,Year, 
   - [x] And adding them. 
   - [x] Removing time-component
- Others:
   - [ ] case-clause

Hmm... Interesting that SQLite Substring starts from 1 and .NET from 0. Should we try to convert those also to .NET-style?

Ping #390 