### PR TITLE
Fix Id

### DIFF
--- a/tests/SqlProvider.Tests/CrudTests.fs
+++ b/tests/SqlProvider.Tests/CrudTests.fs
@@ -108,7 +108,7 @@ let ``Can persist a blob``() =
     let imageBytes = [| 0uy .. 100uy |]
 
     let savedEntity = dc.Main.Pictures.``Create(Image)`` imageBytes
-    savedEntity.Id <- 1234
+    savedEntity.Id <- 1234L
     dc.SubmitUpdates()
 
     let reloadedEntity =


### PR DESCRIPTION
See #https://github.com/fsprojects/SQLProvider/pull/450

> I had the wrong number format for the Pictures.Id field when you merged. (Sorry, I didn't want to change all the local connections again and I was waiting for my own CI to check out.)
> CI has now completed succesfully, you can merge from another PR here.