### PR TITLE
[WIP] Add SqlQueryBuilder wrapper

### DIFF
--- a/src/SQLProvider/SqlProvider.fsproj
+++ b/src/SQLProvider/SqlProvider.fsproj
@@ -72,6 +72,7 @@
       <Link>ExpressionOptimizer.fs</Link>
     </Compile>
     <Compile Include="Operators.fs" />
+    <Compile Include="SqlQueryBuilder.fs" />
     <Compile Include="Utils.fs" />
     <Compile Include="SqlSchema.fs" />
     <Compile Include="DataTable.fs" />

--- a/src/SQLProvider/SqlQueryBuilder.fs
+++ b/src/SQLProvider/SqlQueryBuilder.fs
@@ -287,13 +287,21 @@ type SqlQueryBuilder() =
     /// </summary>
     [<CustomOperation("thenByNullableDescending",MaintainsVariableSpace=true,AllowIntoPattern=true)>] 
     member inline this.ThenByNullableDescending (source, [<ProjectionParameter>] keySelector) = this.QueryBuilder.ThenByNullableDescending (source, keySelector)
+      
+    //// WIP
+    
+    ///// <summary>
+    ///// A query operator that selects elements from another table based on a SQL foreign key relationship'. 
+    ///// </summary>
+    //[<CustomOperation("naturalJoin")>] 
+    //member inline this.NaturalJoin (source:QuerySource<'T,'Q>, body: 'T -> QuerySource<'Result,'Q2>) : QuerySource<'Result,'Q> = 
+    //  // QueryBuilder.For is defined as :
+    //  // QuerySource (Seq.collect (fun x -> (body x).Source) source.Source)
+    
+    //  // QueryBuilder.Join is defined as :
+    //  // QuerySource (System.Linq.Enumerable.Join(outerSource.Source, innerSource.Source, Func<_,_>(outerKeySelector), Func<_,_>(innerKeySelector), Func<_,_,_>(elementSelector)))
 
-    // WIP: Can we turn the (!!) operator into 'naturalJoin'?
-
-    /// <summary>A query operator that correlates two sets of selected values based on a SQL foreign key relationship'. 
-    /// </summary>
-    [<CustomOperation("naturalJoin")>] 
-    member inline this.NaturalJoin (source) = !!source
+    //  this.QueryBuilder.For(QuerySource (!! (source)), body)
 
 [<AutoOpen>]
 module ExtraTopLevelOperators = 

--- a/src/SQLProvider/SqlQueryBuilder.fs
+++ b/src/SQLProvider/SqlQueryBuilder.fs
@@ -306,7 +306,7 @@ type SqlQueryBuilder() =
 [<AutoOpen>]
 module ExtraTopLevelOperators = 
     /// Builds a SQL query using query syntax and operators
-    let sqlQuery = SqlQueryBuilder()
+    let sql = SqlQueryBuilder()
   
     [<AutoOpen>]
     module LowPriority = 

--- a/src/SQLProvider/SqlQueryBuilder.fs
+++ b/src/SQLProvider/SqlQueryBuilder.fs
@@ -1,0 +1,321 @@
+﻿namespace FSharp.Data.Sql
+
+open System.Linq
+open System.Collections.Generic
+open Microsoft.FSharp.Linq
+open Microsoft.FSharp.Quotations
+
+/// The type used to support queries against a database. Use 'sqlQuery { ... }' to use the query syntax.
+type SqlQueryBuilder() =
+
+    let qb = QueryBuilder()
+
+    // The user should not have any need to access the underlying builder, 
+    // but it needs to be public so we can inline the numeric operators (sumBy etc.)
+
+    /// <summary>
+    /// The LINQ query builder underlying this SQL query builder.
+    /// </summary>    
+    member __.QueryBuilder = qb
+        
+    /// <summary>
+    /// A method used to support queries against a database.  Inputs to queries are implicitly wrapped by a call to one of the overloads of this method.
+    /// </summary>
+    member inline this.Source (source : IQueryable<_>) = this.QueryBuilder.Source source
+
+    /// <summary>
+    /// A method used to support queries against a database.  Inputs to queries are implicitly wrapped by a call to one of the overloads of this method.
+    /// </summary>
+    member inline this.Source (source : IEnumerable<_>) = this.QueryBuilder.Source source
+
+    /// <summary>
+    /// A method used to support queries against a database.  Projects each element of a sequence to another sequence and combines the resulting sequences into one sequence.
+    /// </summary>
+    member inline this.For (source, body) = this.QueryBuilder.For (source, body)
+
+    /// <summary>
+    /// A method used to support queries against a database.  Returns an empty sequence that has the specified type argument.
+    /// </summary>
+    member inline this.Zero () = this.QueryBuilder.Zero ()
+
+    /// <summary>
+    /// A method used to support queries against a database.  Returns a sequence of length one that contains the specified value.
+    /// </summary>
+    member inline this.Yield (value) = this.QueryBuilder.Yield (value)
+
+    /// <summary>
+    /// A method used to support queries against a database.  Returns a sequence that contains the specified values.
+    /// </summary>
+    member inline this.YieldFrom (computation) = this.QueryBuilder.YieldFrom (computation)
+
+    /// <summary>
+    /// A method used to support queries against a database.  Indicates that the query should be passed as a quotation to the Run method.
+    /// </summary>
+    member inline this.Quote (query) = this.QueryBuilder.Quote (query)
+
+    /// <summary>
+    /// A method used to support queries against a database.  Runs the given quotation as a query using LINQ rules.
+    /// </summary>
+    member inline internal this.RunQueryAsValue (query: Expr<'T>) : 'T = this.QueryBuilder.Run (query)
+    
+    /// <summary>
+    /// A method used to support queries against a database.  Runs the given quotation as a query using LINQ IQueryable rules.
+    /// </summary>
+    member inline internal this.RunQueryAsEnumerable (query: Expr<QuerySource<_, System.Collections.IEnumerable>>) : IEnumerable<'T> = this.QueryBuilder.Run (query)
+
+    /// <summary>
+    /// A method used to support queries against a database.  Runs the given quotation as a query using LINQ IEnumerable rules.
+    /// </summary>
+    member inline internal this.RunQueryAsQueryable (expression: Expr<QuerySource<'T, IQueryable>>) : IQueryable<'T> = this.QueryBuilder.Run(expression)
+
+    /// <summary>
+    /// A method used to support queries against a database.  Runs the given quotation as a query using LINQ IEnumerable rules.
+    /// </summary>
+    member inline this.Run (expression) = this.RunQueryAsQueryable (expression)
+
+    /// <summary>A query operator that determines whether the selected elements contains a specified element.
+    /// </summary>
+    [<CustomOperation("contains")>] 
+    member inline this.Contains (source, key) = this.QueryBuilder.Contains (source, key)
+
+    /// <summary>A query operator that returns the number of selected elements.
+    /// </summary>
+    [<CustomOperation("count")>] 
+    member inline this.Count (source) = this.QueryBuilder.Count (source)
+
+    ///// <summary>A query operator that selects the last element of those selected so far.
+    ///// </summary>
+    //[<CustomOperation("last")>] 
+    //member inline this.Last (source) = qb.Last (source)
+
+    ///// <summary>A query operator that selects the last element of those selected so far, or a default value if no element is found.
+    ///// </summary>
+    //[<CustomOperation("lastOrDefault")>] 
+    //member inline this.LastOrDefault (source) = qb.LastOrDefault (source)
+
+    /// <summary>A query operator that selects the single, specific element selected so far
+    /// </summary>
+    [<CustomOperation("exactlyOne")>] 
+    member inline this.ExactlyOne (source) = this.QueryBuilder.ExactlyOne (source)
+
+    /// <summary>A query operator that selects the single, specific element of those selected so far, or a default value if that element is not found.
+    /// </summary>
+    [<CustomOperation("exactlyOneOrDefault")>] 
+    member inline this.ExactlyOneOrDefault (source) = this.QueryBuilder.ExactlyOneOrDefault (source)
+
+    /// <summary>A query operator that selects the first element of those selected so far, or a default value if the sequence contains no elements.
+    /// </summary>
+    [<CustomOperation("headOrDefault")>] 
+    member inline this.HeadOrDefault (source) = this.QueryBuilder.HeadOrDefault (source)
+
+    /// <summary>A query operator that projects each of the elements selected so far.
+    /// </summary>
+    [<CustomOperation("select",AllowIntoPattern=true)>] 
+    member inline this.Select (source, [<ProjectionParameter>] projection) = this.QueryBuilder.Select (source, projection)
+
+    /// <summary>A query operator that selects those elements based on a specified predicate. 
+    /// </summary>
+    [<CustomOperation("where",MaintainsVariableSpace=true,AllowIntoPattern=true)>] 
+    member inline this.Where (source, [<ProjectionParameter>] predicate) = this.QueryBuilder.Where (source, predicate)
+
+    /// <summary>A query operator that selects a value for each element selected so far and returns the minimum resulting value. 
+    /// </summary>
+    [<CustomOperation("minBy")>] 
+    member inline this.MinBy (source, [<ProjectionParameter>] valueSelector) = this.QueryBuilder.MinBy (source, valueSelector)
+
+    /// <summary>A query operator that selects a value for each element selected so far and returns the maximum resulting value. 
+    /// </summary>
+    [<CustomOperation("maxBy")>] 
+    member inline this.MaxBy (source, [<ProjectionParameter>] valueSelector) = this.QueryBuilder.MaxBy (source, valueSelector)
+
+    /// <summary>A query operator that groups the elements selected so far according to a specified key selector.
+    /// </summary>
+    [<CustomOperation("groupBy",AllowIntoPattern=true)>] 
+    member inline this.GroupBy (source, [<ProjectionParameter>] keySelector) = this.QueryBuilder.GroupBy (source, keySelector)
+
+    /// <summary>A query operator that sorts the elements selected so far in ascending order by the given sorting key.
+    /// </summary>
+    [<CustomOperation("sortBy",MaintainsVariableSpace=true,AllowIntoPattern=true)>] 
+    member inline this.SortBy (source, [<ProjectionParameter>] keySelector) = this.QueryBuilder.SortBy (source, keySelector)
+
+    /// <summary>A query operator that sorts the elements selected so far in descending order by the given sorting key.
+    /// </summary>
+    [<CustomOperation("sortByDescending",MaintainsVariableSpace=true,AllowIntoPattern=true)>] 
+    member inline this.SortByDescending (source, [<ProjectionParameter>] keySelector) = this.QueryBuilder.SortByDescending (source, keySelector)
+
+    /// <summary>A query operator that performs a subsequent ordering of the elements selected so far in ascending order by the given sorting key.
+    /// This operator may only be used immediately after a 'sortBy', 'sortByDescending', 'thenBy' or 'thenByDescending', or their nullable variants.
+    /// </summary>
+    [<CustomOperation("thenBy",MaintainsVariableSpace=true,AllowIntoPattern=true)>] 
+    member inline this.ThenBy (source, [<ProjectionParameter>] keySelector) = this.QueryBuilder.ThenBy (source, keySelector)
+
+    /// <summary>A query operator that performs a subsequent ordering of the elements selected so far in descending order by the given sorting key.
+    /// This operator may only be used immediately after a 'sortBy', 'sortByDescending', 'thenBy' or 'thenByDescending', or their nullable variants.
+    /// </summary>
+    [<CustomOperation("thenByDescending",MaintainsVariableSpace=true,AllowIntoPattern=true)>] 
+    member inline this.ThenByDescending (source, [<ProjectionParameter>] keySelector) = this.QueryBuilder.ThenByDescending (source, keySelector)
+
+    ///// <summary>A query operator that selects a value for each element selected so far and groups the elements by the given key.
+    ///// </summary>
+    //[<CustomOperation("groupValBy",AllowIntoPattern=true)>] 
+    //member inline this.GroupValBy<'T,'Key,'Value,'Q when 'Key : equality> (source, [<ProjectionParameter>] resultSelector, [<ProjectionParameter>] keySelector) = qb.GroupValBy<'T,'Key,'Value,'Q> (source, resultSelector, keySelector)
+
+    /// <summary>A query operator that correlates two sets of selected values based on matching keys. 
+    /// Normal usage is 'join y in elements2 on (key1 (source) = key2)'. (source) 
+    /// </summary>
+    [<CustomOperation("join",IsLikeJoin=true,JoinConditionWord="on")>] 
+    member inline this.Join (outerSource, innerSource, outerKeySelector, innerKeySelector, resultSelector) = this.QueryBuilder.Join (outerSource, innerSource, outerKeySelector, innerKeySelector, resultSelector)
+
+    ///// <summary>A query operator that correlates two sets of selected values based on matching keys and groups the results. 
+    ///// Normal usage is 'groupJoin y in elements2 on (key1 (source) = key2) (source) into group'. 
+    ///// </summary>
+    //[<CustomOperation("groupJoin",IsLikeGroupJoin=true,JoinConditionWord="on")>] 
+    //member inline this.GroupJoin (outerSource, innerSource, outerKeySelector, innerKeySelector, resultSelector) = qb.GroupJoin (outerSource, innerSource, outerKeySelector, innerKeySelector, resultSelector)
+
+    ///// <summary>A query operator that correlates two sets of selected values based on matching keys and groups the results.
+    ///// If any group is empty, a group with a single default value is used instead. 
+    ///// Normal usage is 'leftOuterJoin y in elements2 on (key1 (source) = key2) (source) into group'. 
+    ///// </summary>
+    //[<CustomOperation("leftOuterJoin",IsLikeGroupJoin=true,JoinConditionWord="on")>] 
+    //member inline this.LeftOuterJoin (outerSource, innerSource, outerKeySelector, innerKeySelector, resultSelector) = qb.LeftOuterJoin (outerSource, innerSource, outerKeySelector, innerKeySelector, resultSelector)
+
+    /// <summary>A query operator that selects a nullable value for each element selected so far and returns the sum of these values. 
+    /// If any nullable does not have a value, it is ignored.
+    /// </summary>
+    [<CustomOperation("sumByNullable")>] 
+    member inline this.SumByNullable (source, [<ProjectionParameter>] valueSelector) = this.QueryBuilder.SumByNullable (source, valueSelector)
+
+    /// <summary>A query operator that selects a nullable value for each element selected so far and returns the minimum of these values. 
+    /// If any nullable does not have a value, it is ignored.
+    /// </summary>
+    [<CustomOperation("minByNullable")>] 
+    member inline this.MinByNullable (source, [<ProjectionParameter>] valueSelector) = this.QueryBuilder.MinByNullable (source, valueSelector)
+
+    /// <summary>A query operator that selects a nullable value for each element selected so far and returns the maximum of these values. 
+    /// If any nullable does not have a value, it is ignored.
+    /// </summary>
+    [<CustomOperation("maxByNullable")>] 
+    member inline this.MaxByNullable (source, [<ProjectionParameter>] valueSelector) = this.QueryBuilder.MaxByNullable (source, valueSelector)
+
+    /// <summary>A query operator that selects a nullable value for each element selected so far and returns the average of these values. 
+    /// If any nullable does not have a value, it is ignored.
+    /// </summary>
+    [<CustomOperation("averageByNullable")>] 
+    member inline this.AverageByNullable (source, [<ProjectionParameter>] projection) = this.QueryBuilder.AverageByNullable (source, projection)
+
+
+    /// <summary>A query operator that selects a value for each element selected so far and returns the average of these values. 
+    /// </summary>
+    [<CustomOperation("averageBy")>] 
+    member inline this.AverageBy (source, [<ProjectionParameter>] projection) = this.QueryBuilder.AverageBy (source, projection)
+
+
+    /// <summary>A query operator that selects distinct elements from the elements selected so far. 
+    /// </summary>
+    [<CustomOperation("distinct",MaintainsVariableSpace=true,AllowIntoPattern=true)>] 
+    member inline this.Distinct (source) = this.QueryBuilder.Distinct (source)
+
+    /// <summary>A query operator that determines whether any element selected so far satisfies a condition.
+    /// </summary>
+    [<CustomOperation("exists")>] 
+    member inline this.Exists (source, [<ProjectionParameter>] predicate) = this.QueryBuilder.Exists (source, predicate)
+
+    /// <summary>A query operator that selects the first element selected so far that satisfies a specified condition.
+    /// </summary>
+    [<CustomOperation("find")>] 
+    member inline this.Find (source, [<ProjectionParameter>] predicate) = this.QueryBuilder.Find (source, predicate)
+
+
+    /// <summary>A query operator that determines whether all elements selected so far satisfies a condition.
+    /// </summary>
+    [<CustomOperation("all")>] 
+    member inline this.All (source, [<ProjectionParameter>] predicate) = this.QueryBuilder.All (source, predicate)
+
+    /// <summary>A query operator that selects the first element from those selected so far.
+    /// </summary>
+    [<CustomOperation("head")>] 
+    member inline this.Head (source) = this.QueryBuilder.Head (source)
+
+    /// <summary>A query operator that selects the element at a specified index amongst those selected so far.
+    /// </summary>
+    [<CustomOperation("nth")>] 
+    member inline this.Nth (source, index) = this.QueryBuilder.Nth (source, index)
+
+    /// <summary>A query operator that bypasses a specified number of the elements selected so far and selects the remaining elements.
+    /// </summary>
+    [<CustomOperation("skip",MaintainsVariableSpace=true,AllowIntoPattern=true)>] 
+    member inline this.Skip (source, count) = this.QueryBuilder.Skip (source, count)
+
+    ///// <summary>A query operator that bypasses elements in a sequence as long as a specified condition is true and then selects the remaining elements.
+    ///// </summary>
+    //[<CustomOperation("skipWhile",MaintainsVariableSpace=true,AllowIntoPattern=true)>] 
+    //member inline this.SkipWhile (source, predicate) = qb.SkipWhile (source, predicate)
+
+    /// <summary>A query operator that selects a value for each element selected so far and returns the sum of these values. 
+    /// </summary>
+    [<CustomOperation("sumBy")>] 
+    member inline this.SumBy (source, [<ProjectionParameter>] projection) = this.QueryBuilder.SumBy (source, projection)
+
+    /// <summary>A query operator that selects a specified number of contiguous elements from those selected so far.
+    /// </summary>
+    [<CustomOperation("take",MaintainsVariableSpace=true,AllowIntoPattern=true)>] 
+    member inline this.Take (source, count) = this.QueryBuilder.Take (source, count)
+
+    ///// <summary>A query operator that selects elements from a sequence as long as a specified condition is true, and then skips the remaining elements.
+    ///// </summary>
+    //[<CustomOperation("takeWhile",MaintainsVariableSpace=true,AllowIntoPattern=true)>] 
+    //member inline this.TakeWhile (source, predicate) = qb.TakeWhile (source, predicate)
+
+    /// <summary>A query operator that sorts the elements selected so far in ascending order by the given nullable sorting key.
+    /// </summary>
+    [<CustomOperation("sortByNullable",MaintainsVariableSpace=true,AllowIntoPattern=true)>] 
+    member inline this.SortByNullable (source, [<ProjectionParameter>] keySelector) = this.QueryBuilder.SortByNullable (source, keySelector)
+
+    /// <summary>A query operator that sorts the elements selected so far in descending order by the given nullable sorting key.
+    /// </summary>
+    [<CustomOperation("sortByNullableDescending",MaintainsVariableSpace=true,AllowIntoPattern=true)>] 
+    member inline this.SortByNullableDescending (source, [<ProjectionParameter>] keySelector) = this.QueryBuilder.SortByNullableDescending (source, keySelector)
+
+    /// <summary>A query operator that performs a subsequent ordering of the elements selected so far in ascending order by the given nullable sorting key.
+    /// This operator may only be used immediately after a 'sortBy', 'sortByDescending', 'thenBy' or 'thenByDescending', or their nullable variants.
+    /// </summary>
+    [<CustomOperation("thenByNullable",MaintainsVariableSpace=true,AllowIntoPattern=true)>] 
+    member inline this.ThenByNullable (source, [<ProjectionParameter>] keySelector) = this.QueryBuilder.ThenByNullable (source, keySelector)
+
+    /// <summary>A query operator that performs a subsequent ordering of the elements selected so far in descending order by the given nullable sorting key.
+    /// This operator may only be used immediately after a 'sortBy', 'sortByDescending', 'thenBy' or 'thenByDescending', or their nullable variants.
+    /// </summary>
+    [<CustomOperation("thenByNullableDescending",MaintainsVariableSpace=true,AllowIntoPattern=true)>] 
+    member inline this.ThenByNullableDescending (source, [<ProjectionParameter>] keySelector) = this.QueryBuilder.ThenByNullableDescending (source, keySelector)
+
+    // WIP: Can we turn the (!!) operator into 'naturalJoin'?
+
+    /// <summary>A query operator that correlates two sets of selected values based on a SQL foreign key relationship'. 
+    /// </summary>
+    [<CustomOperation("naturalJoin")>] 
+    member inline this.NaturalJoin (source) = !!source
+
+[<AutoOpen>]
+module ExtraTopLevelOperators = 
+    /// Builds a SQL query using query syntax and operators
+    let sqlQuery = SqlQueryBuilder()
+  
+    [<AutoOpen>]
+    module LowPriority = 
+        type SqlQueryBuilder with
+
+            /// <summary>
+            /// A method used to support the F# query syntax.  Runs the given quotation as a query using LINQ rules.
+            /// </summary>
+            [<CompiledName("RunQueryAsValue")>]
+            member inline this.Run query = this.RunQueryAsValue query
+
+    [<AutoOpen>]
+    module HighPriority = 
+        type SqlQueryBuilder with
+
+            /// <summary>
+            /// A method used to support the F# query syntax.  Runs the given quotation as a query using LINQ IEnumerable rules.
+            /// </summary>
+            [<CompiledName("RunQueryAsEnumerable")>]
+            member inline this.Run query = this.RunQueryAsEnumerable query

--- a/tests/SqlProvider.Tests/CrudTests.fs
+++ b/tests/SqlProvider.Tests/CrudTests.fs
@@ -42,8 +42,10 @@ let ``Can create and delete an entity``() =
     let dc = sql.GetDataContext()
     
     let originalCustomers = 
-        query { for cust in dc.Main.Customers do
-                select cust }
+        sqlQuery { 
+          for cust in dc.Main.Customers do
+          select cust
+        }
         |> Seq.toList
      
     createCustomer dc |> ignore
@@ -51,8 +53,10 @@ let ``Can create and delete an entity``() =
     dc.SubmitUpdates()
 
     let newCustomers = 
-        query { for cust in dc.Main.Customers do
-                select cust  }
+        sqlQuery { 
+          for cust in dc.Main.Customers do
+          select cust  
+        }
         |> Seq.toList
     
     let created = 
@@ -68,8 +72,10 @@ let ``Can create, update and delete an entity``() =
     let dc = sql.GetDataContext()
     
     let originalCustomers = 
-        query { for cust in dc.Main.Customers do
-                select cust }
+        sqlQuery { 
+          for cust in dc.Main.Customers do
+          select cust 
+        }
         |> Seq.toList
      
     let ent = createCustomer dc
@@ -86,8 +92,10 @@ let ``Can create, update and delete an entity``() =
     let dc2 = sql.GetDataContext()
  
     let newCustomers = 
-        query { for cust in dc2.Main.Customers do
-                select cust  }
+        sqlQuery { 
+          for cust in dc2.Main.Customers do
+          select cust
+        }
         |> Seq.toList
     
     let created = 
@@ -101,8 +109,10 @@ let ``Can create, update and delete an entity``() =
     dc2.SubmitUpdates()
 
     let reallyDeleted = 
-        query { for cust in dc2.Main.Customers do
-                select cust  }
+        sqlQuery { 
+          for cust in dc2.Main.Customers do
+          select cust  
+        }
         |> Seq.toList
 
     Assert.AreEqual(originalCustomers.Length, reallyDeleted.Length)
@@ -118,9 +128,11 @@ let ``Can persist a blob``() =
     dc.SubmitUpdates()
 
     let reloadedEntity =
-        query { for image in dc.Main.Pictures do
-                where (image.Id = savedEntity.Id)
-                head }
+        sqlQuery { 
+          for image in dc.Main.Pictures do
+          where (image.Id = savedEntity.Id)
+          head 
+        }
 
     Assert.That( reloadedEntity.Image, Is.EqualTo(imageBytes))
 
@@ -138,9 +150,10 @@ let ``Can enlist in a transaction scope and rollback changes without complete``(
     let dc2 = sql.GetDataContext()
 
     let created = 
-        query { for cust in dc2.Main.Customers do
-                where (cust.CustomerId = "SQLPROVIDER")
-                select cust  
+        sqlQuery { 
+          for cust in dc2.Main.Customers do
+          where (cust.CustomerId = "SQLPROVIDER")
+          select cust  
         }
         |> Seq.toList
 

--- a/tests/SqlProvider.Tests/QueryTests.fs
+++ b/tests/SqlProvider.Tests/QueryTests.fs
@@ -27,7 +27,7 @@ let isMono = Type.GetType ("Mono.Runtime") <> null
 let ``simple select with contains query``() =
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for cust in dc.Main.Customers do
             select cust.CustomerId
             contains "ALFKI"
@@ -38,7 +38,7 @@ let ``simple select with contains query``() =
 let ``simple select with contains query with where``() =
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for cust in dc.Main.Customers do
             where (cust.City <> "")
             select cust.CustomerId
@@ -50,7 +50,7 @@ let ``simple select with contains query with where``() =
 let ``simple select with contains query when not exists``() =
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for cust in dc.Main.Customers do
             select cust.CustomerId
             contains "ALFKI2"
@@ -61,7 +61,7 @@ let ``simple select with contains query when not exists``() =
 let ``simple select with count``() =
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for cust in dc.Main.Customers do
             select cust.CustomerId
             count
@@ -72,7 +72,7 @@ let ``simple select with count``() =
 let ``simple select with last``() =
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for cust in dc.Main.Customers do
             sortBy cust.CustomerId
             select cust.CustomerId
@@ -84,7 +84,7 @@ let ``simple select with last``() =
 let ``simple select with last or default when not exists``() =
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for cust in dc.Main.Customers do
             where (cust.CustomerId = "ZZZZ")
             select cust.CustomerId
@@ -96,7 +96,7 @@ let ``simple select with last or default when not exists``() =
 let ``simple exists when exists``() =
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for cust in dc.Main.Customers do
             exists (cust.CustomerId = "WOLZA")
         }
@@ -106,7 +106,7 @@ let ``simple exists when exists``() =
 let ``simple select with last or default when exists``() =
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for cust in dc.Main.Customers do
             where (cust.CustomerId = "WOLZA")
             select cust.CustomerId
@@ -118,7 +118,7 @@ let ``simple select with last or default when exists``() =
 let ``simple select with exactly one``() =
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for cust in dc.Main.Customers do
             where (cust.CustomerId = "ALFKI")
             select cust.CustomerId
@@ -130,7 +130,7 @@ let ``simple select with exactly one``() =
 let ``simple select with exactly one when not exists``() =
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for cust in dc.Main.Customers do
             where (cust.CustomerId = "ZZZZ")
             select cust.CustomerId
@@ -142,7 +142,7 @@ let ``simple select with exactly one when not exists``() =
 let ``simple select with head``() =
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for cust in dc.Main.Customers do
             where (cust.CustomerId = "ALFKI")
             select cust.CustomerId
@@ -154,7 +154,7 @@ let ``simple select with head``() =
 let ``simple select with head or Default``() =
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for cust in dc.Main.Customers do
             where (cust.CustomerId = "ALFKI")
             select cust.CustomerId
@@ -166,7 +166,7 @@ let ``simple select with head or Default``() =
 let ``simple select with head or Default when not exists``() =
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for cust in dc.Main.Customers do
             where (cust.CustomerId = "ZZZZ")
             select cust.CustomerId
@@ -178,7 +178,7 @@ let ``simple select with head or Default when not exists``() =
 let ``simple select query``() = 
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for cust in dc.Main.Customers do
             select cust
         } |> Seq.toArray
@@ -189,7 +189,7 @@ let ``simple select query``() =
 let ``simplest select query let temp``() = 
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for cust in dc.Main.Customers do
             let y = cust.City
             select cust.Address
@@ -201,7 +201,7 @@ let ``simplest select query let temp``() =
 let ``simple select query let temp nested``() = 
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for cust in dc.Main.Customers do
             let y1 = cust.Address
             let y2 = cust.City
@@ -214,7 +214,7 @@ let ``simple select query let temp nested``() =
 let ``simple select query let temp``() = 
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for cust in dc.Main.Customers do
             let y = cust.City + "test"
             select y
@@ -229,7 +229,7 @@ let ``simple select query let temp``() =
 let ``simple select query let where``() = 
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for cust in dc.Main.Customers do
             let y = cust.City + "test"
             where (cust.Address <> "")
@@ -243,7 +243,7 @@ let ``simple select query let where``() =
 let ``simple select query let temp used in where``() = 
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for cust in dc.Main.Customers do
             let y = cust.City + "test"
             where (y <> "")
@@ -258,7 +258,7 @@ let ``simple select query let temp used in where``() =
 let ``simple select query with operations in select``() = 
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for cust in dc.Main.Customers do
             select (cust.Country + " " + cust.Address + (1).ToString())
         } |> Seq.toArray
@@ -269,7 +269,7 @@ let ``simple select query with operations in select``() =
 let ``simple select where query``() =
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for cust in dc.Main.Customers do
             where (cust.CustomerId = "ALFKI")
             select cust
@@ -284,7 +284,7 @@ let ``simple select where query``() =
 let ``simple select where null query``() =
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for cust in dc.Main.Customers do
             where (cust.CustomerId <> null)
             select cust
@@ -299,7 +299,7 @@ let ``simple select where null query``() =
 let ``simple select where query right side``() =
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for cust in dc.Main.Customers do
             where ("ALFKI" = cust.CustomerId)
             select cust
@@ -313,7 +313,7 @@ let ``simple select where query right side``() =
 let ``simple select where query between col properties``() =
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for order in dc.Main.Orders do
             where (order.ShippedDate > order.RequiredDate)
             select (order.ShippedDate, order.RequiredDate)
@@ -326,7 +326,7 @@ let ``simple select where query between col properties``() =
 let ``simple nth query``() =
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for cust in dc.Main.Customers do
             select cust
             nth 4
@@ -338,7 +338,7 @@ let ``simple nth query``() =
 let ``simple select where not query``() =
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for cust in dc.Main.Customers do
             where (not(cust.CustomerId = "ALFKI"))
             select cust
@@ -352,7 +352,7 @@ let ``simple select where in query``() =
     let dc = sql.GetDataContext()
     let arr = ["ALFKI"; "ANATR"; "AROUT"]
     let qry = 
-        query {
+        sqlQuery {
             for cust in dc.Main.Customers do
             where (arr.Contains(cust.CustomerId))
             select cust.CustomerId
@@ -369,7 +369,7 @@ let ``simple select where not-in query``() =
     let dc = sql.GetDataContext()
     let arr = ["ALFKI"; "ANATR"; "AROUT"]
     let qry = 
-        query {
+        sqlQuery {
             for cust in dc.Main.Customers do
             where (not(arr.Contains(cust.CustomerId)))
             select cust.CustomerId
@@ -385,14 +385,14 @@ let ``simple select where in queryable query``() =
 
     let dc = sql.GetDataContext()
     let query1 = 
-        query {
+        sqlQuery {
             for cust in dc.Main.Customers do
             where (cust.City="London")
             select cust.CustomerId
         }
 
     let query2 = 
-        query {
+        sqlQuery {
             for cust in dc.Main.Customers do
             where (query1.Contains(cust.CustomerId))
             select cust.CustomerId
@@ -409,7 +409,7 @@ let ``simple select where in query custom syntax``() =
     let dc = sql.GetDataContext()
     let arr = ["ALFKI"; "ANATR"; "AROUT"]
     let qry = 
-        query {
+        sqlQuery {
             for cust in dc.Main.Customers do
             where (cust.CustomerId |=| arr)
             select cust.CustomerId
@@ -423,7 +423,7 @@ let ``simple select where in query custom syntax``() =
 let ``simple select where like query``() =
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for cust in dc.Main.Customers do
             where (cust.CustomerId.Contains("a"))
             select cust.CustomerId
@@ -435,7 +435,7 @@ let ``simple select where like query``() =
 let ``simple select where query with operations in where``() =
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for cust in dc.Main.Customers do
             where (cust.CustomerId = "ALFKI" && (cust.City.StartsWith("B")))
             select cust
@@ -449,7 +449,7 @@ let ``simple select where query with operations in where``() =
 let ``simple select query with minBy``() = 
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for ord in dc.Main.OrderDetails do
             minBy (decimal ord.Discount)
         }   
@@ -459,7 +459,7 @@ let ``simple select query with minBy``() =
 let ``simple select query with minBy2``() = 
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for ord in dc.Main.OrderDetails do
             minBy (ord.Discount)
         }   
@@ -470,7 +470,7 @@ let ``simple select query with minBy2``() =
 let ``simple select query with minBy DateTime``() = 
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for emp in dc.Main.Employees do
             minBy (emp.BirthDate)
         }   
@@ -480,9 +480,9 @@ let ``simple select query with minBy DateTime``() =
 let ``simple select query with sumBy``() = 
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for od in dc.Main.OrderDetails do
-            sumBy od.UnitPrice
+            sumBy (od.UnitPrice)
         }
     Assert.Greater(56501m, qry)
     Assert.Less(56499m, qry)
@@ -491,7 +491,7 @@ let ``simple select query with sumBy``() =
 let ``simple select query with averageBy``() = 
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for od in dc.Main.OrderDetails do
             averageBy od.UnitPrice
         }
@@ -502,7 +502,7 @@ let ``simple select query with averageBy``() =
 let ``simplest select query with groupBy``() = 
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for cust in dc.Main.Customers do
             groupBy cust.City
         } |> Seq.toArray
@@ -513,7 +513,7 @@ let ``simplest select query with groupBy``() =
 let ``simple select query with groupBy``() = 
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for cust in dc.Main.Customers do
             groupBy cust.City into c
             select (c.Key, c.Count())
@@ -526,7 +526,7 @@ let ``simple select query with groupBy``() =
 let ``simple select query with groupBy and then sort``() = 
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for order in dc.Main.Orders do
             groupBy (order.ShipCity) into ts
             where (ts.Count() > 1)
@@ -544,7 +544,7 @@ let ``simple select query with groupBy and then sort``() =
 let ``simple select query with groupBy multiple columns``() = 
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for p in dc.Main.Products do
             groupBy (p.ReorderLevel, p.CategoryId) into c
             select (c.Key, c.Sum(fun i -> i.UnitPrice))
@@ -556,7 +556,7 @@ let ``simple select query with groupBy multiple columns``() =
 let ``simple select query with groupBy sum``() = 
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for od in dc.Main.OrderDetails do
             groupBy od.ProductId into p
             select (p.Key, p.Sum(fun f -> f.UnitPrice), p.Sum(fun f -> f.Discount))
@@ -572,7 +572,7 @@ let ``simple select query with groupBy sum``() =
 let ``simple select query with groupBy having count``() = 
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for cust in dc.Main.Customers do
             groupBy cust.City into c
             where (c.Count() > 1)
@@ -587,7 +587,7 @@ let ``simple select query with groupBy having count``() =
 let ``simple select query with groupBy where and having``() = 
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for emp in dc.Main.Employees do
             where (emp.Country = "USA")
             groupBy emp.City into grp
@@ -605,7 +605,7 @@ let ``simple select query with groupBy where and having``() =
 let ``simple select query with groupBy having key``() = 
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for cust in dc.Main.Customers do
             groupBy cust.City into c
             where (c.Key = "London") 
@@ -619,7 +619,7 @@ let ``simple select query with groupBy having key``() =
 let ``simple select query with groupBy date``() = 
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for emp in dc.Main.Employees do
             groupBy emp.BirthDate into e
             select (e.Key, e.Count())
@@ -631,7 +631,7 @@ let ``simple select query with groupBy date``() =
 let ``simple select query with groupBy2``() = 
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for cust in dc.Main.Customers do
             where (cust.City = "London")
             groupBy (cust.Country, cust.City) into c
@@ -644,7 +644,7 @@ let ``simple select query with groupBy2``() =
 let ``simple select query with groupValBy``() = 
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for cust in dc.Main.Customers do
             groupValBy cust.ContactTitle cust.City into g
             select (g.Key, g.Count())
@@ -655,10 +655,10 @@ let ``simple select query with groupValBy``() =
 let ``complex select query with groupValBy``() = 
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for cust in dc.Main.Customers do
             groupValBy (cust.ContactTitle, Int32.Parse(cust.PostalCode)) (cust.PostalCode, cust.City) into g
-            let maxPlusOne = 1 + query {for i in g do sumBy (snd i) }
+            let maxPlusOne = 1 + sqlQuery {for i in g do sumBy (snd i) }
             select (snd(g.Key), maxPlusOne)
         } |> dict  
     Assert.IsNotEmpty(qry)
@@ -667,7 +667,7 @@ let ``complex select query with groupValBy``() =
 let ``simple if query``() = 
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for cust in dc.Main.Customers do
             if cust.Country = "UK" then select cust.City
         } |> Seq.toArray
@@ -682,7 +682,7 @@ let ``simple select query with case``() =
     // Actual: SELECT [cust].[Country] as 'Country',[cust].[City] as 'City' FROM main.Customers as [cust]
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for cust in dc.Main.Customers do
             select (if cust.Country = "UK" then (cust.City)
                 else ("Outside UK"))
@@ -693,7 +693,7 @@ let ``simple select query with case``() =
 let ``simple select and sort query``() =
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for cust in dc.Main.Customers do
             sortBy cust.City
             select cust.City
@@ -706,7 +706,7 @@ let ``simple select and sort query``() =
 let ``simple select and sort desc query``() =
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for cust in dc.Main.Customers do
             sortByDescending cust.City
             select cust.City
@@ -719,7 +719,7 @@ let ``simple select and sort desc query``() =
 let ``simple select and sort query with then by query``() =
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for cust in dc.Main.Customers do
             sortBy cust.Country
             thenBy cust.City
@@ -733,7 +733,7 @@ let ``simple select and sort query with then by query``() =
 let ``simple select and sort query with then by desc query``() =
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for cust in dc.Main.Customers do
             sortBy cust.Country
             thenByDescending cust.City
@@ -747,7 +747,7 @@ let ``simple select and sort query with then by desc query``() =
 let ``simple sort query with lambda cast to IComparable``() =
     let dc = sql.GetDataContext()
     let qry =
-        query {
+        sqlQuery {
             for cust in dc.Main.Customers do
             sortBy ((fun (c : sql.dataContext.``main.CustomersEntity``) -> c.CustomerId :> IComparable) cust)
             select cust.City
@@ -761,7 +761,7 @@ let ``simple sort query with lambda cast to IComparable``() =
 let ``simple sort query with then by desc query with lambda cast to IComparable``() =
     let dc = sql.GetDataContext()
     let qry =
-        query {
+        sqlQuery {
             for cust in dc.Main.Customers do
             sortBy cust.CompanyName
             thenByDescending ((fun (c : sql.dataContext.``main.CustomersEntity``) -> c.CustomerId :> IComparable) cust)
@@ -776,7 +776,7 @@ let ``simple sort query with then by desc query with lambda cast to IComparable`
 let ``simple select query with join``() = 
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for cust in dc.Main.Customers do
             join order in dc.Main.Orders on (cust.CustomerId = order.CustomerId)
             select (cust.CustomerId, order.OrderDate)
@@ -796,7 +796,7 @@ let ``simple select query with join``() =
 let ``simple select query with join and then groupBy``() = 
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for cust in dc.Main.Customers do
             join order in dc.Main.Orders on (cust.CustomerId = order.CustomerId)
             groupBy cust.City into c
@@ -810,7 +810,7 @@ let ``simple select query with join and then groupBy``() =
 let ``simple select query with groupBy and then join``() = 
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for cust in dc.Main.Customers do
             groupBy cust.City into c
             join order in dc.Main.Orders on (c.Key = order.ShipCity)
@@ -825,7 +825,7 @@ let ``simple select query with groupBy and then join``() =
 let ``simple select query with join multi columns``() = 
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for cust in dc.Main.Customers do
             join order in dc.Main.Orders on ((cust.CustomerId, cust.CustomerId) = (order.CustomerId, order.CustomerId))
             select (cust.CustomerId, order.OrderDate)
@@ -845,7 +845,7 @@ let ``simple select query with join multi columns``() =
 let ``simple select query with join using relationships``() = 
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for cust in dc.Main.Customers do
             for order in cust.``main.Orders by CustomerID`` do
             select (cust.CustomerId, order.OrderDate)
@@ -864,7 +864,7 @@ let ``simple select query with join using relationships``() =
 let ``simple select query with group join``() = 
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for cust in dc.Main.Customers do
             groupJoin ord in dc.Main.Orders on (cust.CustomerId = ord.CustomerId) into g
             for order in g do
@@ -889,7 +889,7 @@ let ``simple select query with group join``() =
 let ``simple select query with multiple joins on relationships``() = 
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for cust in dc.Main.Customers do
             for order in cust.``main.Orders by CustomerID`` do
             for orderDetail in order.``main.OrderDetails by OrderID`` do
@@ -913,7 +913,7 @@ let ``simple select query with multiple joins on relationships``() =
 let ``simple select query with left outer join``() = 
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for cust in dc.Main.Customers do
             leftOuterJoin order in dc.Main.Orders on (cust.CustomerId = order.CustomerId) into result
             for order in result.DefaultIfEmpty() do
@@ -933,7 +933,7 @@ let ``simple select query with left outer join``() =
 let ``simple sumBy``() = 
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for od in dc.Main.OrderDetails do
             sumBy od.UnitPrice
         }
@@ -943,7 +943,7 @@ let ``simple sumBy``() =
 let ``simple async sum``() = 
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for od in dc.Main.OrderDetails do
             select od.UnitPrice
         } |> Seq.sumAsync |> Async.RunSynchronously
@@ -953,7 +953,7 @@ let ``simple async sum``() =
 let ``simple averageBy``() = 
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for od in dc.Main.OrderDetails do
             averageBy od.UnitPrice
         }
@@ -963,7 +963,7 @@ let ``simple averageBy``() =
 let ``simple averageByNullable``() = 
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for od in dc.Main.OrderDetails do
             averageByNullable (System.Nullable(od.UnitPrice))
         }
@@ -973,7 +973,7 @@ let ``simple averageByNullable``() =
 let ``simple select with distinct``() =
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for cust in dc.Main.Customers do
             select cust.City
             distinct
@@ -987,7 +987,7 @@ let ``simple select with distinct``() =
 let ``simple select with skip``() =
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for cust in dc.Main.Customers do
             select cust.City
             skip 5
@@ -1002,7 +1002,7 @@ let ``simple select with skip``() =
 let ``simple select with take``() =
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for cust in dc.Main.Customers do
             select cust.City
             take 5
@@ -1017,7 +1017,7 @@ let ``simple select with take``() =
 let ``simple select query with all``() = 
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for ord in dc.Main.OrderDetails do
             all (ord.UnitPrice > 0m)
         }   
@@ -1027,7 +1027,7 @@ let ``simple select query with all``() =
 let ``simple select query with all false``() = 
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for ord in dc.Main.OrderDetails do
             all (ord.UnitPrice > 10m)
         }   
@@ -1037,7 +1037,7 @@ let ``simple select query with all false``() =
 let ``simple select query with find``() = 
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for ord in dc.Main.OrderDetails do
             find (ord.UnitPrice > 10m)
         }   
@@ -1051,7 +1051,7 @@ type Dummy<'t> = D of 't
 let ``simple select into a generic type`` () =
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for emp in dc.Main.Customers do
             select (D {First=emp.ContactName})
         } |> Seq.toList
@@ -1066,7 +1066,7 @@ let ``simple select into a generic type with pipe`` () =
     else
         let dc = sql.GetDataContext()
         let qry = 
-            query {
+            sqlQuery {
                 for emp in dc.Main.Customers do
                 select ({First=emp.ContactName} |> D)
             } |> Seq.toList
@@ -1084,7 +1084,7 @@ let ``simple select with bool outside query``() =
     let myCond4 = 4
 
     let qry = 
-        query {
+        sqlQuery {
             for cust in dc.Main.Customers do
             // Simple booleans outside queries are supported:
             where (((myCond1 && myCond1=true) && cust.City="Helsinki" || myCond1) || cust.City="London")
@@ -1106,7 +1106,7 @@ let ``simple select with bool outside query2``() =
     let myCond4 = 4
 
     let qry = 
-        query {
+        sqlQuery {
             for cust in dc.Main.Customers do
             // Simple booleans outside queries are supported:
             where (myCond4 > 3 || (myCond2 && cust.Address="test" && not(myCond2)))
@@ -1122,7 +1122,7 @@ let ``simple select query async``() =
     let task = 
         async {
             let! asyncquery =
-                query {
+                sqlQuery {
                     for cust in dc.Main.Customers do
                     select cust
                 } |> Seq.executeQueryAsync 
@@ -1137,7 +1137,7 @@ type sqlOption = SqlDataProvider<Common.DatabaseProviderTypes.SQLITE, connection
 let ``simple select with contains query with where boolean option type``() =
     let dc = sqlOption.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for cust in dc.Main.Customers do
             where (cust.City.IsSome)
             select cust.CustomerId
@@ -1150,7 +1150,7 @@ let ``simple select with contains query with where boolean option type``() =
 let ``simple canonical operation substing query``() =
     let dc = sql.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for cust in dc.Main.Customers do
             // Database spesific warning here: Substring of SQLite starts from 1.
             where (cust.CustomerId.Substring(2,3)+"F"="NATF")
@@ -1167,7 +1167,7 @@ let ``simple canonical operations query``() =
 
     let qry = 
         let L = "L"
-        query {
+        sqlQuery {
             // Silly query not hitting indexes, so testing purposes only...
             for cust in dc.Main.Customers do
             // This is not yet working:
@@ -1195,12 +1195,12 @@ let ``simple canonical operations query``() =
 let ``simple union query test``() = 
     let dc = sql.GetDataContext()
     let query1 = 
-        query {
+        sqlQuery {
             for cus in dc.Main.Customers do
             select (cus.City)
         }
     let query2 = 
-        query {
+        sqlQuery {
             for emp in dc.Main.Employees do
             select (emp.City)
         } 
@@ -1220,12 +1220,12 @@ let ``simple union query test``() =
 let ``simple union all query test``() = 
     let dc = sql.GetDataContext()
     let query1 = 
-        query {
+        sqlQuery {
             for cus in dc.Main.Customers do
             select (cus.City)
         }
     let query2 = 
-        query {
+        sqlQuery {
             for emp in dc.Main.Employees do
             select (emp.City)
         } 
@@ -1239,19 +1239,19 @@ let ``simple union all query test``() =
 let ``verify groupBy results``() = 
     let dc = sql.GetDataContext()
     let enumtest =
-        query {
+        sqlQuery {
             for cust in dc.Main.Customers do
             select (cust)
         } |> Seq.toList
     let inlogics = 
-        query {
+        sqlQuery {
             for cust in enumtest do
             groupBy cust.City into c
             select (c.Key, c.Count())
         } |> Seq.toArray |> Array.sortBy (fun (k,v) -> k )
 
     let groupqry = 
-        query {
+        sqlQuery {
             for cust in dc.Main.Customers do
             groupBy cust.City into c
             select (c.Key, c.Count())
@@ -1263,7 +1263,7 @@ let ``verify groupBy results``() =
 [<Test >]
 let ``simple delete where query``() =
     let dc = sql.GetDataContext()
-    query {
+    sqlQuery {
         for cust in dc.Main.Customers do
         where (cust.City = "Atlantis" || cust.CompanyName = "Home")
     } |> Seq.``delete all items from single table`` 
@@ -1274,7 +1274,7 @@ let ``simple delete where query``() =
 let ``simple left join``() = 
     let dc = sqlOption.GetDataContext()
     let qry = 
-        query {
+        sqlQuery {
             for o in dc.Main.Orders do
             for c in (!!) o.``main.Customers by CustomerID`` do
             select (o.CustomerId, c.CustomerId)

--- a/tests/SqlProvider.Tests/QueryTests.fs
+++ b/tests/SqlProvider.Tests/QueryTests.fs
@@ -17,7 +17,7 @@ let connectionString = @"Data Source=./db/northwindEF.db;Version=3;Read Only=fal
 // Tools -> Extensions and Updates... -> Online -> NUnit Test Adapter for Visual Studio
 // http://nunit.org/index.php?p=vsTestAdapter&r=2.6.4
 
-type sql = SqlDataProvider<Common.DatabaseProviderTypes.SQLITE, connectionString, CaseSensitivityChange=Common.CaseSensitivityChange.ORIGINAL>
+type Sql = SqlDataProvider<Common.DatabaseProviderTypes.SQLITE, connectionString, CaseSensitivityChange=Common.CaseSensitivityChange.ORIGINAL>
 FSharp.Data.Sql.Common.QueryEvents.SqlQueryEvent |> Event.add (printfn "Executing SQL: %O")
    
 
@@ -25,9 +25,9 @@ let isMono = Type.GetType ("Mono.Runtime") <> null
 
 [<Test>]
 let ``simple select with contains query``() =
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for cust in dc.Main.Customers do
             select cust.CustomerId
             contains "ALFKI"
@@ -36,9 +36,9 @@ let ``simple select with contains query``() =
 
 [<Test>]
 let ``simple select with contains query with where``() =
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for cust in dc.Main.Customers do
             where (cust.City <> "")
             select cust.CustomerId
@@ -48,9 +48,9 @@ let ``simple select with contains query with where``() =
 
 [<Test>]
 let ``simple select with contains query when not exists``() =
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for cust in dc.Main.Customers do
             select cust.CustomerId
             contains "ALFKI2"
@@ -59,9 +59,9 @@ let ``simple select with contains query when not exists``() =
 
 [<Test >]
 let ``simple select with count``() =
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for cust in dc.Main.Customers do
             select cust.CustomerId
             count
@@ -70,9 +70,9 @@ let ``simple select with count``() =
 
 [<Test; Ignore("Not Supported")>]
 let ``simple select with last``() =
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for cust in dc.Main.Customers do
             sortBy cust.CustomerId
             select cust.CustomerId
@@ -82,9 +82,9 @@ let ``simple select with last``() =
 
 [<Test; Ignore("Not Supported")>]
 let ``simple select with last or default when not exists``() =
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for cust in dc.Main.Customers do
             where (cust.CustomerId = "ZZZZ")
             select cust.CustomerId
@@ -94,9 +94,9 @@ let ``simple select with last or default when not exists``() =
 
 [<Test>]
 let ``simple exists when exists``() =
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for cust in dc.Main.Customers do
             exists (cust.CustomerId = "WOLZA")
         }
@@ -104,9 +104,9 @@ let ``simple exists when exists``() =
 
 [<Test; Ignore("Not Supported")>]
 let ``simple select with last or default when exists``() =
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for cust in dc.Main.Customers do
             where (cust.CustomerId = "WOLZA")
             select cust.CustomerId
@@ -116,9 +116,9 @@ let ``simple select with last or default when exists``() =
 
 [<Test >]
 let ``simple select with exactly one``() =
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for cust in dc.Main.Customers do
             where (cust.CustomerId = "ALFKI")
             select cust.CustomerId
@@ -128,9 +128,9 @@ let ``simple select with exactly one``() =
 
 [<Test>]
 let ``simple select with exactly one when not exists``() =
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for cust in dc.Main.Customers do
             where (cust.CustomerId = "ZZZZ")
             select cust.CustomerId
@@ -140,9 +140,9 @@ let ``simple select with exactly one when not exists``() =
 
 [<Test >]
 let ``simple select with head``() =
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for cust in dc.Main.Customers do
             where (cust.CustomerId = "ALFKI")
             select cust.CustomerId
@@ -152,9 +152,9 @@ let ``simple select with head``() =
 
 [<Test>]
 let ``simple select with head or Default``() =
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for cust in dc.Main.Customers do
             where (cust.CustomerId = "ALFKI")
             select cust.CustomerId
@@ -164,9 +164,9 @@ let ``simple select with head or Default``() =
 
 [<Test>]
 let ``simple select with head or Default when not exists``() =
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for cust in dc.Main.Customers do
             where (cust.CustomerId = "ZZZZ")
             select cust.CustomerId
@@ -176,9 +176,9 @@ let ``simple select with head or Default when not exists``() =
 
 [<Test >]
 let ``simple select query``() = 
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for cust in dc.Main.Customers do
             select cust
         } |> Seq.toArray
@@ -187,9 +187,9 @@ let ``simple select query``() =
 
 [<Test>]
 let ``simplest select query let temp``() = 
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for cust in dc.Main.Customers do
             let y = cust.City
             select cust.Address
@@ -199,9 +199,9 @@ let ``simplest select query let temp``() =
 
 [<Test>]
 let ``simple select query let temp nested``() = 
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for cust in dc.Main.Customers do
             let y1 = cust.Address
             let y2 = cust.City
@@ -212,9 +212,9 @@ let ``simple select query let temp nested``() =
 
 [<Test>]
 let ``simple select query let temp``() = 
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for cust in dc.Main.Customers do
             let y = cust.City + "test"
             select y
@@ -227,9 +227,9 @@ let ``simple select query let temp``() =
 
 [<Test>]
 let ``simple select query let where``() = 
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for cust in dc.Main.Customers do
             let y = cust.City + "test"
             where (cust.Address <> "")
@@ -241,9 +241,9 @@ let ``simple select query let where``() =
 
 [<Test; Ignore("Not supported")>]
 let ``simple select query let temp used in where``() = 
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for cust in dc.Main.Customers do
             let y = cust.City + "test"
             where (y <> "")
@@ -256,9 +256,9 @@ let ``simple select query let temp used in where``() =
 
 [<Test >]
 let ``simple select query with operations in select``() = 
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for cust in dc.Main.Customers do
             select (cust.Country + " " + cust.Address + (1).ToString())
         } |> Seq.toArray
@@ -267,9 +267,9 @@ let ``simple select query with operations in select``() =
 
 [<Test >]
 let ``simple select where query``() =
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for cust in dc.Main.Customers do
             where (cust.CustomerId = "ALFKI")
             select cust
@@ -282,9 +282,9 @@ let ``simple select where query``() =
 
 [<Test >]
 let ``simple select where null query``() =
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for cust in dc.Main.Customers do
             where (cust.CustomerId <> null)
             select cust
@@ -297,9 +297,9 @@ let ``simple select where null query``() =
 
 [<Test >]
 let ``simple select where query right side``() =
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for cust in dc.Main.Customers do
             where ("ALFKI" = cust.CustomerId)
             select cust
@@ -311,9 +311,9 @@ let ``simple select where query right side``() =
 
 [<Test >]
 let ``simple select where query between col properties``() =
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for order in dc.Main.Orders do
             where (order.ShippedDate > order.RequiredDate)
             select (order.ShippedDate, order.RequiredDate)
@@ -324,9 +324,9 @@ let ``simple select where query between col properties``() =
 
 [<Test >]
 let ``simple nth query``() =
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for cust in dc.Main.Customers do
             select cust
             nth 4
@@ -336,9 +336,9 @@ let ``simple nth query``() =
 
 [<Test >]
 let ``simple select where not query``() =
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for cust in dc.Main.Customers do
             where (not(cust.CustomerId = "ALFKI"))
             select cust
@@ -349,10 +349,10 @@ let ``simple select where not query``() =
 
 [<Test >]
 let ``simple select where in query``() =
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let arr = ["ALFKI"; "ANATR"; "AROUT"]
     let qry = 
-        sqlQuery {
+        sql {
             for cust in dc.Main.Customers do
             where (arr.Contains(cust.CustomerId))
             select cust.CustomerId
@@ -366,10 +366,10 @@ let ``simple select where in query``() =
     
 [<Test >]
 let ``simple select where not-in query``() =
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let arr = ["ALFKI"; "ANATR"; "AROUT"]
     let qry = 
-        sqlQuery {
+        sql {
             for cust in dc.Main.Customers do
             where (not(arr.Contains(cust.CustomerId)))
             select cust.CustomerId
@@ -383,16 +383,16 @@ let ``simple select where not-in query``() =
 [<Test >]
 let ``simple select where in queryable query``() =
 
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let query1 = 
-        sqlQuery {
+        sql {
             for cust in dc.Main.Customers do
             where (cust.City="London")
             select cust.CustomerId
         }
 
     let query2 = 
-        sqlQuery {
+        sql {
             for cust in dc.Main.Customers do
             where (query1.Contains(cust.CustomerId))
             select cust.CustomerId
@@ -406,10 +406,10 @@ let ``simple select where in queryable query``() =
 
 [<Test >]
 let ``simple select where in query custom syntax``() =
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let arr = ["ALFKI"; "ANATR"; "AROUT"]
     let qry = 
-        sqlQuery {
+        sql {
             for cust in dc.Main.Customers do
             where (cust.CustomerId |=| arr)
             select cust.CustomerId
@@ -421,9 +421,9 @@ let ``simple select where in query custom syntax``() =
 
 [<Test >]
 let ``simple select where like query``() =
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for cust in dc.Main.Customers do
             where (cust.CustomerId.Contains("a"))
             select cust.CustomerId
@@ -433,9 +433,9 @@ let ``simple select where like query``() =
 
 [<Test >]
 let ``simple select where query with operations in where``() =
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for cust in dc.Main.Customers do
             where (cust.CustomerId = "ALFKI" && (cust.City.StartsWith("B")))
             select cust
@@ -447,9 +447,9 @@ let ``simple select where query with operations in where``() =
 
 [<Test>]
 let ``simple select query with minBy``() = 
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for ord in dc.Main.OrderDetails do
             minBy (decimal ord.Discount)
         }   
@@ -457,9 +457,9 @@ let ``simple select query with minBy``() =
 
 [<Test>]
 let ``simple select query with minBy2``() = 
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for ord in dc.Main.OrderDetails do
             minBy (ord.Discount)
         }   
@@ -468,9 +468,9 @@ let ``simple select query with minBy2``() =
 
 [<Test>]
 let ``simple select query with minBy DateTime``() = 
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for emp in dc.Main.Employees do
             minBy (emp.BirthDate)
         }   
@@ -478,9 +478,9 @@ let ``simple select query with minBy DateTime``() =
 
 [<Test>]
 let ``simple select query with sumBy``() = 
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for od in dc.Main.OrderDetails do
             sumBy (od.UnitPrice)
         }
@@ -489,9 +489,9 @@ let ``simple select query with sumBy``() =
 
 [<Test>]
 let ``simple select query with averageBy``() = 
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for od in dc.Main.OrderDetails do
             averageBy od.UnitPrice
         }
@@ -500,9 +500,9 @@ let ``simple select query with averageBy``() =
 
 [<Test>]
 let ``simplest select query with groupBy``() = 
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for cust in dc.Main.Customers do
             groupBy cust.City
         } |> Seq.toArray
@@ -511,9 +511,9 @@ let ``simplest select query with groupBy``() =
 
 [<Test>]
 let ``simple select query with groupBy``() = 
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for cust in dc.Main.Customers do
             groupBy cust.City into c
             select (c.Key, c.Count())
@@ -524,9 +524,9 @@ let ``simple select query with groupBy``() =
 
 [<Test>]
 let ``simple select query with groupBy and then sort``() = 
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for order in dc.Main.Orders do
             groupBy (order.ShipCity) into ts
             where (ts.Count() > 1)
@@ -542,9 +542,9 @@ let ``simple select query with groupBy and then sort``() =
 
 [<Test>]
 let ``simple select query with groupBy multiple columns``() = 
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for p in dc.Main.Products do
             groupBy (p.ReorderLevel, p.CategoryId) into c
             select (c.Key, c.Sum(fun i -> i.UnitPrice))
@@ -554,9 +554,9 @@ let ``simple select query with groupBy multiple columns``() =
 
 [<Test>]
 let ``simple select query with groupBy sum``() = 
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for od in dc.Main.OrderDetails do
             groupBy od.ProductId into p
             select (p.Key, p.Sum(fun f -> f.UnitPrice), p.Sum(fun f -> f.Discount))
@@ -570,9 +570,9 @@ let ``simple select query with groupBy sum``() =
         
 [<Test>]
 let ``simple select query with groupBy having count``() = 
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for cust in dc.Main.Customers do
             groupBy cust.City into c
             where (c.Count() > 1)
@@ -585,9 +585,9 @@ let ``simple select query with groupBy having count``() =
 
 [<Test>]
 let ``simple select query with groupBy where and having``() = 
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for emp in dc.Main.Employees do
             where (emp.Country = "USA")
             groupBy emp.City into grp
@@ -603,9 +603,9 @@ let ``simple select query with groupBy where and having``() =
 
 [<Test>]
 let ``simple select query with groupBy having key``() = 
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for cust in dc.Main.Customers do
             groupBy cust.City into c
             where (c.Key = "London") 
@@ -617,9 +617,9 @@ let ``simple select query with groupBy having key``() =
 
 [<Test>]
 let ``simple select query with groupBy date``() = 
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for emp in dc.Main.Employees do
             groupBy emp.BirthDate into e
             select (e.Key, e.Count())
@@ -629,9 +629,9 @@ let ``simple select query with groupBy date``() =
 
 [<Test>]
 let ``simple select query with groupBy2``() = 
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for cust in dc.Main.Customers do
             where (cust.City = "London")
             groupBy (cust.Country, cust.City) into c
@@ -642,9 +642,9 @@ let ``simple select query with groupBy2``() =
 
 [<Test; Ignore("Not Supported")>]
 let ``simple select query with groupValBy``() = 
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for cust in dc.Main.Customers do
             groupValBy cust.ContactTitle cust.City into g
             select (g.Key, g.Count())
@@ -653,21 +653,21 @@ let ``simple select query with groupValBy``() =
 
 [<Test; Ignore("Not Supported")>]
 let ``complex select query with groupValBy``() = 
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for cust in dc.Main.Customers do
             groupValBy (cust.ContactTitle, Int32.Parse(cust.PostalCode)) (cust.PostalCode, cust.City) into g
-            let maxPlusOne = 1 + sqlQuery {for i in g do sumBy (snd i) }
+            let maxPlusOne = 1 + sql {for i in g do sumBy (snd i) }
             select (snd(g.Key), maxPlusOne)
         } |> dict  
     Assert.IsNotEmpty(qry)
 
 [<Test;>]
 let ``simple if query``() = 
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for cust in dc.Main.Customers do
             if cust.Country = "UK" then select cust.City
         } |> Seq.toArray
@@ -680,9 +680,9 @@ let ``simple select query with case``() =
     // Works but wrong implementation. Doesn't transfer logics to SQL.
     // Expected: SELECT CASE [cust].[Country] WHEN "UK" THEN [cust].[City] ELSE "Outside UK" END as 'City' FROM main.Customers as [cust]
     // Actual: SELECT [cust].[Country] as 'Country',[cust].[City] as 'City' FROM main.Customers as [cust]
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for cust in dc.Main.Customers do
             select (if cust.Country = "UK" then (cust.City)
                 else ("Outside UK"))
@@ -691,9 +691,9 @@ let ``simple select query with case``() =
 
 [<Test >]
 let ``simple select and sort query``() =
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for cust in dc.Main.Customers do
             sortBy cust.City
             select cust.City
@@ -704,9 +704,9 @@ let ``simple select and sort query``() =
 
 [<Test >]
 let ``simple select and sort desc query``() =
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for cust in dc.Main.Customers do
             sortByDescending cust.City
             select cust.City
@@ -717,9 +717,9 @@ let ``simple select and sort desc query``() =
 
 [<Test>]
 let ``simple select and sort query with then by query``() =
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for cust in dc.Main.Customers do
             sortBy cust.Country
             thenBy cust.City
@@ -731,9 +731,9 @@ let ``simple select and sort query with then by query``() =
 
 [<Test>]
 let ``simple select and sort query with then by desc query``() =
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for cust in dc.Main.Customers do
             sortBy cust.Country
             thenByDescending cust.City
@@ -745,9 +745,9 @@ let ``simple select and sort query with then by desc query``() =
 
 [<Test>]
 let ``simple sort query with lambda cast to IComparable``() =
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry =
-        sqlQuery {
+        sql {
             for cust in dc.Main.Customers do
             sortBy ((fun (c : sql.dataContext.``main.CustomersEntity``) -> c.CustomerId :> IComparable) cust)
             select cust.City
@@ -759,12 +759,12 @@ let ``simple sort query with lambda cast to IComparable``() =
 
 [<Test>]
 let ``simple sort query with then by desc query with lambda cast to IComparable``() =
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry =
-        sqlQuery {
+        sql {
             for cust in dc.Main.Customers do
             sortBy cust.CompanyName
-            thenByDescending ((fun (c : sql.dataContext.``main.CustomersEntity``) -> c.CustomerId :> IComparable) cust)
+            thenByDescending ((fun (c : Sql.dataContext.``main.CustomersEntity``) -> c.CustomerId :> IComparable) cust)
             select cust.City
             take 1
         } |> Seq.toArray
@@ -774,9 +774,9 @@ let ``simple sort query with then by desc query with lambda cast to IComparable`
 
 [<Test >]
 let ``simple select query with join``() = 
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for cust in dc.Main.Customers do
             join order in dc.Main.Orders on (cust.CustomerId = order.CustomerId)
             select (cust.CustomerId, order.OrderDate)
@@ -794,9 +794,9 @@ let ``simple select query with join``() =
 
 [<Test; Ignore("Grouping over multiple tables is not supported yet")>]
 let ``simple select query with join and then groupBy``() = 
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for cust in dc.Main.Customers do
             join order in dc.Main.Orders on (cust.CustomerId = order.CustomerId)
             groupBy cust.City into c
@@ -808,9 +808,9 @@ let ``simple select query with join and then groupBy``() =
 
 [<Test; Ignore("Joining over grouping is not supported yet")>]
 let ``simple select query with groupBy and then join``() = 
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for cust in dc.Main.Customers do
             groupBy cust.City into c
             join order in dc.Main.Orders on (c.Key = order.ShipCity)
@@ -823,9 +823,9 @@ let ``simple select query with groupBy and then join``() =
 
 [<Test >]
 let ``simple select query with join multi columns``() = 
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for cust in dc.Main.Customers do
             join order in dc.Main.Orders on ((cust.CustomerId, cust.CustomerId) = (order.CustomerId, order.CustomerId))
             select (cust.CustomerId, order.OrderDate)
@@ -843,9 +843,9 @@ let ``simple select query with join multi columns``() =
 
 [<Test >]
 let ``simple select query with join using relationships``() = 
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for cust in dc.Main.Customers do
             for order in cust.``main.Orders by CustomerID`` do
             select (cust.CustomerId, order.OrderDate)
@@ -862,9 +862,9 @@ let ``simple select query with join using relationships``() =
 
 [<Test; Ignore("Not Supported")>]
 let ``simple select query with group join``() = 
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for cust in dc.Main.Customers do
             groupJoin ord in dc.Main.Orders on (cust.CustomerId = ord.CustomerId) into g
             for order in g do
@@ -887,9 +887,9 @@ let ``simple select query with group join``() =
 
 [<Test >]
 let ``simple select query with multiple joins on relationships``() = 
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for cust in dc.Main.Customers do
             for order in cust.``main.Orders by CustomerID`` do
             for orderDetail in order.``main.OrderDetails by OrderID`` do
@@ -911,9 +911,9 @@ let ``simple select query with multiple joins on relationships``() =
 
 [<Test; Ignore("Not Supported")>]
 let ``simple select query with left outer join``() = 
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for cust in dc.Main.Customers do
             leftOuterJoin order in dc.Main.Orders on (cust.CustomerId = order.CustomerId) into result
             for order in result.DefaultIfEmpty() do
@@ -931,9 +931,9 @@ let ``simple select query with left outer join``() =
 
 [<Test>]
 let ``simple sumBy``() = 
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for od in dc.Main.OrderDetails do
             sumBy od.UnitPrice
         }
@@ -941,9 +941,9 @@ let ``simple sumBy``() =
 
 [<Test>]
 let ``simple async sum``() = 
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for od in dc.Main.OrderDetails do
             select od.UnitPrice
         } |> Seq.sumAsync |> Async.RunSynchronously
@@ -951,9 +951,9 @@ let ``simple async sum``() =
 
 [<Test>]
 let ``simple averageBy``() = 
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for od in dc.Main.OrderDetails do
             averageBy od.UnitPrice
         }
@@ -961,9 +961,9 @@ let ``simple averageBy``() =
 
 [<Test>]
 let ``simple averageByNullable``() = 
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for od in dc.Main.OrderDetails do
             averageByNullable (System.Nullable(od.UnitPrice))
         }
@@ -971,9 +971,9 @@ let ``simple averageByNullable``() =
 
 [<Test >]
 let ``simple select with distinct``() =
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for cust in dc.Main.Customers do
             select cust.City
             distinct
@@ -985,9 +985,9 @@ let ``simple select with distinct``() =
 
 [<Test>]
 let ``simple select with skip``() =
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for cust in dc.Main.Customers do
             select cust.City
             skip 5
@@ -1000,9 +1000,9 @@ let ``simple select with skip``() =
 
 [<Test >]
 let ``simple select with take``() =
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for cust in dc.Main.Customers do
             select cust.City
             take 5
@@ -1015,9 +1015,9 @@ let ``simple select with take``() =
 
 [<Test>]
 let ``simple select query with all``() = 
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for ord in dc.Main.OrderDetails do
             all (ord.UnitPrice > 0m)
         }   
@@ -1025,9 +1025,9 @@ let ``simple select query with all``() =
 
 [<Test>]
 let ``simple select query with all false``() = 
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for ord in dc.Main.OrderDetails do
             all (ord.UnitPrice > 10m)
         }   
@@ -1035,9 +1035,9 @@ let ``simple select query with all false``() =
 
 [<Test>]
 let ``simple select query with find``() = 
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for ord in dc.Main.OrderDetails do
             find (ord.UnitPrice > 10m)
         }   
@@ -1049,9 +1049,9 @@ type Dummy<'t> = D of 't
 
 [<Test >]
 let ``simple select into a generic type`` () =
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for emp in dc.Main.Customers do
             select (D {First=emp.ContactName})
         } |> Seq.toList
@@ -1064,9 +1064,9 @@ let ``simple select into a generic type with pipe`` () =
         Console.WriteLine "This is not supported in Mono: simple select into a generic type with pipe"
         Assert.IsFalse false
     else
-        let dc = sql.GetDataContext()
+        let dc = Sql.GetDataContext()
         let qry = 
-            sqlQuery {
+            sql {
                 for emp in dc.Main.Customers do
                 select ({First=emp.ContactName} |> D)
             } |> Seq.toList
@@ -1075,7 +1075,7 @@ let ``simple select into a generic type with pipe`` () =
 
 [<Test >]
 let ``simple select with bool outside query``() = 
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let rnd = System.Random()
     // Direct booleans outside LINQ:
     let myCond1 = true
@@ -1084,7 +1084,7 @@ let ``simple select with bool outside query``() =
     let myCond4 = 4
 
     let qry = 
-        sqlQuery {
+        sql {
             for cust in dc.Main.Customers do
             // Simple booleans outside queries are supported:
             where (((myCond1 && myCond1=true) && cust.City="Helsinki" || myCond1) || cust.City="London")
@@ -1097,7 +1097,7 @@ let ``simple select with bool outside query``() =
 
 [<Test >]
 let ``simple select with bool outside query2``() = 
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let rnd = System.Random()
     // Direct booleans outside LINQ:
     let myCond1 = true
@@ -1106,7 +1106,7 @@ let ``simple select with bool outside query2``() =
     let myCond4 = 4
 
     let qry = 
-        sqlQuery {
+        sql {
             for cust in dc.Main.Customers do
             // Simple booleans outside queries are supported:
             where (myCond4 > 3 || (myCond2 && cust.Address="test" && not(myCond2)))
@@ -1118,11 +1118,11 @@ let ``simple select with bool outside query2``() =
 
 [<Test >]
 let ``simple select query async``() = 
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let task = 
         async {
             let! asyncquery =
-                sqlQuery {
+                sql {
                     for cust in dc.Main.Customers do
                     select cust
                 } |> Seq.executeQueryAsync 
@@ -1137,7 +1137,7 @@ type sqlOption = SqlDataProvider<Common.DatabaseProviderTypes.SQLITE, connection
 let ``simple select with contains query with where boolean option type``() =
     let dc = sqlOption.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for cust in dc.Main.Customers do
             where (cust.City.IsSome)
             select cust.CustomerId
@@ -1148,9 +1148,9 @@ let ``simple select with contains query with where boolean option type``() =
 
 [<Test >]
 let ``simple canonical operation substing query``() =
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for cust in dc.Main.Customers do
             // Database spesific warning here: Substring of SQLite starts from 1.
             where (cust.CustomerId.Substring(2,3)+"F"="NATF")
@@ -1163,11 +1163,11 @@ let ``simple canonical operation substing query``() =
 
 [<Test >]
 let ``simple canonical operations query``() =
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
 
     let qry = 
         let L = "L"
-        sqlQuery {
+        sql {
             // Silly query not hitting indexes, so testing purposes only...
             for cust in dc.Main.Customers do
             // This is not yet working:
@@ -1193,14 +1193,14 @@ let ``simple canonical operations query``() =
 
 [<Test>]
 let ``simple union query test``() = 
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let query1 = 
-        sqlQuery {
+        sql {
             for cus in dc.Main.Customers do
             select (cus.City)
         }
     let query2 = 
-        sqlQuery {
+        sql {
             for emp in dc.Main.Employees do
             select (emp.City)
         } 
@@ -1218,14 +1218,14 @@ let ``simple union query test``() =
 
 [<Test>]
 let ``simple union all query test``() = 
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let query1 = 
-        sqlQuery {
+        sql {
             for cus in dc.Main.Customers do
             select (cus.City)
         }
     let query2 = 
-        sqlQuery {
+        sql {
             for emp in dc.Main.Employees do
             select (emp.City)
         } 
@@ -1237,21 +1237,21 @@ let ``simple union all query test``() =
     
 [<Test>]
 let ``verify groupBy results``() = 
-    let dc = sql.GetDataContext()
+    let dc = Sql.GetDataContext()
     let enumtest =
-        sqlQuery {
+        sql {
             for cust in dc.Main.Customers do
             select (cust)
         } |> Seq.toList
     let inlogics = 
-        sqlQuery {
+        sql {
             for cust in enumtest do
             groupBy cust.City into c
             select (c.Key, c.Count())
         } |> Seq.toArray |> Array.sortBy (fun (k,v) -> k )
 
     let groupqry = 
-        sqlQuery {
+        sql {
             for cust in dc.Main.Customers do
             groupBy cust.City into c
             select (c.Key, c.Count())
@@ -1262,8 +1262,8 @@ let ``verify groupBy results``() =
 
 [<Test >]
 let ``simple delete where query``() =
-    let dc = sql.GetDataContext()
-    sqlQuery {
+    let dc = Sql.GetDataContext()
+    sql {
         for cust in dc.Main.Customers do
         where (cust.City = "Atlantis" || cust.CompanyName = "Home")
     } |> Seq.``delete all items from single table`` 
@@ -1274,7 +1274,7 @@ let ``simple delete where query``() =
 let ``simple left join``() = 
     let dc = sqlOption.GetDataContext()
     let qry = 
-        sqlQuery {
+        sql {
             for o in dc.Main.Orders do
             for c in (!!) o.``main.Customers by CustomerID`` do
             select (o.CustomerId, c.CustomerId)


### PR DESCRIPTION
I think it's really bad UX that the library lets you use unsupported `query` operators without any compile-time warning, and you have to look in the documentation to find out which ones are missing. People [keep](https://stackoverflow.com/questions/36360670/sqlprovider-query-errors-with-unrecognized-method-call) [being](https://github.com/fsprojects/SQLProvider/issues/133) [surprised](https://github.com/fsprojects/SQLProvider/issues/235) by that.

Although it would obviously be ideal to implement `groupJoin` and the other missing ones, I figured that there could be a simpler solution first: provide a `sqlQuery` computation expression where the unsupported operators are simply not available.

The `sql` builder in this PR is a dumb calque of [the original `query` CE](https://github.com/Microsoft/visualfsharp/blob/44fa027b308681a1b78a089e44fa1ab35ff77b41/src/fsharp/FSharp.Core/Query.fsi). The queries are still regular `IQueryables` so you can freely mix and match `sql` and `query` without issue (and it doesn't break existing code). As you can see, the tests that use unsupported operators become compile-time failures.

Other safety improvements that could potentially be achieved through this CE:

- I think it should be possible, and I would really like to, replace the `!!` operator with a more intuitive `naturalJoin` operator, like this:
```
for cust in dc.Main.Customers do
naturalJoin order in cust.``main.Orders by CustomerID`` do
select (order, cust)
```
  but I'm having trouble making it work - it doesn't seem like `CustomOperationAttribute` lets you define an operator that is "like `for`". Plus I'm not sure if the  `!!` operator would even be correctly recognized by the code in `SqlRuntime.Linq.fs` this way

- It might be possible to [ensure that `join` is only used on supported targets](https://github.com/fsprojects/SQLProvider/issues/396), by wrapping `QuerySource` in a SQL-specific wrapper class?

Thoughts?

