### PR TITLE
Possibility to execute stored procedures asynchronous (InvokeAsync) #423

### DIFF
--- a/docs/content/core/mysql.fsx
+++ b/docs/content/core/mysql.fsx
@@ -24,6 +24,10 @@ for a complete list of connection string options.
 let connString  = "Server=localhost;Database=HR;User=root;Password=password"
 
 (**
+
+To deal with some MySQL data connection problems you might want to add some more parameters to connectionstring:
+`Auto Enlist=false; Convert Zero Datetime=true;`
+
 ### ConnectionStringName
 
 Instead of storing the connection string in the source code, you

--- a/src/SQLProvider/Providers.Firebird.fs
+++ b/src/SQLProvider/Providers.Firebird.fs
@@ -360,7 +360,8 @@ module Firebird =
             par.Value
         else null
 
-    let executeSprocCommand (com:IDbCommand) (inputParams:QueryParameter[]) (retCols:QueryParameter[]) (values:obj[]) =
+    let executeSprocCommandCommon (inputParams:QueryParameter [])  (retCols:QueryParameter[]) (values:obj[]) =
+
         let inputParameters = inputParams |> Array.filter (fun p -> p.Direction = ParameterDirection.Input)
 
         let outps =
@@ -375,9 +376,9 @@ module Firebird =
                  let p = createCommandParameter true ip values.[i]
                  (ip.Ordinal,p))
 
-        Array.append outps inps
-        |> Array.sortBy fst
-        |> Array.iter (fun (_,p) -> com.Parameters.Add(p) |> ignore)
+        let allParams =
+            Array.append outps inps
+            |> Array.sortBy fst
 
         let processReturnColumn reader (retCol:QueryParameter) =
             match retCol.TypeMapping.ProviderTypeName with
@@ -389,6 +390,13 @@ module Firebird =
                 match outps |> Array.tryFind (fun (_,p) -> p.ParameterName = retCol.Name) with
                 | Some(_,p) -> ScalarResultSet(p.ParameterName, readParameter p)
                 | None -> failwithf "Excepted return column %s but could not find it in the parameter set" retCol.Name
+
+        allParams, processReturnColumn, outps
+
+    let executeSprocCommand (com:IDbCommand) (inputParams:QueryParameter[]) (retCols:QueryParameter[]) (values:obj[]) =
+
+        let allParams, processReturnColumn, outps = executeSprocCommandCommon inputParams retCols values
+        allParams |> Array.iter (fun (_,p) -> com.Parameters.Add(p) |> ignore)
 
         match retCols with
         | [||] -> com.ExecuteNonQuery() |> ignore; Unit
@@ -406,6 +414,30 @@ module Firebird =
         | cols ->
             use reader = com.ExecuteReader()
             Set(cols |> Array.map (processReturnColumn reader))
+
+    let executeSprocCommandAsync (com:System.Data.Common.DbCommand) (inputParams:QueryParameter[]) (retCols:QueryParameter[]) (values:obj[]) =
+        async {
+            let allParams, processReturnColumn, outps = executeSprocCommandCommon inputParams retCols values
+            allParams |> Array.iter (fun (_,p) -> com.Parameters.Add(p) |> ignore)
+
+            match retCols with
+            | [||] -> do! com.ExecuteNonQueryAsync() |> Async.AwaitIAsyncResult |> Async.Ignore
+                      return Unit
+            | [|retCol|] ->
+                use! reader = com.ExecuteReaderAsync() |> Async.AwaitTask
+                match retCol.TypeMapping.ProviderTypeName with
+                | Some "cursor" ->
+                    let result = SingleResultSet(retCol.Name, Sql.dataReaderToArray reader)
+                    reader.NextResult() |> ignore
+                    return result
+                | _ ->
+                    match outps |> Array.tryFind (fun (_,p) -> p.ParameterName = retCol.Name) with
+                    | Some(_,p) -> return Scalar(p.ParameterName, readParameter p)
+                    | None -> return failwithf "Excepted return column %s but could not find it in the parameter set" retCol.Name
+            | cols ->
+                use! reader = com.ExecuteReaderAsync() |> Async.AwaitTask
+                return Set(cols |> Array.map (processReturnColumn reader))
+        }
 
 type internal FirebirdProvider(resolutionPath, owner, referencedAssemblies) as this =
     let pkLookup = ConcurrentDictionary<string,string list>()
@@ -556,6 +588,7 @@ type internal FirebirdProvider(resolutionPath, owner, referencedAssemblies) as t
         member __.CreateCommand(connection,commandText) = Firebird.createCommand commandText connection
         member __.CreateCommandParameter(param, value) = Firebird.createCommandParameter false param value
         member __.ExecuteSprocCommand(com,definition,retCols,values) = Firebird.executeSprocCommand com definition retCols values
+        member __.ExecuteSprocCommandAsync(com,definition,retCols,values) = Firebird.executeSprocCommandAsync com definition retCols values
         member __.CreateTypeMappings(con) = Sql.connect con Firebird.createTypeMappings
 
         member __.GetTables(con,cs) =

--- a/src/SQLProvider/Providers.MSAccess.fs
+++ b/src/SQLProvider/Providers.MSAccess.fs
@@ -259,6 +259,7 @@ type internal MSAccessProvider() =
             upcast p
 
         member __.ExecuteSprocCommand(_,_,_,_) =  raise(NotImplementedException())
+        member __.ExecuteSprocCommandAsync(_,_,_,_) =  raise(NotImplementedException())
         member __.CreateTypeMappings(con) = createTypeMappings (con:?>OleDbConnection)
 
         member __.GetTables(con,_) =

--- a/src/SQLProvider/Providers.Odbc.fs
+++ b/src/SQLProvider/Providers.Odbc.fs
@@ -230,7 +230,26 @@ type internal OdbcProvider(quotehcar : OdbcQuoteCharacter) =
             Option.iter (fun l -> p.Size <- l) param.Length
             upcast p
 
-        member __.ExecuteSprocCommand(_,_,_,_) = ReturnValueType.Unit
+        /// Not implemented yet
+        member __.ExecuteSprocCommand(com,inputParams,_,_) =
+            let odbcCommand = new OdbcCommand("{call " + com.CommandText + " (?)}")
+            let inputParameters = inputParams |> Array.filter (fun p -> p.Direction = ParameterDirection.Input)
+            odbcCommand.CommandType <- CommandType.StoredProcedure;
+            inputParameters |> Array.iter (fun (p) -> odbcCommand.Parameters.Add(p) |> ignore)
+            odbcCommand.ExecuteNonQuery() |> ignore
+            ReturnValueType.Unit
+
+        /// Not implemented yet
+        member __.ExecuteSprocCommandAsync(com,inputParams,_,_) =
+            async {
+                let odbcCommand = new OdbcCommand("{call " + com.CommandText + " (?)}")
+                let inputParameters = inputParams |> Array.filter (fun p -> p.Direction = ParameterDirection.Input)
+                odbcCommand.CommandType <- CommandType.StoredProcedure;
+                inputParameters |> Array.iter (fun (p) -> odbcCommand.Parameters.Add(p) |> ignore)
+                do! odbcCommand.ExecuteNonQueryAsync() |> Async.AwaitIAsyncResult |> Async.Ignore
+                return ReturnValueType.Unit
+            }
+
         member __.CreateTypeMappings(con) = createTypeMappings (con:?>OdbcConnection)
 
         member __.GetTables(con,_) =

--- a/src/SQLProvider/Providers.SQLite.fs
+++ b/src/SQLProvider/Providers.SQLite.fs
@@ -285,6 +285,7 @@ type internal SQLiteProvider(resolutionPath, referencedAssemblies, runtimeAssemb
             p
 
         member __.ExecuteSprocCommand(_,_,_,_) =  raise(NotImplementedException())
+        member __.ExecuteSprocCommandAsync(_,_,_,_) =  raise(NotImplementedException())
 
         member __.CreateTypeMappings(con) =
             if con.State <> ConnectionState.Open then con.Open()

--- a/src/SQLProvider/SqlRuntime.Common.fs
+++ b/src/SQLProvider/SqlRuntime.Common.fs
@@ -313,6 +313,7 @@ and ISqlDataContext =
     abstract CreateRelated              : SqlEntity * string * string * string * string * string * RelationshipDirection -> System.Linq.IQueryable<SqlEntity>
     abstract CreateEntities             : string -> System.Linq.IQueryable<SqlEntity>
     abstract CallSproc                  : RunTimeSprocDefinition * QueryParameter[] * obj[] -> obj
+    abstract CallSprocAsync             : RunTimeSprocDefinition * QueryParameter[] * obj[] -> Async<SqlEntity>
     abstract GetIndividual              : string * obj -> SqlEntity
     abstract SubmitChangedEntity        : SqlEntity -> unit
     abstract SubmitPendingChanges       : unit -> unit
@@ -512,6 +513,8 @@ and internal ISqlProvider =
     abstract GenerateQueryText : SqlQuery * string * Table * Dictionary<string,ResizeArray<string>>*bool -> string * ResizeArray<IDbDataParameter>
     ///Builds a command representing a call to a stored procedure
     abstract ExecuteSprocCommand : IDbCommand * QueryParameter[] * QueryParameter[] *  obj[] -> ReturnValueType
+    ///Builds a command representing a call to a stored procedure, executing async
+    abstract ExecuteSprocCommandAsync : System.Data.Common.DbCommand * QueryParameter[] * QueryParameter[] *  obj[] -> Async<ReturnValueType>
 
 /// GroupResultItems is an item to create key-igrouping-structure.
 /// From the select group-by projection, aggregate operations like Enumerable.Count() 

--- a/tests/SqlProvider.Tests/scripts/MySqlTests.fsx
+++ b/tests/SqlProvider.Tests/scripts/MySqlTests.fsx
@@ -8,7 +8,7 @@ open FSharp.Data.Sql.Common
 open Newtonsoft.Json
         
 [<Literal>]
-let connStr = "Server=localhost;Database=HR;Uid=admin;Pwd=password;"
+let connStr = "Server=localhost;Database=HR;Uid=admin;Pwd=password;Auto Enlist=false; Convert Zero Datetime=true;"
 [<Literal>]
 let resolutionFolder = __SOURCE_DIRECTORY__ + @"/../../../packages/scripts/MySql.Data/lib/net45/"
 
@@ -179,6 +179,12 @@ let employees =
       for e in ctx.Procedures.GetEmployees.Invoke().ResultSet do
         yield e.MapTo<Employee>()
     ]
+
+let employeesAsync =
+    async {
+        let! res = ctx.Procedures.GetEmployees.InvokeAsync()
+        return res.ResultSet |> Array.map(fun e -> e.MapTo<Employee>())
+    } |> Async.RunSynchronously
 
 type Region = {
     RegionId : decimal

--- a/tests/SqlProvider.Tests/scripts/SqlServerTests.fsx
+++ b/tests/SqlProvider.Tests/scripts/SqlServerTests.fsx
@@ -201,6 +201,12 @@ let employees =
         yield e.MapTo<Employee>()
     ]
 
+let employeesAsync =
+    async {
+        let! ia = ctx.Procedures.GetEmployees.InvokeAsync()
+        return ia.ResultSet
+    } |> Async.RunSynchronously
+
 type Region = {
     RegionId : int
     RegionName : string


### PR DESCRIPTION
Tested with MySQL, Postgres and MsSql.
Not tested with Oracle, Firebird.

Stored procedures support had not been implemented at all to SQLite, Access and Odbc.

SQLite doesn't support them. 
But Odbc could really benefit on some kind of "execute-command" possibility:
E.g. [SAS](http://support.sas.com/software/products/odbc/) needs some kind of pre-settings-config-commands-execution.
There is a separate typeprovider for SAS but it can't write items to SAS what SQLProvider could do if SAS is working (I don't have any SAS to connect, to try if it would work).
