### PR TITLE
We need unit-test for Procedure calls. So here it is.

### DIFF
--- a/src/SQLProvider/Providers.MSAccess.fs
+++ b/src/SQLProvider/Providers.MSAccess.fs
@@ -103,6 +103,7 @@ type internal MSAccessProvider() =
                     let providerType = unbox<int> r.["ProviderDbType"]
                     let dbType = getDbType providerType
                     yield { ProviderTypeName = Some oleDbType; ClrType = clrType; DbType = dbType; ProviderType = Some providerType; }
+                yield { ProviderTypeName = Some "cursor"; ClrType = (typeof<SqlEntity[]>).ToString(); DbType = DbType.Object; ProviderType = None; }
             ]
 
         let clrMappings =

--- a/src/SQLProvider/Providers.Odbc.fs
+++ b/src/SQLProvider/Providers.Odbc.fs
@@ -62,6 +62,7 @@ type internal OdbcProvider(quotechar : OdbcQuoteCharacter) =
                         let providerType = unbox<int> r.Table.Columns.["ProviderDbType"].Ordinal
                         let dbType = getDbType providerType
                         yield { ProviderTypeName = Some oleDbType; ClrType = clrType; DbType = dbType; ProviderType = Some providerType; }
+                yield { ProviderTypeName = Some "cursor"; ClrType = (typeof<SqlEntity[]>).ToString(); DbType = DbType.Object; ProviderType = None; }
             ]
 
         let clrMappings =

--- a/src/SQLProvider/SqlRuntime.DataContext.fs
+++ b/src/SQLProvider/SqlRuntime.DataContext.fs
@@ -42,12 +42,13 @@ type public SqlDataContext (typeName, connectionString:string, providerType, res
                 // the minimum base set of data available
                 prov.CreateTypeMappings(con)
                 prov.GetTables(con,caseSensitivity) |> ignore
-                if (providerType.GetType() <> typeof<Providers.MSAccessProvider>) then con.Close()
+                if (providerType <> DatabaseProviderTypes.MSACCESS && providerType.GetType() <> typeof<Providers.MSAccessProvider>) then con.Close()
                 prov)
 
     let initCallSproc (dc:SqlDataContext) (def:RunTimeSprocDefinition) (values:obj array) (con:IDbConnection) (com:IDbCommand) =
         
-        com.CommandType <- CommandType.StoredProcedure
+        if (providerType <> DatabaseProviderTypes.SQLITE) then 
+            com.CommandType <- CommandType.StoredProcedure
 
         let columns =
             def.Params

--- a/tests/SqlProvider.Tests/QueryTests.fs
+++ b/tests/SqlProvider.Tests/QueryTests.fs
@@ -1340,3 +1340,21 @@ let ``simple left join``() =
     
     let hasNulls = qry |> Seq.map(fst) |> Seq.filter(Option.isNone) |> Seq.isEmpty |> not
     Assert.IsTrue hasNulls
+
+
+[<Test>]
+let ``simple quert sproc result``() = 
+    let dc = sql.GetDataContext()
+    let pragmaSchemav = dc.Pragma.Get.Invoke("schema_version")
+    let res = pragmaSchemav.ResultSet |> Array.map(fun i -> i.ColumnValues |> Map.ofSeq)
+    let ver = (res |> Seq.head).["schema_version"] :?> Int64
+    Assert.IsTrue(ver > 1L)
+
+    let pragmaFk = dc.Pragma.GetOf.Invoke("foreign_key_list", "EmployeesTerritories")
+    let res = pragmaFk.ResultSet |> Array.map(fun i -> i.ColumnValues |> Map.ofSeq)
+    Assert.IsNotNull(res)
+
+    let pragmaSchemaAsync = 
+        dc.Pragma.Get.InvokeAsync("schema_version")
+        |> Async.RunSynchronously
+    Assert.IsNotNull(pragmaSchemaAsync.ResultSet)


### PR DESCRIPTION
This is a bit hack, but...

- Our unit test run in SQLite and are run when a release is created.
- SQLite doesn't support stored procedures
- But the procedure logic is quite complex and fragile

So. Instead of "Procedures" and "Functions", there is now "Pragmas" for SQLite. [Pragmas](https://sqlite.org/pragma.html#pragma_page_count) are SQLite way to query database settings. We support only Get (to not mess things too much). It is using our stored-procedure-logic to fetch pragmas, so this way we can test the stored procedure logics.

```fsharp
let pragmaSchemav = dc.Pragma.Get.Invoke("schema_version")
let pragmaFk = dc.Pragma.GetOf.Invoke("foreign_key_list", "EmployeesTerritories")
```
So that #466 shouldn't happen any more.
