### PR TITLE
Possibility to use simple but dangerous DELETE-queries. 

### DIFF
--- a/src/SQLProvider/Providers.MSAccess.fs
+++ b/src/SQLProvider/Providers.MSAccess.fs
@@ -282,7 +282,7 @@ type internal MSAccessProvider() =
         member __.GetIndividualsQueryText(table,amount) = sprintf "SELECT TOP %i * FROM [%s]" amount table.Name
         member __.GetIndividualQueryText(table,column) = sprintf "SELECT * FROM [%s] WHERE [%s] = @id" table.Name column
 
-        member __.GenerateQueryText(sqlQuery,baseAlias,baseTable,projectionColumns) =
+        member __.GenerateQueryText(sqlQuery,baseAlias,baseTable,projectionColumns,isDeleteScript) =
             let sb = System.Text.StringBuilder()
             let parameters = ResizeArray<_>()
             let (~~) (t:string) = sb.Append t |> ignore
@@ -451,15 +451,18 @@ type internal MSAccessProvider() =
                     if i > 0 then ~~ ", "
                     ~~ (sprintf "[%s].[%s] %s" alias column (if not desc then "DESC" else "")))
 
-            // SELECT
-            if sqlQuery.Distinct then ~~(sprintf "SELECT DISTINCT %s%s " (if sqlQuery.Take.IsSome then sprintf "TOP %i " sqlQuery.Take.Value else "")   columns)
-            elif sqlQuery.Count then ~~("SELECT COUNT(1) ")
-            else  ~~(sprintf "SELECT %s%s " (if sqlQuery.Take.IsSome then sprintf "TOP %i " sqlQuery.Take.Value else "")  columns)
-            // FROM
             //add in 'numLinks' open parens, after FROM, closing each after each JOIN statement
             let numLinks = sqlQuery.Links.Length
+            if isDeleteScript then
+                ~~(sprintf "DELETE FROM %s[%s] " (new String('(',numLinks)) (baseTable.Name.Replace("\"","")))
+            else 
+                // SELECT
+                if sqlQuery.Distinct then ~~(sprintf "SELECT DISTINCT %s%s " (if sqlQuery.Take.IsSome then sprintf "TOP %i " sqlQuery.Take.Value else "")   columns)
+                elif sqlQuery.Count then ~~("SELECT COUNT(1) ")
+                else  ~~(sprintf "SELECT %s%s " (if sqlQuery.Take.IsSome then sprintf "TOP %i " sqlQuery.Take.Value else "")  columns)
+                // FROM
 
-            ~~(sprintf "FROM %s[%s] as [%s] " (new String('(',numLinks)) (baseTable.Name.Replace("\"","")) baseAlias)
+                ~~(sprintf "FROM %s[%s] as [%s] " (new String('(',numLinks)) (baseTable.Name.Replace("\"","")) baseAlias)
 
             fromBuilder(numLinks)
             // WHERE

--- a/src/SQLProvider/Providers.MsSqlServer.fs
+++ b/src/SQLProvider/Providers.MsSqlServer.fs
@@ -565,7 +565,7 @@ type internal MSSqlServerProvider(tableNames:string) =
         member __.GetIndividualsQueryText(table,amount) = sprintf "SELECT TOP %i * FROM %s" amount table.FullName
         member __.GetIndividualQueryText(table,column) = sprintf "SELECT * FROM [%s].[%s] WHERE [%s].[%s].[%s] = @id" table.Schema table.Name table.Schema table.Name column
 
-        member __.GenerateQueryText(sqlQuery,baseAlias,baseTable,projectionColumns) =
+        member __.GenerateQueryText(sqlQuery,baseAlias,baseTable,projectionColumns,isDeleteScript) =
             let sb = System.Text.StringBuilder()
             let parameters = ResizeArray<_>()
             let (~~) (t:string) = sb.Append t |> ignore
@@ -744,15 +744,18 @@ type internal MSSqlServerProvider(tableNames:string) =
                     if i > 0 then ~~ ", "
                     ~~ (sprintf "[%s].[%s]%s" alias column (if not desc then "DESC" else "")))
 
-            // SELECT
-            if sqlQuery.Distinct then ~~(sprintf "SELECT DISTINCT %s%s " (if sqlQuery.Take.IsSome then sprintf "TOP %i " sqlQuery.Take.Value else "")   columns)
-            elif sqlQuery.Count then ~~("SELECT COUNT(1) ")
-            else
-                match sqlQuery.Skip, sqlQuery.Take with
-                | None, Some take -> ~~(sprintf "SELECT TOP %i %s " take columns)
-                | _ -> ~~(sprintf "SELECT %s " columns)
-            // FROM
-            ~~(sprintf "FROM [%s].[%s] as [%s] " baseTable.Schema baseTable.Name baseAlias)
+            if isDeleteScript then
+                ~~(sprintf "DELETE FROM [%s].[%s] " baseTable.Schema baseTable.Name)
+            else 
+                // SELECT
+                if sqlQuery.Distinct then ~~(sprintf "SELECT DISTINCT %s%s " (if sqlQuery.Take.IsSome then sprintf "TOP %i " sqlQuery.Take.Value else "")   columns)
+                elif sqlQuery.Count then ~~("SELECT COUNT(1) ")
+                else
+                    match sqlQuery.Skip, sqlQuery.Take with
+                    | None, Some take -> ~~(sprintf "SELECT TOP %i %s " take columns)
+                    | _ -> ~~(sprintf "SELECT %s " columns)
+                // FROM
+                ~~(sprintf "FROM [%s].[%s] as [%s] " baseTable.Schema baseTable.Name baseAlias)
             fromBuilder()
             // WHERE
             if sqlQuery.Filters.Length > 0 then

--- a/src/SQLProvider/Providers.MySql.fs
+++ b/src/SQLProvider/Providers.MySql.fs
@@ -511,7 +511,7 @@ type internal MySqlProvider(resolutionPath, owner, referencedAssemblies) as this
         member __.GetIndividualsQueryText(table,amount) = sprintf "SELECT * FROM %s LIMIT %i;" (table.FullName.Replace("\"","`").Replace("[","`").Replace("]","`").Replace("``","`")) amount
         member __.GetIndividualQueryText(table,column) = sprintf "SELECT * FROM `%s`.`%s` WHERE `%s`.`%s`.`%s` = @id" table.Schema (MySql.ripQuotes table.Name) table.Schema (MySql.ripQuotes table.Name) column
 
-        member this.GenerateQueryText(sqlQuery,baseAlias,baseTable,projectionColumns) =
+        member this.GenerateQueryText(sqlQuery,baseAlias,baseTable,projectionColumns,isDeleteScript) =
             let sb = System.Text.StringBuilder()
             let parameters = ResizeArray<_>()
             let (~~) (t:string) = sb.Append t |> ignore
@@ -694,12 +694,16 @@ type internal MySqlProvider(resolutionPath, owner, referencedAssemblies) as this
                     if i > 0 then ~~ ", "
                     ~~ (sprintf "`%s`.`%s` %s" alias column (if not desc then "DESC" else "")))
 
-            // SELECT
-            if sqlQuery.Distinct then ~~(sprintf "SELECT DISTINCT %s " columns)
-            elif sqlQuery.Count then ~~("SELECT COUNT(1) ")
-            else  ~~(sprintf "SELECT %s " columns)
-            // FROM
-            ~~(sprintf "FROM %s as `%s` " (baseTable.FullName.Replace("\"","`").Replace("[","`").Replace("]","`").Replace("``","`"))  baseAlias)
+            let basetable = baseTable.FullName.Replace("\"","`").Replace("[","`").Replace("]","`").Replace("``","`")
+            if isDeleteScript then
+                ~~(sprintf "DELETE FROM %s " basetable)
+            else 
+                // SELECT
+                if sqlQuery.Distinct then ~~(sprintf "SELECT DISTINCT %s " columns)
+                elif sqlQuery.Count then ~~("SELECT COUNT(1) ")
+                else  ~~(sprintf "SELECT %s " columns)
+                // FROM
+                ~~(sprintf "FROM %s as `%s` " basetable  baseAlias)
             fromBuilder()
             // WHERE
             if sqlQuery.Filters.Length > 0 then

--- a/src/SQLProvider/Providers.Odbc.fs
+++ b/src/SQLProvider/Providers.Odbc.fs
@@ -301,7 +301,7 @@ type internal OdbcProvider(quotehcar : OdbcQuoteCharacter) =
             sprintf "SELECT * FROM %c%s%c WHERE %c%s%s%s%c = ?" 
                         cOpen table.Name cClose cOpen table.Name separator column cClose
 
-        member __.GenerateQueryText(sqlQuery,baseAlias,baseTable,projectionColumns) =
+        member __.GenerateQueryText(sqlQuery,baseAlias,baseTable,projectionColumns,isDeleteScript) =
             let separator = (sprintf "%c.%c" cClose cOpen).Trim()
             let sb = System.Text.StringBuilder()
             let parameters = ResizeArray<_>()
@@ -469,13 +469,16 @@ type internal OdbcProvider(quotehcar : OdbcQuoteCharacter) =
             let stripSpecialCharacters (s:string) =
                 String(s.ToCharArray() |> Array.filter(fun c -> Char.IsLetterOrDigit c || c = ' ' || c = '_'))
 
-            // SELECT
-            let columnsFixed = if String.IsNullOrEmpty columns then "*" else columns
-            if sqlQuery.Distinct then ~~(sprintf "SELECT DISTINCT %s " columnsFixed)
-            elif sqlQuery.Count then ~~("SELECT COUNT(1) ")
-            else  ~~(sprintf "SELECT %s " columnsFixed)
-            // FROM
-            ~~(sprintf "FROM %c%s%c as %c%s%c " cOpen (baseTable.Name.Replace("\"", "")) cClose cOpen (stripSpecialCharacters baseAlias) cClose)
+            if isDeleteScript then
+                ~~(sprintf "DELETE FROM %c%s%c " cOpen (baseTable.Name.Replace("\"", "")) cClose)
+            else 
+                // SELECT
+                let columnsFixed = if String.IsNullOrEmpty columns then "*" else columns
+                if sqlQuery.Distinct then ~~(sprintf "SELECT DISTINCT %s " columnsFixed)
+                elif sqlQuery.Count then ~~("SELECT COUNT(1) ")
+                else  ~~(sprintf "SELECT %s " columnsFixed)
+                // FROM
+                ~~(sprintf "FROM %c%s%c as %c%s%c " cOpen (baseTable.Name.Replace("\"", "")) cClose cOpen (stripSpecialCharacters baseAlias) cClose)
             fromBuilder()
             // WHERE
             if sqlQuery.Filters.Length > 0 then

--- a/src/SQLProvider/Providers.Oracle.fs
+++ b/src/SQLProvider/Providers.Oracle.fs
@@ -613,7 +613,7 @@ type internal OracleProvider(resolutionPath, owner, referencedAssemblies, tableN
         member __.GetIndividualsQueryText(table,amount) = Oracle.getIndivdualsQueryText amount table
         member __.GetIndividualQueryText(table,column) = Oracle.getIndivdualQueryText table column
 
-        member this.GenerateQueryText(sqlQuery,baseAlias,baseTable,projectionColumns) =
+        member this.GenerateQueryText(sqlQuery,baseAlias,baseTable,projectionColumns,isDeleteScript) =
             let sb = System.Text.StringBuilder()
             let parameters = ResizeArray<_>()
             let (~~) (t:string) = sb.Append t |> ignore
@@ -779,12 +779,15 @@ type internal OracleProvider(resolutionPath, owner, referencedAssemblies, tableN
                     if i > 0 then ~~ ", "
                     ~~ (sprintf "%s.%s%s" alias (quoteWhiteSpace column) (if not desc then " DESC NULLS LAST" else " ASC NULLS FIRST")))
 
-            // SELECT
-            if sqlQuery.Distinct then ~~(sprintf "SELECT DISTINCT %s " columns)
-            elif sqlQuery.Count then ~~("SELECT COUNT(1) ")
-            else  ~~(sprintf "SELECT %s " columns)
-            // FROM
-            ~~(sprintf "FROM %s %s " baseTable.FullName baseAlias)
+            if isDeleteScript then
+                ~~(sprintf "DELETE FROM %s " baseTable.FullName)
+            else 
+                // SELECT
+                if sqlQuery.Distinct then ~~(sprintf "SELECT DISTINCT %s " columns)
+                elif sqlQuery.Count then ~~("SELECT COUNT(1) ")
+                else  ~~(sprintf "SELECT %s " columns)
+                // FROM
+                ~~(sprintf "FROM %s %s " baseTable.FullName baseAlias)
             fromBuilder()
             // WHERE
             if sqlQuery.Filters.Length > 0 then

--- a/src/SQLProvider/Providers.SQLite.fs
+++ b/src/SQLProvider/Providers.SQLite.fs
@@ -337,7 +337,7 @@ type internal SQLiteProvider(resolutionPath, referencedAssemblies, runtimeAssemb
         member __.GetIndividualsQueryText(table,amount) = sprintf "SELECT * FROM %s LIMIT %i;" table.FullName amount
         member __.GetIndividualQueryText(table,column) = sprintf "SELECT * FROM [%s].[%s] WHERE [%s].[%s].[%s] = @id" table.Schema table.Name table.Schema table.Name column
 
-        member this.GenerateQueryText(sqlQuery,baseAlias,baseTable,projectionColumns) =
+        member this.GenerateQueryText(sqlQuery,baseAlias,baseTable,projectionColumns,isDeleteScript) =
             let sb = System.Text.StringBuilder()
             let parameters = ResizeArray<_>()
             let (~~) (t:string) = sb.Append t |> ignore
@@ -503,12 +503,15 @@ type internal SQLiteProvider(resolutionPath, referencedAssemblies, runtimeAssemb
                     if i > 0 then ~~ ", "
                     ~~ (sprintf "[%s].[%s]%s" alias column (if not desc then "DESC" else "")))
 
-            // SELECT
-            if sqlQuery.Distinct then ~~(sprintf "SELECT DISTINCT %s " columns)
-            elif sqlQuery.Count then ~~("SELECT COUNT(1) ")
-            else  ~~(sprintf "SELECT %s " columns)
-            // FROM
-            ~~(sprintf "FROM %s as [%s] " baseTable.FullName baseAlias)
+            if isDeleteScript then
+                ~~(sprintf "DELETE FROM %s " baseTable.FullName)
+            else 
+                // SELECT
+                if sqlQuery.Distinct then ~~(sprintf "SELECT DISTINCT %s " columns)
+                elif sqlQuery.Count then ~~("SELECT COUNT(1) ")
+                else  ~~(sprintf "SELECT %s " columns)
+                // FROM
+                ~~(sprintf "FROM %s as [%s] " baseTable.FullName baseAlias)
             fromBuilder()
             // WHERE
             if sqlQuery.Filters.Length > 0 then

--- a/src/SQLProvider/SqlRuntime.Common.fs
+++ b/src/SQLProvider/SqlRuntime.Common.fs
@@ -483,7 +483,7 @@ and internal ISqlProvider =
     /// Accepts a SqlQuery object and produces the SQL to execute on the server.
     /// the other parameters are the base table alias, the base table, and a dictionary containing
     /// the columns from the various table aliases that are in the SELECT projection
-    abstract GenerateQueryText : SqlQuery * string * Table * Dictionary<string,ResizeArray<string>> -> string * ResizeArray<IDbDataParameter>
+    abstract GenerateQueryText : SqlQuery * string * Table * Dictionary<string,ResizeArray<string>>*bool -> string * ResizeArray<IDbDataParameter>
     ///Builds a command representing a call to a stored procedure
     abstract ExecuteSprocCommand : IDbCommand * QueryParameter[] * QueryParameter[] *  obj[] -> ReturnValueType
 

--- a/src/SQLProvider/SqlRuntime.QueryExpression.fs
+++ b/src/SQLProvider/SqlRuntime.QueryExpression.fs
@@ -251,7 +251,7 @@ module internal QueryExpressionTransformer =
 
         newProjection, projectionMap, groupProjectionMap
 
-    let convertExpression exp (entityIndex:string ResizeArray) con (provider:ISqlProvider) =
+    let convertExpression exp (entityIndex:string ResizeArray) con (provider:ISqlProvider) isDeleteScript =
         // first convert the abstract query tree into a more useful format
         let legaliseName (alias:alias) =
                 if alias.StartsWith("_") then alias.TrimStart([|'_'|]) else alias
@@ -459,6 +459,6 @@ module internal QueryExpressionTransformer =
                                             | None -> snd sqlQuery.UltimateChild.Value
                                 lock myLock (fun () -> provider.GetColumns (con,table) |> ignore ))
 
-        let (sql,parameters) = provider.GenerateQueryText(sqlQuery,baseAlias,baseTable,projectionColumns)
+        let (sql,parameters) = provider.GenerateQueryText(sqlQuery,baseAlias,baseTable,projectionColumns,isDeleteScript)
 
         (sql,parameters,projectionDelegate,baseTable)

--- a/tests/SqlProvider.Tests/QueryTests.fs
+++ b/tests/SqlProvider.Tests/QueryTests.fs
@@ -1146,4 +1146,6 @@ let ``simple delete where query``() =
         for cust in dc.Main.Customers do
         where (cust.City = "Atlantis" || cust.CompanyName = "Home")
     } |> Seq.``delete all items from single table`` 
-    |> Async.RunSynchronously
+    |> Async.RunSynchronously |> ignore
+    ()
+

--- a/tests/SqlProvider.Tests/QueryTests.fs
+++ b/tests/SqlProvider.Tests/QueryTests.fs
@@ -1138,3 +1138,12 @@ let ``verify groupBy results``() =
     let res = groupqry |> dict  
 
     CollectionAssert.AreEqual(inlogics,groupqry)
+
+[<Test >]
+let ``simple delete where query``() =
+    let dc = sql.GetDataContext()
+    query {
+        for cust in dc.Main.Customers do
+        where (cust.City = "Atlantis" || cust.CompanyName = "Home")
+    } |> Seq.``delete all items from single table`` 
+    |> Async.RunSynchronously

--- a/tests/SqlProvider.Tests/scripts/MSAccessTests.fsx
+++ b/tests/SqlProvider.Tests/scripts/MSAccessTests.fsx
@@ -84,3 +84,12 @@ let asyncContainsQuery =
         } |> Async.StartAsTask
     r.Wait()
     r.Result
+
+
+//******************** Delete all test **********************//
+
+query {
+    for c in ctx.Northwind.Customers do
+    where (c.ContactName.Value = "Tuomas")
+} |> Seq.``delete all items from single table`` 
+|> Async.RunSynchronously

--- a/tests/SqlProvider.Tests/scripts/MySqlTests.fsx
+++ b/tests/SqlProvider.Tests/scripts/MySqlTests.fsx
@@ -237,3 +237,11 @@ let taskarray =
     ) |> Seq.toArray |> Tasks.Task.WaitAll
 
 ctx.GetUpdates()
+
+//******************** Delete all test **********************//
+
+query {
+    for count in ctx.Hr.Countries do
+    where (count.CountryName = "Andorra" || count.RegionId = 99934u)
+} |> Seq.``delete all items from single table`` 
+|> Async.RunSynchronously

--- a/tests/SqlProvider.Tests/scripts/SqlServerTests.fsx
+++ b/tests/SqlProvider.Tests/scripts/SqlServerTests.fsx
@@ -214,3 +214,12 @@ let getemployees hireDate =
     ]
 
 getemployees (new System.DateTime(1999,4,1))
+
+
+//******************** Delete all test **********************//
+
+query {
+    for c in ctx.Dbo.Employees do
+    where (c.FirstName = "Tuomas")
+} |> Seq.``delete all items from single table`` 
+|> Async.RunSynchronously


### PR DESCRIPTION
You have done backups of your database, right?

This is for feature #401

```fsharp
query {
    for c in ctx.Dbo.Employees do
    where (...)
} |> Seq.``delete all items from single table``  |> Async.RunSynchronously
```
```sql
DELETE FROM [dbo].[EMPLOYEES] WHERE (...)
```

Be warned, you will shoot your own foot with this cannon.

Happy deleting!
