### PR TITLE
Add support for casts to IComparable in lambdas of sortBy, sortByDescending, thenBy and thenByDescending query operations.

### DIFF
--- a/src/SQLProvider/SqlRuntime.Linq.fs
+++ b/src/SQLProvider/SqlRuntime.Linq.fs
@@ -477,7 +477,7 @@ module internal QueryImplementation =
                         let ty = typedefof<SqlQueryable<_>>.MakeGenericType(meth.GetGenericArguments().[0])
                         ty.GetConstructors().[0].Invoke [| source.DataContext ; source.Provider; Take(amount,source.SqlExpression) ; source.TupleIndex; |] :?> IQueryable<_>
 
-                    | MethodCall(None, (MethodWithName "OrderBy" | MethodWithName "OrderByDescending" as meth), [SourceWithQueryData source; OptionalQuote (Lambda([ParamName param], SqlColumnGet(entity,key,_))) ]) ->
+                    | MethodCall(None, (MethodWithName "OrderBy" | MethodWithName "OrderByDescending" as meth), [SourceWithQueryData source; OptionalQuote (Lambda([ParamName param], OptionalConvertOrTypeAs (SqlColumnGet(entity,key,_)))) ]) ->
                         let alias =
                              match entity with
                              | "" when source.SqlExpression.HasAutoTupled() -> param
@@ -492,7 +492,7 @@ module internal QueryImplementation =
                         let x = ty.GetConstructors().[0].Invoke [| source.DataContext ; source.Provider; sqlExpression; source.TupleIndex; |]
                         x :?> IQueryable<_>
 
-                    | MethodCall(None, (MethodWithName "ThenBy" | MethodWithName "ThenByDescending" as meth), [SourceWithQueryData source; OptionalQuote (Lambda([ParamName param], SqlColumnGet(entity,key,_))) ]) ->
+                    | MethodCall(None, (MethodWithName "ThenBy" | MethodWithName "ThenByDescending" as meth), [SourceWithQueryData source; OptionalQuote (Lambda([ParamName param], OptionalConvertOrTypeAs (SqlColumnGet(entity,key,_)))) ]) ->
                         let alias =
                             match entity with
                             | "" when source.SqlExpression.HasAutoTupled() -> param

--- a/tests/SqlProvider.Tests/QueryTests.fs
+++ b/tests/SqlProvider.Tests/QueryTests.fs
@@ -706,6 +706,35 @@ let ``simple select and sort query with then by desc query``() =
     CollectionAssert.IsNotEmpty qry    
     CollectionAssert.AreEquivalent([|"Buenos Aires"; "Buenos Aires"; "Buenos Aires"; "Salzburg"|], qry.[0..3])
 
+[<Test>]
+let ``simple sort query with lambda cast to IComparable``() =
+    let dc = sql.GetDataContext()
+    let qry =
+        query {
+            for cust in dc.Main.Customers do
+            sortBy ((fun (c : sql.dataContext.``main.CustomersEntity``) -> c.CustomerId :> IComparable) cust)
+            select cust.City
+            take 1
+        } |> Seq.toArray
+
+    CollectionAssert.IsNotEmpty qry
+    CollectionAssert.AreEquivalent([|"Berlin"|], qry)
+
+[<Test>]
+let ``simple sort query with then by desc query with lambda cast to IComparable``() =
+    let dc = sql.GetDataContext()
+    let qry =
+        query {
+            for cust in dc.Main.Customers do
+            sortBy cust.CompanyName
+            thenByDescending ((fun (c : sql.dataContext.``main.CustomersEntity``) -> c.CustomerId :> IComparable) cust)
+            select cust.City
+            take 1
+        } |> Seq.toArray
+
+    CollectionAssert.IsNotEmpty qry
+    CollectionAssert.AreEquivalent([|"Berlin"|], qry)
+
 [<Test >]
 let ``simple select query with join``() = 
     let dc = sql.GetDataContext()


### PR DESCRIPTION
Fixes #407.

This change ignores optional `Convert` expression nodes inside lambdas passed to `sortBy`, `sortByDescending`, `thenBy` or `thenByDescending` operations:

```fsharp
query {
    for item in db.Main.Items do
    sortBy ((fun (i : Db.dataContext.``main.ItemsEntity``) -> m.Id :> IComparable) item)
    select item
}
```

This query is now convertible to SQL.

I also added two unit tests (one for `sortBy` and one for `thenByDescending`) to check if the cast to `IComparable` is allowed.