### PR TITLE
Fix Travis delayed initialization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then rm -rf /usr/local/var/postgres; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then initdb /usr/local/var/postgres; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pg_ctl -D /usr/local/var/postgres start; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then until pg_ctl status -D /usr/local/var/postgres; do >1 echo "Postgres is unavailable - sleeping"; sleep 1; done; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then until pg_ctl -D /usr/local/var/postgres status; do echo "Postgres is unavailable - sleeping"; sleep 0.05; done; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then createuser -s postgres; fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then rm -rf /usr/local/var/postgres; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then initdb /usr/local/var/postgres; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pg_ctl -D /usr/local/var/postgres start; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then until pg_ctl status /usr/local/var/postgres; do >1 echo "Postgres is unavailable - sleeping"; sleep 1; done; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then until pg_ctl status -D /usr/local/var/postgres; do >1 echo "Postgres is unavailable - sleeping"; sleep 1; done; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then createuser -s postgres; fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then rm -rf /usr/local/var/postgres; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then initdb /usr/local/var/postgres; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pg_ctl -D /usr/local/var/postgres start; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then until pg_ctl status; do >1 echo "Postgres is unavailable - sleeping"; sleep 1; done; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then until pg_ctl status /usr/local/var/postgres; do >1 echo "Postgres is unavailable - sleeping"; sleep 1; done; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then createuser -s postgres; fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ before_script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then rm -rf /usr/local/var/postgres; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then initdb /usr/local/var/postgres; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pg_ctl -D /usr/local/var/postgres start; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then until pg_ctl status; do >1 echo "Postgres is unavailable - sleeping"; sleep 1; done; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then createuser -s postgres; fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,7 @@ before_script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then rm -rf /usr/local/var/postgres; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then initdb /usr/local/var/postgres; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pg_ctl -D /usr/local/var/postgres start; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then until pg_ctl -D /usr/local/var/postgres status; do echo "Postgres is unavailable - sleeping"; sleep 0.05; done; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then createuser -s postgres; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then until createuser -s postgres; do echo "Postgres is unavailable - sleeping"; sleep 0.05; done; fi
 
 script:
   - ./build.sh All


### PR DESCRIPTION
Adds a loop to ensure that the `createuser` init command goes through even if it takes a few more split-seconds for the postgresql service to start.

As a test, I've restarted the job five times just to be sure, and hasn't failed so far (most time taken has been 200ms).