### PR TITLE
Fix sproc name overload + Fix Postgresql sprocs

### DIFF
--- a/.paket/Paket.Restore.targets
+++ b/.paket/Paket.Restore.targets
@@ -136,15 +136,21 @@
   </Target>
 
   <Target Name="PaketOverrideNuspec" AfterTargets="GenerateNuspec" Condition="('$(IsPackable)' == '' Or '$(IsPackable)' == 'true') And Exists('$(MSBuildProjectDirectory)/obj/$(MSBuildProjectFile).references')" >
+    <ItemGroup>
+      <_NuspecFilesNewLocation Include="$(BaseIntermediateOutputPath)$(Configuration)/*.nuspec"/>
+    </ItemGroup>
+
     <PropertyGroup>
       <PaketProjectFile>$(MSBuildProjectDirectory)/$(MSBuildProjectFile)</PaketProjectFile>
       <ContinuePackingAfterGeneratingNuspec>true</ContinuePackingAfterGeneratingNuspec>
       <UseNewPack>false</UseNewPack>
       <UseNewPack Condition=" '$(NuGetToolVersion)' != '4.0.0' ">true</UseNewPack>
+      <AdjustedNuspecOutputPath>$(BaseIntermediateOutputPath)$(Configuration)/</AdjustedNuspecOutputPath>
+      <AdjustedNuspecOutputPath Condition="@(_NuspecFilesNewLocation) == ''">$(BaseIntermediateOutputPath)</AdjustedNuspecOutputPath>
     </PropertyGroup>
 
     <ItemGroup>
-      <_NuspecFiles Include="$(BaseIntermediateOutputPath)*.nuspec"/>
+      <_NuspecFiles Include="$(AdjustedNuspecOutputPath)*.nuspec"/>
     </ItemGroup>
 
     <Exec Command='$(PaketCommand) fix-nuspecs files "@(_NuspecFiles)" project-file "$(PaketProjectFile)" ' Condition="@(_NuspecFiles) != ''" />
@@ -188,7 +194,7 @@
               Serviceable="$(Serviceable)"
               FrameworkAssemblyReferences="@(_FrameworkAssemblyReferences)"
               ContinuePackingAfterGeneratingNuspec="$(ContinuePackingAfterGeneratingNuspec)"
-              NuspecOutputPath="$(BaseIntermediateOutputPath)"
+              NuspecOutputPath="$(AdjustedNuspecOutputPath)"
               IncludeBuildOutput="$(IncludeBuildOutput)"
               BuildOutputFolder="$(BuildOutputTargetFolder)"
               ContentTargetFolders="$(ContentTargetFolders)"
@@ -230,7 +236,7 @@
               Serviceable="$(Serviceable)"
               AssemblyReferences="@(_References)"
               ContinuePackingAfterGeneratingNuspec="$(ContinuePackingAfterGeneratingNuspec)"
-              NuspecOutputPath="$(BaseIntermediateOutputPath)"
+              NuspecOutputPath="$(AdjustedNuspecOutputPath)"
               IncludeBuildOutput="$(IncludeBuildOutput)"
               BuildOutputFolder="$(BuildOutputTargetFolder)"
               ContentTargetFolders="$(ContentTargetFolders)"

--- a/src/SQLProvider/Providers.Postgresql.fs
+++ b/src/SQLProvider/Providers.Postgresql.fs
@@ -434,7 +434,7 @@ module PostgreSQL =
 	          ,COALESCE((
 			          SELECT STRING_AGG(x.param, E'\n')
 			          FROM (
-				          SELECT p.parameter_mode || ';' || p.parameter_name || ';' || p.data_type AS param
+				          SELECT p.parameter_mode || ';' || COALESCE(p.parameter_name, ('param' || p.ORDINAL_POSITION::TEXT)) || ';' || p.data_type AS param
 				          FROM information_schema.parameters p
 				          WHERE p.specific_name = r.specific_name
 				          ORDER BY p.ordinal_position

--- a/src/SQLProvider/SqlDesignTime.fs
+++ b/src/SQLProvider/SqlDesignTime.fs
@@ -289,7 +289,7 @@ type SqlTypeProvider(config: TypeProviderConfig) as this =
         let generateSprocMethod (container:ProvidedTypeDefinition) (con:IDbConnection) (sproc:CompileTimeSprocDefinition) =    
             
             let sprocname = SchemaProjections.buildSprocName(sproc.Name.DbName) 
-                            |> SchemaProjections.avoidNameClashBy container.GetMember
+                            |> SchemaProjections.avoidNameClashBy (container.GetMember >> Array.isEmpty >> not)
 
             let rt = ctxt.ProvidedTypeDefinition(sprocname,None, true)
             let resultType = ctxt.ProvidedTypeDefinition("Result", None, true)
@@ -339,7 +339,7 @@ type SqlTypeProvider(config: TypeProviderConfig) as this =
                               
             let niceUniqueSprocName = 
                 SchemaProjections.buildSprocName(sproc.Name.ProcName)
-                |> SchemaProjections.avoidNameClashBy container.GetProperty  
+                |> SchemaProjections.avoidNameClashBy (container.GetProperty >> (<>) null)
 
             let p = ctxt.ProvidedProperty(niceUniqueSprocName, resultType, getterCode = (fun args -> <@@ ((%%args.[0] : obj) :?>ISqlDataContext) @@>) ) 
             let dbName = sproc.Name.DbName

--- a/src/SQLProvider/SqlDesignTime.fs
+++ b/src/SQLProvider/SqlDesignTime.fs
@@ -31,7 +31,7 @@ type SqlTypeProvider(config: TypeProviderConfig) as this =
     inherit TypeProviderForNamespaces()
     let sqlRuntimeInfo = SqlRuntimeInfo(config)
     let ctxt = ProvidedTypesContext.Create(config)
-    let ns = "FSharp.Data.Sql"
+    let [<Literal>] FSHARP_DATA_SQL = "FSharp.Data.Sql"
     
     let createTypes(connnectionString, conStringName,dbVendor,resolutionPath,individualsAmount,useOptionTypes,owner,caseSensitivity, tableNames, odbcquote, sqliteLibrary, rootTypeName) = 
         let resolutionPath = 
@@ -51,7 +51,7 @@ type SqlTypeProvider(config: TypeProviderConfig) as this =
             | cs -> cs
                     
         let rootType, prov, con = 
-            let rootType = ctxt.ProvidedTypeDefinition(sqlRuntimeInfo.RuntimeAssembly,ns,rootTypeName,Some typeof<obj>, true)
+            let rootType = ctxt.ProvidedTypeDefinition(sqlRuntimeInfo.RuntimeAssembly,FSHARP_DATA_SQL,rootTypeName,Some typeof<obj>, true)
             let prov = ProviderBuilder.createProvider dbVendor resolutionPath config.ReferencedAssemblies config.RuntimeAssembly owner tableNames odbcquote sqliteLibrary
             let con = prov.CreateConnection conString
             this.Disposing.Add(fun _ -> 
@@ -287,7 +287,10 @@ type SqlTypeProvider(config: TypeProviderConfig) as this =
                 attProps @ relProps)
         
         let generateSprocMethod (container:ProvidedTypeDefinition) (con:IDbConnection) (sproc:CompileTimeSprocDefinition) =    
-            let sprocname = SchemaProjections.buildSprocName(sproc.Name.DbName)
+            
+            let sprocname = SchemaProjections.buildSprocName(sproc.Name.DbName) 
+                            |> SchemaProjections.avoidNameClashBy container.GetMember
+
             let rt = ctxt.ProvidedTypeDefinition(sprocname,None, true)
             let resultType = ctxt.ProvidedTypeDefinition("Result", None, true)
             resultType.AddMember(ctxt.ProvidedConstructor([ctxt.ProvidedParameter("sqlDataContext", typeof<ISqlDataContext>)]))
@@ -333,8 +336,12 @@ type SqlTypeProvider(config: TypeProviderConfig) as this =
                      ctxt.ProvidedMethod("InvokeAsync", parameters, asyncRet, invokeCode = QuotationHelpers.quoteRecord runtimeSproc (fun args var -> 
                         <@@ (((%%args.[0] : obj):?>ISqlDataContext)).CallSprocAsync(%%var, %%retColsExpr,  %%Expr.NewArray(typeof<obj>,List.map(fun e -> Expr.Coerce(e,typeof<obj>)) args.Tail)) @@>))]
             )
+                              
+            let niceUniqueSprocName = 
+                SchemaProjections.buildSprocName(sproc.Name.ProcName)
+                |> SchemaProjections.avoidNameClashBy container.GetProperty  
 
-            let p = ctxt.ProvidedProperty(SchemaProjections.buildSprocName(sproc.Name.ProcName), resultType, getterCode = (fun args -> <@@ ((%%args.[0] : obj) :?>ISqlDataContext) @@>) ) 
+            let p = ctxt.ProvidedProperty(niceUniqueSprocName, resultType, getterCode = (fun args -> <@@ ((%%args.[0] : obj) :?>ISqlDataContext) @@>) ) 
             let dbName = sproc.Name.DbName
             p.AddXmlDocDelayed(fun _ -> sprintf "<summary>%s</summary>" dbName)
             p
@@ -612,7 +619,7 @@ type SqlTypeProvider(config: TypeProviderConfig) as this =
         if (dbVendor <> DatabaseProviderTypes.MSACCESS) then con.Close()
         rootType
     
-    let paramSqlType = ctxt.ProvidedTypeDefinition(sqlRuntimeInfo.RuntimeAssembly, ns, "SqlDataProvider", Some(typeof<obj>), true)
+    let paramSqlType = ctxt.ProvidedTypeDefinition(sqlRuntimeInfo.RuntimeAssembly, FSHARP_DATA_SQL, "SqlDataProvider", Some(typeof<obj>), true)
     
     let conString = ctxt.ProvidedStaticParameter("ConnectionString",typeof<string>, "")
     let connStringName = ctxt.ProvidedStaticParameter("ConnectionStringName", typeof<string>, "")    
@@ -672,7 +679,7 @@ type SqlTypeProvider(config: TypeProviderConfig) as this =
     do paramSqlType.AddXmlDoc helpText               
     
     // add them to the namespace    
-    do this.AddNamespace(ns, [paramSqlType])
+    do this.AddNamespace(FSHARP_DATA_SQL, [paramSqlType])
                             
 [<assembly:TypeProviderAssembly>] 
 do()

--- a/src/SQLProvider/Utils.fs
+++ b/src/SQLProvider/Utils.fs
@@ -2,6 +2,9 @@
     
 open System
 open System.Collections.Generic
+open ProviderImplementation
+open ProviderImplementation.ProvidedTypes
+open Microsoft.FSharp.Core.CompilerServices
 
 module internal Utilities = 
     
@@ -250,6 +253,18 @@ module internal SchemaProjections =
         name.[0].ToString().ToLowerInvariant() + name.Substring(1)
       else name
     
+    /// Add ' until the property is non-unique
+    let rec avoidPropertyClash (container:ProvidedTypeDefinition) name =
+      match container.GetProperty name with
+      | null -> name
+      | _ -> avoidPropertyClash container (name + "'")
+    
+    /// Add ' until the type is unique
+    let rec avoidTypeNameClash (container:IProvidedNamespace) name =
+      match container.GetTypes() |> Array.exists (fun t -> t.Name = name) with
+      | false -> name
+      | true -> avoidTypeNameClash container (name + "'")
+        
     let buildTableName (tableName:string) = 
         //Current Name = [SCHEMA].[TABLE_NAME]
         if(tableName.Contains("."))

--- a/src/SQLProvider/Utils.fs
+++ b/src/SQLProvider/Utils.fs
@@ -2,9 +2,6 @@
     
 open System
 open System.Collections.Generic
-open ProviderImplementation
-open ProviderImplementation.ProvidedTypes
-open Microsoft.FSharp.Core.CompilerServices
 
 module internal Utilities = 
     

--- a/src/SQLProvider/Utils.fs
+++ b/src/SQLProvider/Utils.fs
@@ -253,17 +253,11 @@ module internal SchemaProjections =
         name.[0].ToString().ToLowerInvariant() + name.Substring(1)
       else name
     
-    /// Add ' until the property is non-unique
-    let rec avoidPropertyClash (container:ProvidedTypeDefinition) name =
-      match container.GetProperty name with
+    /// Add ' until the name is unique
+    let rec avoidNameClashBy nameFinder name =
+      match nameFinder name with
       | null -> name
-      | _ -> avoidPropertyClash container (name + "'")
-    
-    /// Add ' until the type is unique
-    let rec avoidTypeNameClash (container:IProvidedNamespace) name =
-      match container.GetTypes() |> Array.exists (fun t -> t.Name = name) with
-      | false -> name
-      | true -> avoidTypeNameClash container (name + "'")
+      | _ -> avoidNameClashBy nameFinder (name + "'")
         
     let buildTableName (tableName:string) = 
         //Current Name = [SCHEMA].[TABLE_NAME]

--- a/src/SQLProvider/Utils.fs
+++ b/src/SQLProvider/Utils.fs
@@ -254,10 +254,9 @@ module internal SchemaProjections =
       else name
     
     /// Add ' until the name is unique
-    let rec avoidNameClashBy nameFinder name =
-      match nameFinder name with
-      | null -> name
-      | _ -> avoidNameClashBy nameFinder (name + "'")
+    let rec avoidNameClashBy nameExists name =
+      if nameExists name then avoidNameClashBy nameExists (name + "'")
+      else name
         
     let buildTableName (tableName:string) = 
         //Current Name = [SCHEMA].[TABLE_NAME]


### PR DESCRIPTION
General fix:
 - If multiple stored procedures would get the same .NET names, the additional ones get apostrophes added to make them unique - eg. `Foo`, `Foo'`. See #470 

Postgres fixes:
 - No longer shows sprocs that the user isn't allowed to execute
 - No longer shows trigger sprocs (which cannot be manually executed)
 - No longer shows sprocs where any required parameter (input or input-output) lacks a suitable type mapping
 - Anonymous parameters in stored procedures are now given generic `param1`, `param2`, etc. names on the .NET side. Doesn't seem to break anything, even in the unlikely case where you explicitly named your *second* parameter `param1` for some reason.

Unrelated:
 - Ran the latest Paket and it updated Paket.Restore.Targets