### PR TITLE
Map 'ltree' type to strings

### DIFF
--- a/src/SQLProvider/Providers.Postgresql.fs
+++ b/src/SQLProvider/Providers.Postgresql.fs
@@ -169,7 +169,7 @@ module PostgreSQL =
               "jsonb"                       , typemap<string>                     ["Jsonb"]
               "line"                        , namemap "NpgsqlLine"                ["Line"]
               "lseg"                        , namemap "NpgsqlLSeg"                ["LSeg"]
-              "ltree"                       , typemap<string>                     ["LTree"]
+              "ltree"                       , typemap<string>                     ["Unknown"]
               "macaddr"                     , typemap<PhysicalAddress>            ["MacAddr"]
               "money"                       , typemap<decimal>                    ["Money"]
               "name"                        , typemap<string>                     ["Name"]

--- a/src/SQLProvider/Providers.Postgresql.fs
+++ b/src/SQLProvider/Providers.Postgresql.fs
@@ -169,6 +169,7 @@ module PostgreSQL =
               "jsonb"                       , typemap<string>                     ["Jsonb"]
               "line"                        , namemap "NpgsqlLine"                ["Line"]
               "lseg"                        , namemap "NpgsqlLSeg"                ["LSeg"]
+              "ltree"                       , typemap<string>                     ["LTree"]
               "macaddr"                     , typemap<PhysicalAddress>            ["MacAddr"]
               "money"                       , typemap<decimal>                    ["Money"]
               "name"                        , typemap<string>                     ["Name"]


### PR DESCRIPTION
[`ltree` is an extension that ships with default PostgreSQL installations](https://www.postgresql.org/docs/10/static/ltree.html), and allows for efficient storage and querying of tree-like data structures. Syntax is `'Root.Branch.Leaf'::ltree`

Currently SQLProvider doesn't support it at all, and if you have a table with a `ltree`-type column that entire table will error out.

This PR adds `ltree` to the typemap dictionary, handling it as plain strings (it's a start!). Using the `Unknown` Npgsql mapping means the string will be cast at runtime to the proper `ltree` type.
