### PR TITLE
Canonical operations support for aggregation operators (SUM/AVG/MIN/MAX) in single table

### DIFF
--- a/src/SQLProvider/Operators.fs
+++ b/src/SQLProvider/Operators.fs
@@ -87,7 +87,7 @@ module ColumnSchema =
     and SqlColumnType =
     | KeyColumn of string
     | CanonicalOperation of CanonicalOp * SqlColumnType
-    | GroupColumn of AggregateOperation
+    | GroupColumn of AggregateOperation * SqlColumnType
 
     and SqlStringOrColumn =
     | SqlStr of string

--- a/src/SQLProvider/SqlRuntime.Async.fs
+++ b/src/SQLProvider/SqlRuntime.Async.fs
@@ -62,7 +62,16 @@ module AsyncOperations =
             match s with
             | :? IWithSqlService as svc ->
                 match svc.SqlExpression with
-                | Projection(MethodCall(None, _, [SourceWithQueryData source; OptionalQuote (Lambda([ParamName param], SqlColumnGet(entity,KeyColumn key,_))) ]),_) ->
+                | Projection(MethodCall(None, _, [SourceWithQueryData source; OptionalQuote (Lambda([ParamName param], SqlColumnGet(entity,op,_))) ]),_) ->
+                    
+                    let key = 
+                        let rec getBaseCol x =
+                            match x with
+                            | KeyColumn k -> k
+                            | CanonicalOperation(_, c) -> getBaseCol c
+                            | GroupColumn(_, c) -> getBaseCol c
+                        getBaseCol op
+
                     let alias =
                             match entity with
                             | "" when source.SqlExpression.HasAutoTupled() -> param
@@ -70,16 +79,16 @@ module AsyncOperations =
                             | _ -> FSharp.Data.Sql.Common.Utilities.resolveTuplePropertyName entity source.TupleIndex
                     let sqlExpression =
                             match agg, source.SqlExpression with
-                            | "Sum", BaseTable("",entity)  -> AggregateOp("",GroupColumn(SumOp(key)),BaseTable(alias,entity))
-                            | "Sum", _ ->  AggregateOp(alias,GroupColumn(SumOp(key)),source.SqlExpression)
-                            | "Max", BaseTable("",entity)  -> AggregateOp("",GroupColumn(MaxOp(key)),BaseTable(alias,entity))
-                            | "Max", _ ->  AggregateOp(alias,GroupColumn(MaxOp(key)),source.SqlExpression)
-                            | "Min", BaseTable("",entity)  -> AggregateOp("",GroupColumn(MinOp(key)),BaseTable(alias,entity))
-                            | "Min", _ ->  AggregateOp(alias,GroupColumn(MinOp(key)),source.SqlExpression)
-                            | "Count", BaseTable("",entity)  -> AggregateOp("",GroupColumn(CountOp(key)),BaseTable(alias,entity))
-                            | "Count", _ ->  AggregateOp(alias,GroupColumn(CountOp(key)),source.SqlExpression)
-                            | "Average", BaseTable("",entity)  -> AggregateOp("",GroupColumn(AvgOp(key)),BaseTable(alias,entity))
-                            | "Average", _ ->  AggregateOp(alias,GroupColumn(AvgOp(key)),source.SqlExpression)
+                            | "Sum", BaseTable("",entity)  -> AggregateOp("",GroupColumn(SumOp(key), op),BaseTable(alias,entity))
+                            | "Sum", _ ->  AggregateOp(alias,GroupColumn(SumOp(key), op),source.SqlExpression)
+                            | "Max", BaseTable("",entity)  -> AggregateOp("",GroupColumn(MaxOp(key), op),BaseTable(alias,entity))
+                            | "Max", _ ->  AggregateOp(alias,GroupColumn(MaxOp(key), op),source.SqlExpression)
+                            | "Min", BaseTable("",entity)  -> AggregateOp("",GroupColumn(MinOp(key), op),BaseTable(alias,entity))
+                            | "Min", _ ->  AggregateOp(alias,GroupColumn(MinOp(key), op),source.SqlExpression)
+                            | "Count", BaseTable("",entity)  -> AggregateOp("",GroupColumn(CountOp(key), op),BaseTable(alias,entity))
+                            | "Count", _ ->  AggregateOp(alias,GroupColumn(CountOp(key), op),source.SqlExpression)
+                            | "Average", BaseTable("",entity)  -> AggregateOp("",GroupColumn(AvgOp(key), op),BaseTable(alias,entity))
+                            | "Average", _ ->  AggregateOp(alias,GroupColumn(AvgOp(key), op),source.SqlExpression)
                             | _ -> failwithf "Unsupported aggregation `%s` in execution expression `%s`" agg (source.SqlExpression.ToString())
                     let! res = executeQueryScalarAsync source.DataContext source.Provider sqlExpression source.TupleIndex 
                     if res = box(DBNull.Value) then return Unchecked.defaultof<'T> else

--- a/src/SQLProvider/SqlRuntime.Common.fs
+++ b/src/SQLProvider/SqlRuntime.Common.fs
@@ -601,7 +601,7 @@ module internal CommonTasks =
             let replaceAlias = function "" -> basealias | x -> x
             let replaceEmptyKey = 
                 match key with
-                | KeyColumn keyName -> function GroupColumn (KeyOp k) when k = "" -> GroupColumn (KeyOp keyName) | x -> x
+                | KeyColumn keyName -> function GroupColumn (KeyOp k,c) when k = "" -> GroupColumn (KeyOp keyName,c) | x -> x
                 | _ -> fun x -> x
 
             let rec parseFilters conditionList = 

--- a/src/SQLProvider/SqlRuntime.Patterns.fs
+++ b/src/SQLProvider/SqlRuntime.Patterns.fs
@@ -200,26 +200,27 @@ let rec (|SqlColumnGet|_|) (e:Expression) =
             me.Expression <> null && me.Expression.Type <> null && me.Expression.Type.Name <> null &&
             me.Expression.Type.Name.StartsWith("IGrouping")  -> 
         match me.Member with 
-        | :? PropertyInfo as p when p.Name = "Key" -> Some(String.Empty, GroupColumn (KeyOp ""), p.DeclaringType) 
+        | :? PropertyInfo as p when p.Name = "Key" -> Some(String.Empty, GroupColumn (KeyOp "",SqlColumnType.KeyColumn("Key")), p.DeclaringType) 
         | _ -> None
     | ExpressionType.Call, ( :? MethodCallExpression as e) when e.Arguments <> null && e.Arguments.Count = 1 && 
             e.Arguments.[0] <> null && e.Arguments.[0].Type <> null && e.Arguments.[0].Type.Name <> null &&
             e.Arguments.[0].Type.Name.StartsWith("IGrouping") ->
         if e.Arguments.[0].NodeType = ExpressionType.Parameter then
+            let pn = match e.Arguments.[0] with :? ParameterExpression as p -> p.Name | _ -> e.Method.Name
             match e.Method.Name with
-            | "Count" -> Some(String.Empty, GroupColumn (CountOp ""), e.Method.DeclaringType)
-            | "Average" -> Some(String.Empty, GroupColumn (AvgOp ""), e.Method.DeclaringType)
-            | "Min" -> Some(String.Empty, GroupColumn (MinOp ""), e.Method.DeclaringType)
-            | "Max" -> Some(String.Empty, GroupColumn (MaxOp ""), e.Method.DeclaringType)
-            | "Sum" -> Some(String.Empty, GroupColumn (SumOp ""), e.Method.DeclaringType)
+            | "Count" -> Some(String.Empty, GroupColumn (CountOp "",SqlColumnType.KeyColumn(pn)), e.Method.DeclaringType)
+            | "Average" -> Some(String.Empty, GroupColumn (AvgOp "",SqlColumnType.KeyColumn(pn)), e.Method.DeclaringType)
+            | "Min" -> Some(String.Empty, GroupColumn (MinOp "",SqlColumnType.KeyColumn(pn)), e.Method.DeclaringType)
+            | "Max" -> Some(String.Empty, GroupColumn (MaxOp "",SqlColumnType.KeyColumn(pn)), e.Method.DeclaringType)
+            | "Sum" -> Some(String.Empty, GroupColumn (SumOp "",SqlColumnType.KeyColumn(pn)), e.Method.DeclaringType)
             | _ -> None
         else 
             match e.Arguments.[0], e.Method.Name with
-            | :? MemberExpression as m, "Count" -> Some(m.Member.Name, GroupColumn (CountOp ""), e.Method.DeclaringType)
-            | :? MemberExpression as m, "Average" -> Some(m.Member.Name, GroupColumn (AvgOp ""), e.Method.DeclaringType)
-            | :? MemberExpression as m, "Min" -> Some(m.Member.Name, GroupColumn (MinOp ""), e.Method.DeclaringType)
-            | :? MemberExpression as m, "Max" -> Some(m.Member.Name, GroupColumn (MaxOp ""), e.Method.DeclaringType)
-            | :? MemberExpression as m, "Sum" -> Some(m.Member.Name, GroupColumn (SumOp ""), e.Method.DeclaringType)
+            | :? MemberExpression as m, "Count" -> Some(m.Member.Name, GroupColumn (CountOp "",SqlColumnType.KeyColumn(m.Member.Name)), e.Method.DeclaringType)
+            | :? MemberExpression as m, "Average" -> Some(m.Member.Name, GroupColumn (AvgOp "",SqlColumnType.KeyColumn(m.Member.Name)), e.Method.DeclaringType)
+            | :? MemberExpression as m, "Min" -> Some(m.Member.Name, GroupColumn (MinOp "",SqlColumnType.KeyColumn(m.Member.Name)), e.Method.DeclaringType)
+            | :? MemberExpression as m, "Max" -> Some(m.Member.Name, GroupColumn (MaxOp "",SqlColumnType.KeyColumn(m.Member.Name)), e.Method.DeclaringType)
+            | :? MemberExpression as m, "Sum" -> Some(m.Member.Name, GroupColumn (SumOp "",SqlColumnType.KeyColumn(m.Member.Name)), e.Method.DeclaringType)
             | _ -> None
 
     // These are canonical functions

--- a/src/SQLProvider/SqlRuntime.QueryExpression.fs
+++ b/src/SQLProvider/SqlRuntime.QueryExpression.fs
@@ -363,12 +363,12 @@ module internal QueryExpressionTransformer =
                                         group 
                                         |> Seq.choose(fun (a, c) -> 
                                             match op, c with
-                                            | KeyOp i, KeyColumn c when String.IsNullOrEmpty i -> Some (a, GroupColumn(KeyOp c))
-                                            | MaxOp i, KeyColumn c -> Some (a, GroupColumn(MaxOp (if String.IsNullOrEmpty i then c else i)))
-                                            | MinOp i, KeyColumn c -> Some (a, GroupColumn(MinOp (if String.IsNullOrEmpty i then c else i)))
-                                            | SumOp i, KeyColumn c -> Some (a, GroupColumn(SumOp (if String.IsNullOrEmpty i then c else i)))
-                                            | AvgOp i, KeyColumn c -> Some (a, GroupColumn(AvgOp (if String.IsNullOrEmpty i then c else i)))
-                                            | CountOp i, KeyColumn c -> Some (a, GroupColumn(CountOp (if String.IsNullOrEmpty i then c else i)))
+                                            | KeyOp i, KeyColumn c when String.IsNullOrEmpty i -> Some (a, GroupColumn(KeyOp c, KeyColumn c))
+                                            | MaxOp i, KeyColumn c -> Some (a, GroupColumn(MaxOp (if String.IsNullOrEmpty i then c else i), KeyColumn c))
+                                            | MinOp i, KeyColumn c -> Some (a, GroupColumn(MinOp (if String.IsNullOrEmpty i then c else i), KeyColumn c))
+                                            | SumOp i, KeyColumn c -> Some (a, GroupColumn(SumOp (if String.IsNullOrEmpty i then c else i), KeyColumn c))
+                                            | AvgOp i, KeyColumn c -> Some (a, GroupColumn(AvgOp (if String.IsNullOrEmpty i then c else i), KeyColumn c))
+                                            | CountOp i, KeyColumn c -> Some (a, GroupColumn(CountOp (if String.IsNullOrEmpty i then c else i), KeyColumn c))
                                             | _ -> None)
                                     ) |> Seq.concat |> Seq.toList
                                 group, aggregations)

--- a/src/SQLProvider/Utils.fs
+++ b/src/SQLProvider/Utils.fs
@@ -115,24 +115,29 @@ module internal Utilities =
             | RoundDecimals x -> sprintf "ROUND(%s,%d)" column x
             | BasicMath(o, c) -> sprintf "(%s %s %O)" column o c
             | _ -> failwithf "Not yet supported: %O %s" op (key.ToString())
-        | GroupColumn (KeyOp key) -> colSprint key
-        | GroupColumn (CountOp _) -> sprintf "COUNT(1)"
-        | GroupColumn (AvgOp key) -> sprintf "AVG(%s)" (colSprint key)
-        | GroupColumn (MinOp key) -> sprintf "MIN(%s)" (colSprint key)
-        | GroupColumn (MaxOp key) -> sprintf "MAX(%s)" (colSprint key)
-        | GroupColumn (SumOp key) -> sprintf "SUM(%s)" (colSprint key)
+        | GroupColumn (AvgOp key, KeyColumn _) -> sprintf "AVG(%s)" (colSprint key)
+        | GroupColumn (MinOp key, KeyColumn _) -> sprintf "MIN(%s)" (colSprint key)
+        | GroupColumn (MaxOp key, KeyColumn _) -> sprintf "MAX(%s)" (colSprint key)
+        | GroupColumn (SumOp key, KeyColumn _) -> sprintf "SUM(%s)" (colSprint key)
+        | GroupColumn (KeyOp key,_) -> colSprint key
+        | GroupColumn (CountOp _,_) -> sprintf "COUNT(1)"
+        // Nested aggregate operators, e.g. select(x*y) |> Seq.sum
+        | GroupColumn (AvgOp _,x) -> sprintf "AVG(%s)" (recursionBase x)
+        | GroupColumn (MinOp _,x) -> sprintf "MIN(%s)" (recursionBase x)
+        | GroupColumn (MaxOp _,x) -> sprintf "MAX(%s)" (recursionBase x)
+        | GroupColumn (SumOp _,x) -> sprintf "SUM(%s)" (recursionBase x)
 
     let rec genericAliasNotation aliasSprint = function
         | SqlColumnType.KeyColumn col -> aliasSprint col
         | SqlColumnType.CanonicalOperation(op,col) -> 
             let subItm = genericAliasNotation aliasSprint col
             aliasSprint (sprintf "%s_%O" (op.ToString().Replace(" ", "_")) subItm)
-        | GroupColumn (KeyOp key) -> aliasSprint key
-        | GroupColumn (CountOp key) -> aliasSprint (sprintf "COUNT_%s" key)
-        | GroupColumn (AvgOp key) -> aliasSprint (sprintf "AVG_%s" key)
-        | GroupColumn (MinOp key) -> aliasSprint (sprintf "MIN_%s" key)
-        | GroupColumn (MaxOp key) -> aliasSprint (sprintf "MAX_%s" key)
-        | GroupColumn (SumOp key) -> aliasSprint (sprintf "SUM_%s" key)
+        | GroupColumn (KeyOp key,_) -> aliasSprint key
+        | GroupColumn (CountOp key,_) -> aliasSprint (sprintf "COUNT_%s" key)
+        | GroupColumn (AvgOp key,_) -> aliasSprint (sprintf "AVG_%s" key)
+        | GroupColumn (MinOp key,_) -> aliasSprint (sprintf "MIN_%s" key)
+        | GroupColumn (MaxOp key,_) -> aliasSprint (sprintf "MAX_%s" key)
+        | GroupColumn (SumOp key,_) -> aliasSprint (sprintf "SUM_%s" key)
 
 
 module ConfigHelpers = 

--- a/tests/SqlProvider.Tests/QueryTests.fs
+++ b/tests/SqlProvider.Tests/QueryTests.fs
@@ -510,6 +510,17 @@ let ``simple select query with averageBy``() =
     Assert.Greater(27m, qry)
     Assert.Less(26m, qry)
 
+let ``simple select query with averageBy length``() = 
+    let dc = sql.GetDataContext()
+    let qry = 
+        query {
+            for c in dc.Main.Customers do
+            averageBy (decimal(c.ContactName.Length))
+        }
+    Assert.Greater(14m, qry)
+    Assert.Less(13m, qry)
+
+
 [<Test>]
 let ``simplest select query with groupBy``() = 
     let dc = sql.GetDataContext()

--- a/tests/SqlProvider.Tests/QueryTests.fs
+++ b/tests/SqlProvider.Tests/QueryTests.fs
@@ -488,6 +488,18 @@ let ``simple select query with sumBy``() =
     Assert.Less(56499m, qry)
 
 [<Test>]
+let ``simple select query with sumBy times two``() = 
+    let dc = sql.GetDataContext()
+    let qry = 
+        query {
+            for od in dc.Main.OrderDetails do
+            sumBy (od.UnitPrice*od.UnitPrice-2m)
+        }
+    Assert.Greater(3393420m, qry)
+    Assert.Less(3393418m, qry)
+
+
+[<Test>]
 let ``simple select query with averageBy``() = 
     let dc = sql.GetDataContext()
     let qry = 
@@ -948,6 +960,17 @@ let ``simple async sum``() =
             select od.UnitPrice
         } |> Seq.sumAsync |> Async.RunSynchronously
     Assert.That(qry, Is.EqualTo(56500.91M).Within(0.001M))
+
+[<Test>]
+let ``simple async sum with operations``() = 
+    let dc = sql.GetDataContext()
+    let qry = 
+        query {
+            for od in dc.Main.OrderDetails do
+            select ((od.UnitPrice+1m)*od.UnitPrice)
+        } |> Seq.sumAsync |> Async.RunSynchronously
+    Assert.That(qry, Is.EqualTo(3454230.7769M).Within(0.1M))
+
 
 [<Test>]
 let ``simple averageBy``() = 


### PR DESCRIPTION
Ok, we still have usually the `select` clause executed as F# delegate.

But I really needed to do this efficiently for a large database table:

```SQL
SELECT SUM(t.Sum * t.Rate) 
WHERE ...
FROM myTable t
```

```fsharp
let totalFunds =
   query { for i in myTable do
           where (...whatever...)
           sumBy (i.Sum * i.Rate) }
```

...or...

```
let totalFundsAsync =
   query { for i in myTable do
           where (...whatever...)
           select (i.Sum * i.Rate)
   } |> Seq.sumAsync
```

So after this PR you can use canonical operations when aggregating data and they will be executed in SQL for a single table.

```fsharp
let avgNameLen =
   query {
       for c in dc.Main.Customers do
       averageBy (decimal(c.ContactName.Length))
   }
```

