### PR TITLE
REPRO test cases for #issue #483

### DIFF
--- a/src/SQLProvider/Providers.SQLite.fs
+++ b/src/SQLProvider/Providers.SQLite.fs
@@ -29,7 +29,7 @@ type internal SQLiteProvider(resolutionPath, referencedAssemblies, runtimeAssemb
             [   "System.Int16","smallint",10
                 "System.Int32","int",11
                 "System.Double","real",8
-                "System.Single","single",15
+                "System.Single","single",15 
                 "System.Double","float",8
                 "System.Double","double",8
                 "System.Decimal","money",7
@@ -583,7 +583,7 @@ type internal SQLiteProvider(resolutionPath, referencedAssemblies, runtimeAssemb
 
             // first build  the select statement, this is easy ...
             let selectcolumns =
-                if projectionColumns |> Seq.isEmpty then "1" else
+                if projectionColumns |> Seq.isEmpty then "*" else
                 String.Join(",",
                     [|for KeyValue(k,v) in projectionColumns do
                         if v.Count = 0 then   // if no columns exist in the projection then get everything

--- a/src/SQLProvider/Providers.SQLite.fs
+++ b/src/SQLProvider/Providers.SQLite.fs
@@ -583,7 +583,7 @@ type internal SQLiteProvider(resolutionPath, referencedAssemblies, runtimeAssemb
 
             // first build  the select statement, this is easy ...
             let selectcolumns =
-                if projectionColumns |> Seq.isEmpty then "*" else
+                if projectionColumns |> Seq.isEmpty then "1" else
                 String.Join(",",
                     [|for KeyValue(k,v) in projectionColumns do
                         if v.Count = 0 then   // if no columns exist in the projection then get everything

--- a/src/SQLProvider/SqlRuntime.QueryExpression.fs
+++ b/src/SQLProvider/SqlRuntime.QueryExpression.fs
@@ -56,7 +56,19 @@ module internal QueryExpressionTransformer =
                 elif ultimateChild.IsSome then
                     Some (alias,fst(ultimateChild.Value), Some(key,mi))
                 else None
-            | _ -> None
+            
+            | eOther -> 
+                if eOther.NodeType.ToString().Contains("Parameter") then
+                    let param = eOther :?> ParameterExpression
+                    if (param.Type.Name.Equals("SqlEntity")) then
+                        let alias = Utilities.resolveTuplePropertyName (param.Name) tupleIndex
+                        if aliasEntityDict.ContainsKey(alias) then
+                            Some (alias,aliasEntityDict.[alias].FullName, None)
+                        elif ultimateChild.IsSome then
+                            Some (alias,fst(ultimateChild.Value), None)
+                        else None
+                    else None
+                else None
 
         let (|GroupByAggregate|_|) (e:Expression) =
             // On group-by aggregates we support currently only direct calls like .Count() or .Sum()

--- a/tests/SqlProvider.Tests/QueryTests.fs
+++ b/tests/SqlProvider.Tests/QueryTests.fs
@@ -126,6 +126,46 @@ let ``simple select with exactly one``() =
         }
     Assert.AreEqual("ALFKI", qry)  
 
+[<Test >]
+let ``option from join select with exactly one``() =
+    let dc = sql.GetDataContext()
+    let qry = 
+        query {
+            for cust in dc.Main.Customers do
+            join ord in dc.Main.Orders on (cust.CustomerId = ord.CustomerId)
+            where (cust.CustomerId = "ALFKI" && ord.OrderId = (int64 10643))
+            select (Some (cust, ord))
+            exactlyOneOrDefault
+        } 
+
+    match qry with
+    | Some(cust, ord) ->
+        let id = cust.CustomerId
+        let ordId = ord.OrderId
+        Assert.AreEqual("ALFKI",id)
+        Assert.AreEqual(10643,ordId)
+    | None ->
+        Assert.Fail()
+
+[<Test >]
+let ``option from simple select with exactly one``() =
+    let dc = sql.GetDataContext()
+    let qry = 
+        query {
+            for cust in dc.Main.Customers do
+            where (cust.CustomerId = "ALFKI")
+            select (Some cust)
+            exactlyOneOrDefault
+        } 
+
+    match qry with
+    | Some cust ->
+        let id = cust.CustomerId
+        Assert.AreEqual("ALFKI",id)
+    | None ->
+        Assert.Fail()
+     
+
 [<Test>]
 let ``simple select with exactly one when not exists``() =
     let dc = sql.GetDataContext()
@@ -138,6 +178,7 @@ let ``simple select with exactly one when not exists``() =
         }
     Assert.IsTrue(isNull(qry))
     Assert.AreEqual(null, qry)  
+
 
 [<Test >]
 let ``simple select with head``() =


### PR DESCRIPTION
select (Some ...) only works when... is a tuple e.g. (cust,ord) from a join 
but it doesn't when it is a simple select (Some cust) from a table
in the latter case there are no meaningful keys/values in the data dictionary of the query builder