### PR TITLE
Revert TypeProvider SDK to earlier version, which was more suitable for SQLProvider

### DIFF
--- a/paket.lock
+++ b/paket.lock
@@ -1479,8 +1479,8 @@ GROUP SourceFiles
 
 GITHUB
   remote: fsprojects/FSharp.TypeProviders.SDK
-    src/ProvidedTypes.fs (e75f056b5a675d04445649d872aa020439a6442a)
-    src/ProvidedTypes.fsi (e75f056b5a675d04445649d872aa020439a6442a)
+    src/ProvidedTypes.fs (e0436b11faed9e7938b3c90d874a535f94311b87)
+    src/ProvidedTypes.fsi (e0436b11faed9e7938b3c90d874a535f94311b87)
   remote: Thorium/Linq.Expression.Optimizer
     src/Code/ExpressionOptimizer.fs (297f7d9f75c7d8d86b1d00bae0b535d8e48f572d)
 GROUP Standard

--- a/src/SQLProvider/Providers.MsSqlServer.fs
+++ b/src/SQLProvider/Providers.MsSqlServer.fs
@@ -503,9 +503,9 @@ type internal MSSqlServerProvider(tableNames:string) =
             if con.State <> ConnectionState.Open then con.Open()
             use reader = com.ExecuteReader()
             if reader.Read() then
-                let itm = reader.GetSqlString(0)
-                if itm.Value <> null then
-                    reader.GetSqlString(0).Value.ToString()
+                let itm = reader.GetValue(0)
+                if itm <> null then
+                    reader.GetValue(0).ToString()
                 else ""
             else ""
 
@@ -527,7 +527,7 @@ type internal MSSqlServerProvider(tableNames:string) =
             use reader = com.ExecuteReader()
             if reader.Read() then
                 try
-                    reader.GetSqlString(0).Value.ToString()
+                    reader.GetValue(0).ToString()
                 with 
                 | :? InvalidCastException -> ""
             else ""

--- a/tests/SqlProvider.Tests/QueryTests.fs
+++ b/tests/SqlProvider.Tests/QueryTests.fs
@@ -19,7 +19,7 @@ let connectionString = @"Data Source=./db/northwindEF.db;Version=3;Read Only=fal
 
 type sql = SqlDataProvider<Common.DatabaseProviderTypes.SQLITE, connectionString, CaseSensitivityChange=Common.CaseSensitivityChange.ORIGINAL>
 FSharp.Data.Sql.Common.QueryEvents.SqlQueryEvent |> Event.add (printfn "Executing SQL: %O")
-   
+let inline isNull (x:^T when ^T : not struct) = obj.ReferenceEquals (x, null)   
 
 let isMono = Type.GetType ("Mono.Runtime") <> null
 
@@ -136,6 +136,7 @@ let ``simple select with exactly one when not exists``() =
             select cust.CustomerId
             exactlyOneOrDefault
         }
+    Assert.IsTrue(isNull(qry))
     Assert.AreEqual(null, qry)  
 
 [<Test >]


### PR DESCRIPTION
The recent had problems with empty constructors, procedure return types and SqlEntities being structs.
