### PR TITLE
WIP: Case when else support

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,9 @@
+### 1.1.30 - 01.02.2018
+* Postgres ltree mapping PR #510
+* Single table group-by over a constant value PR #511
+* More aggregate functions: StdDev, Variance
+* More canonical math functions: Sqrt, Sin, Cos, Tan, ASin, ACos, ATan, Math.Max and Math.Min
+
 ### 1.1.29 - 25.01.2018
 * Firebird fixes for numeric columns and column descriptions, PR #508
 

--- a/docs/content/core/querying.fsx
+++ b/docs/content/core/querying.fsx
@@ -228,6 +228,17 @@ Math.Min(x,y)   | SELECT(MIN) | LEAST     | LEAST   | LEAST | MIN        | iif(x
 Microsoft SQL Server doesn't have Greatest and Least functions, so that will be done via nested SQL clause: (select max(v) from (values (x), (y)) as value(v))
 It might also not be standard ODBC, but should work e.g. on Amazon Redshift.
 
+#### Condition operations
+
+| .NET            | MsSqlServer| PostgreSql| MySql    | Oracle   | SQLite   | MSAccess  | Odbc     | Notes
+|-----------------|------------|-----------|----------|----------|----------|-----------|----------|---------------|
+if x then y else z| CASE WHEN  | CASE WHEN | IF(x,y,z)| CASE WHEN| CASE WHEN| iif(x,y,z)| CASE WHEN|   |
+
+If the condition is not using SQL columns, it will be parsed before creation of SQL.
+If the condition is containing columns, it will be parsed into SQL.
+
+If the condition is in the result of projection (the final select clause), it will be parsed after execution of the SQL.
+
 #### Aggregate Functions 
 
 Also you can use these to return an aggregated value, or in a group-by clause:

--- a/docs/content/core/querying.fsx
+++ b/docs/content/core/querying.fsx
@@ -179,7 +179,7 @@ Operations do support parameters to be either constants or other SQL-columns (e.
 #### .NET DateTime Functions
 
 | .NET         | MsSqlServer    | PostgreSql| MySql    | Oracle    | SQLite  | MSAccess  | Odbc      |  Notes
-|--------------|----------------|-----------|----------|-----------|---------|-----------|-----------|--------------------------|
+|--------------|----------------|-----------|----------|-----------|---------|-----------|-----------|-------------------|
 .Date          | CAST(AS DATE)  | DATE_TRUNC| DATE     | TRUNC     | STRFTIME| DateValue(Format)| CONVERT(SQL_DATE)  |   |
 .Year          | YEAR           | DATE_PART | YEAR     | EXTRACT   | STRFTIME| Year      | YEAR       |   |
 .Month         | MONTH          | DATE_PART | MONTH    | EXTRACT   | STRFTIME| Month     | MONTH      |   |
@@ -203,7 +203,7 @@ Odbc standard doesn't seem to have a date-add functionality.
 #### Numerical Functions (e.g. Microsoft.FSharp.Core.Operators)
 
 | .NET          | MsSqlServer| PostgreSql| MySql   | Oracle| SQLite     | MSAccess| Odbc     |  Notes
-|---------------|------------|-----------|---------|-------|------------|---------|----------|--------------------------|
+|---------------|------------|-----------|---------|-------|------------|---------|----------|-------------------|
 abs(i)          | ABS        | ABS       | ABS     | ABS   | ABS        | Abs     | ABS      |   |
 ceil(i)         | CEILING    | CEILING   | CEILING | CEIL  | CAST + 0.5 | Fix+1   | CEILING  |   |
 floor(i)        | FLOOR      | FLOOR     | FLOOR   | FLOOR | CAST AS INT| Int     | FLOOR    |   |
@@ -233,7 +233,7 @@ It might also not be standard ODBC, but should work e.g. on Amazon Redshift.
 Also you can use these to return an aggregated value, or in a group-by clause:
 
 | .NET          | MsSqlServer| PostgreSql| MySql   | Oracle   | SQLite | MSAccess| Odbc     |  Notes
-|---------------|------------|-----------|---------|----------|--------|---------|----------|--------------------------|
+|---------------|------------|-----------|---------|----------|--------|---------|----------|--------------------|
 count           | COUNT      | COUNT     | COUNT   | COUNT    | COUNT  | COUNT   | COUNT    |   |
 sum             | SUM        | SUM       | SUM     | SUM      | SUM    | SUM     | SUM      |   |
 min             | MIN        | MIN       | MIN     | MIN      | MIN    | MIN     | MIN      |   |

--- a/src/SQLProvider/AssemblyInfo.fs
+++ b/src/SQLProvider/AssemblyInfo.fs
@@ -5,13 +5,13 @@ open System.Reflection
 [<assembly: AssemblyTitleAttribute("SQLProvider")>]
 [<assembly: AssemblyProductAttribute("SQLProvider")>]
 [<assembly: AssemblyDescriptionAttribute("Type providers for SQL database access.")>]
-[<assembly: AssemblyVersionAttribute("1.1.29")>]
-[<assembly: AssemblyFileVersionAttribute("1.1.29")>]
+[<assembly: AssemblyVersionAttribute("1.1.30")>]
+[<assembly: AssemblyFileVersionAttribute("1.1.30")>]
 do ()
 
 module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyTitle = "SQLProvider"
     let [<Literal>] AssemblyProduct = "SQLProvider"
     let [<Literal>] AssemblyDescription = "Type providers for SQL database access."
-    let [<Literal>] AssemblyVersion = "1.1.29"
-    let [<Literal>] AssemblyFileVersion = "1.1.29"
+    let [<Literal>] AssemblyVersion = "1.1.30"
+    let [<Literal>] AssemblyFileVersion = "1.1.30"

--- a/src/SQLProvider/Operators.fs
+++ b/src/SQLProvider/Operators.fs
@@ -52,15 +52,15 @@ module ColumnSchema =
 
     type CanonicalOp =
     //String functions
-    | Substring of SqlIntOrColumn
-    | SubstringWithLength of SqlIntOrColumn*SqlIntOrColumn
+    | Substring of SqlItemOrColumn
+    | SubstringWithLength of SqlItemOrColumn*SqlItemOrColumn
     | ToUpper
     | ToLower
     | Trim
     | Length
-    | Replace of SqlStringOrColumn*SqlStringOrColumn
-    | IndexOf of SqlStringOrColumn
-    | IndexOfStart of SqlStringOrColumn*SqlIntOrColumn
+    | Replace of SqlItemOrColumn*SqlItemOrColumn
+    | IndexOf of SqlItemOrColumn
+    | IndexOfStart of SqlItemOrColumn*SqlItemOrColumn
     // Date functions
     | Date
     | Year
@@ -69,11 +69,11 @@ module ColumnSchema =
     | Hour
     | Minute
     | Second
-    | AddYears of SqlIntOrColumn
+    | AddYears of SqlItemOrColumn
     | AddMonths of int
-    | AddDays of SqlFloatOrColumn
+    | AddDays of SqlItemOrColumn
     | AddHours of float
-    | AddMinutes of SqlFloatOrColumn
+    | AddMinutes of SqlItemOrColumn
     | AddSeconds of float
     // Numerical functions
     | Abs
@@ -89,34 +89,27 @@ module ColumnSchema =
     | ASin
     | ACos
     | ATan
-    | Greatest of SqlDecimalOrColumn
-    | Least of SqlDecimalOrColumn
+    | Greatest of SqlItemOrColumn
+    | Least of SqlItemOrColumn
     // Other
     | BasicMath of string*obj //operation, constant
     | BasicMathOfColumns of string*string*SqlColumnType //operation, alias, column
+    | CaseSql of SqlItemOrColumn * SqlItemOrColumn
 
     and SqlColumnType =
     | KeyColumn of string
     | CanonicalOperation of CanonicalOp * SqlColumnType
     | GroupColumn of AggregateOperation * SqlColumnType
 
-    and SqlStringOrColumn =
-    | SqlStr of string
-    | SqlStrCol of string*SqlColumnType //alias*column
-
     // More recursion, because you mighn want to say e.g.
     // where (x.Substring(x.IndexOf("."), (x.Length-x.IndexOf("."))
-    and SqlIntOrColumn =
+    and SqlItemOrColumn =
+    | SqlCol of string*SqlColumnType //alias*column
     | SqlInt of int
-    | SqlIntCol of string*SqlColumnType //alias*column
-
-    and SqlFloatOrColumn =
     | SqlFloat of float
-    | SqlNumCol of string*SqlColumnType //alias*column
-
-    and SqlDecimalOrColumn =
     | SqlDecimal of decimal
-    | SqlDecimalCol of string*SqlColumnType //alias*column
+    | SqlStr of string
+    | SqlDateTime of System.DateTime
 
 
 // Dummy operators, these are placeholders that are replaced in the expression tree traversal with special server-side operations such as In, Like

--- a/src/SQLProvider/Operators.fs
+++ b/src/SQLProvider/Operators.fs
@@ -121,11 +121,7 @@ module ColumnSchema =
     // where (x.Substring(x.IndexOf("."), (x.Length-x.IndexOf("."))
     and SqlItemOrColumn =
     | SqlCol of string*SqlColumnType //alias*column
-    | SqlInt of int
-    | SqlFloat of float
-    | SqlDecimal of decimal
-    | SqlStr of string
-    | SqlDateTime of System.DateTime
+    | SqlConstant of obj
 
     type ProjectionParameter =
     | EntityColumn of string

--- a/src/SQLProvider/Providers.Firebird.fs
+++ b/src/SQLProvider/Providers.Firebird.fs
@@ -137,23 +137,23 @@ module Firebird =
             let column = fieldNotation al col
             match cf with
             // String functions
-            | Replace(SqlStr(searchItm),SqlStrCol(al2, col2)) -> sprintf "REPLACE(%s,'%s',%s)" column searchItm (fieldNotation al2 col2)
-            | Replace(SqlStrCol(al2, col2),SqlStr(toItm)) -> sprintf "REPLACE(%s,%s,'%s')" column (fieldNotation al2 col2) toItm
-            | Replace(SqlStrCol(al2, col2),SqlStrCol(al3, col3)) -> sprintf "REPLACE(%s,%s,%s)" column (fieldNotation al2 col2) (fieldNotation al3 col3)
+            | Replace(SqlStr(searchItm),SqlCol(al2, col2)) -> sprintf "REPLACE(%s,'%s',%s)" column searchItm (fieldNotation al2 col2)
+            | Replace(SqlCol(al2, col2),SqlStr(toItm)) -> sprintf "REPLACE(%s,%s,'%s')" column (fieldNotation al2 col2) toItm
+            | Replace(SqlCol(al2, col2),SqlCol(al3, col3)) -> sprintf "REPLACE(%s,%s,%s)" column (fieldNotation al2 col2) (fieldNotation al3 col3)
             | Substring(SqlInt startPos) -> sprintf "SUBSTR(%s FROM %i)" column startPos
-            | Substring(SqlIntCol(al2, col2)) -> sprintf "SUBSTR(%s FROM %s)" column (fieldNotation al2 col2)
+            | Substring(SqlCol(al2, col2)) -> sprintf "SUBSTR(%s FROM %s)" column (fieldNotation al2 col2)
             | SubstringWithLength(SqlInt startPos,SqlInt strLen) -> sprintf "SUBSTR(%s FROM %i FOR %i)" column startPos strLen
-            | SubstringWithLength(SqlInt startPos,SqlIntCol(al2, col2)) -> sprintf "SUBSTR(%s FROM %i FOR %s)" column startPos (fieldNotation al2 col2)
-            | SubstringWithLength(SqlIntCol(al2, col2),SqlInt strLen) -> sprintf "SUBSTR(%s FROM %s FOR %i)" column (fieldNotation al2 col2) strLen
-            | SubstringWithLength(SqlIntCol(al2, col2),SqlIntCol(al3, col3)) -> sprintf "SUBSTR(%s FROM %s FOR %s)" column (fieldNotation al2 col2) (fieldNotation al3 col3)
+            | SubstringWithLength(SqlInt startPos,SqlCol(al2, col2)) -> sprintf "SUBSTR(%s FROM %i FOR %s)" column startPos (fieldNotation al2 col2)
+            | SubstringWithLength(SqlCol(al2, col2),SqlInt strLen) -> sprintf "SUBSTR(%s FROM %s FOR %i)" column (fieldNotation al2 col2) strLen
+            | SubstringWithLength(SqlCol(al2, col2),SqlCol(al3, col3)) -> sprintf "SUBSTR(%s FROM %s FOR %s)" column (fieldNotation al2 col2) (fieldNotation al3 col3)
             | Trim -> sprintf "TRIM(%s)" column
             | Length -> sprintf "CHAR_LENGTH(%s)" column
             | IndexOf(SqlStr search) -> sprintf "POSITION('%s',%s)" search column
-            | IndexOf(SqlStrCol(al2, col2)) -> sprintf "POSITION(%s,%s)" (fieldNotation al2 col2) column
+            | IndexOf(SqlCol(al2, col2)) -> sprintf "POSITION(%s,%s)" (fieldNotation al2 col2) column
             | IndexOfStart(SqlStr(search),(SqlInt startPos)) -> sprintf "POSITION('%s',%s,%d)" search column startPos
-            | IndexOfStart(SqlStr(search),SqlIntCol(al2, col2)) -> sprintf "POSITION('%s',%s,%s)" search column (fieldNotation al2 col2)
-            | IndexOfStart(SqlStrCol(al2, col2),(SqlInt startPos)) -> sprintf "POSITION(%s,%s,%d)" (fieldNotation al2 col2) column startPos
-            | IndexOfStart(SqlStrCol(al2, col2),SqlIntCol(al3, col3)) -> sprintf "POSITION(%s,%s,%s)" (fieldNotation al2 col2) column (fieldNotation al3 col3)
+            | IndexOfStart(SqlStr(search),SqlCol(al2, col2)) -> sprintf "POSITION('%s',%s,%s)" search column (fieldNotation al2 col2)
+            | IndexOfStart(SqlCol(al2, col2),(SqlInt startPos)) -> sprintf "POSITION(%s,%s,%d)" (fieldNotation al2 col2) column startPos
+            | IndexOfStart(SqlCol(al2, col2),SqlCol(al3, col3)) -> sprintf "POSITION(%s,%s,%s)" (fieldNotation al2 col2) column (fieldNotation al3 col3)
             // Date functions
             | Date -> sprintf "CAST (%s AS DATE)" column
             | Year -> sprintf "EXTRACT(YEAR FROM %s)" column
@@ -163,22 +163,32 @@ module Firebird =
             | Minute -> sprintf "EXTRACT(MINUTE FROM %s)" column
             | Second -> sprintf "EXTRACT(SECOND FROM %s)" column
             | AddYears(SqlInt x) -> sprintf "DATEADD(%d YEAR TO %s)" x column
-            | AddYears(SqlIntCol(al2, col2)) -> sprintf "DATEADD(%s YEAR TO %s)" (fieldNotation al2 col2) column
+            | AddYears(SqlCol(al2, col2)) -> sprintf "DATEADD(%s YEAR TO %s)" (fieldNotation al2 col2) column
             | AddMonths x -> sprintf "DATEADD(%d MONTH TO %s)" x column
             | AddDays(SqlFloat x) -> sprintf "DATEADD(%f DAY TO %s)" x column // SQL ignores decimal part :-(
-            | AddDays(SqlNumCol(al2, col2)) -> sprintf "DATEADD(%s DAY TO %s)" (fieldNotation al2 col2) column
+            | AddDays(SqlCol(al2, col2)) -> sprintf "DATEADD(%s DAY TO %s)" (fieldNotation al2 col2) column
             | AddHours x -> sprintf "DATEADD(%f HOUR TO %s)" x column
             | AddMinutes(SqlFloat x) -> sprintf "DATEADD(%f MINUTE TO %s)" x column
-            | AddMinutes(SqlNumCol(al2, col2)) -> sprintf "DATEADD(%s MINUTE TO %s)" (fieldNotation al2 col2) column
+            | AddMinutes(SqlCol(al2, col2)) -> sprintf "DATEADD(%s MINUTE TO %s)" (fieldNotation al2 col2) column
             | AddSeconds x -> sprintf "DATEADD(%f SECOND TO %s)" x column
             // Math functions
             | Truncate -> sprintf "TRUNC(%s)" column
             | BasicMathOfColumns(o, a, c) -> sprintf "(%s %s %s)" column o (fieldNotation a c)
             | BasicMath(o, par) when (par :? String || par :? Char) -> sprintf "(%s %s '%O')" column o par            
             | Greatest(SqlDecimal x) -> sprintf "GREATEST(%M, %s)" x column
-            | Greatest(SqlDecimalCol(al2, col2)) -> sprintf "GREATEST(%s, %s)" (fieldNotation al2 col2) column
+            | Greatest(SqlCol(al2, col2)) -> sprintf "GREATEST(%s, %s)" (fieldNotation al2 col2) column
             | Least(SqlDecimal x) -> sprintf "LEAST(%M, %s)" x column
-            | Least(SqlDecimalCol(al2, col2)) -> sprintf "LEAST(%s, %s)" (fieldNotation al2 col2) column
+            | Least(SqlCol(al2, col2)) -> sprintf "LEAST(%s, %s)" (fieldNotation al2 col2) column
+            //if-then-else
+            | CaseSql(SqlCol(al2, col2), SqlCol(al3, col3)) -> sprintf "CASE WHEN %s THEN %s ELSE %s END" column (fieldNotation al2 col2) (fieldNotation al3 col3)
+            | CaseSql(SqlCol(al2, col2), SqlInt(itm)) -> sprintf "CASE WHEN %s THEN %s ELSE %d END" column (fieldNotation al2 col2) itm
+            | CaseSql(SqlInt(itm), SqlCol(al2, col2)) -> sprintf "CASE WHEN %s THEN %d ELSE %s END" column itm (fieldNotation al2 col2)
+            | CaseSql(SqlCol(al2, col2), SqlDecimal(itm)) -> sprintf "CASE WHEN %s THEN %s ELSE %M END" column (fieldNotation al2 col2) itm
+            | CaseSql(SqlDecimal(itm), SqlCol(al2, col2)) -> sprintf "CASE WHEN %s THEN %M ELSE %s END" column itm (fieldNotation al2 col2)
+            | CaseSql(SqlCol(al2, col2), SqlDateTime(itm)) -> sprintf "CASE WHEN %s THEN %s ELSE '%s' END" column (fieldNotation al2 col2) (itm.ToString("yyyy-MM-dd HH:mm:ss"))
+            | CaseSql(SqlDateTime(itm), SqlCol(al2, col2)) -> sprintf "CASE WHEN %s THEN '%s' ELSE %s END" column (itm.ToString("yyyy-MM-dd HH:mm:ss")) (fieldNotation al2 col2)
+            | CaseSql(SqlCol(al2, col2), SqlStr(itm)) -> sprintf "CASE WHEN %s THEN %s ELSE '%s' END" column (fieldNotation al2 col2) itm
+            | CaseSql(SqlStr(itm), SqlCol(al2, col2)) -> sprintf "CASE WHEN %s THEN '%s' ELSE %s END" column itm (fieldNotation al2 col2)
             | _ -> Utilities.genericFieldNotation (fieldNotation al) colSprint c
         | _ -> Utilities.genericFieldNotation (fieldNotation al) colSprint c
 

--- a/src/SQLProvider/Providers.MSAccess.fs
+++ b/src/SQLProvider/Providers.MSAccess.fs
@@ -330,23 +330,24 @@ type internal MSAccessProvider() =
                     let column = fieldNotation al col
                     match cf with
                     // String functions
-                    | Replace(SqlStr(searchItm),SqlCol(al2, col2)) -> sprintf "REPLACE(%s,%s,%s)" column (fieldParam (box searchItm)) (fieldNotation al2 col2)
-                    | Replace(SqlCol(al2, col2),SqlStr(toItm)) -> sprintf "REPLACE(%s,%s,%s)" column (fieldNotation al2 col2) (fieldParam (box toItm))
+                    | Replace(SqlConstant searchItm,SqlCol(al2, col2)) -> sprintf "REPLACE(%s,%s,%s)" column (fieldParam searchItm) (fieldNotation al2 col2)
+                    | Replace(SqlCol(al2, col2), SqlConstant toItm) -> sprintf "REPLACE(%s,%s,%s)" column (fieldNotation al2 col2) (fieldParam toItm)
                     | Replace(SqlCol(al2, col2),SqlCol(al3, col3)) -> sprintf "REPLACE(%s,%s,%s)" column (fieldNotation al2 col2) (fieldNotation al3 col3)
-                    | Substring(SqlInt startPos) -> sprintf "Mid(%s, %i)" column startPos
+                    | Replace(SqlConstant searchItm, SqlConstant toItm) -> sprintf "REPLACE(%s,%s,%s)" column (fieldParam searchItm) (fieldParam toItm)
+                    | Substring(SqlConstant startPos) -> sprintf "Mid(%s, %s)" column (fieldParam startPos)
                     | Substring(SqlCol(al2, col2)) -> sprintf "Mid(%s, %s)" column (fieldNotation al2 col2)
-                    | SubstringWithLength(SqlInt startPos,SqlInt strLen) -> sprintf "Mid(%s, %i, %i)" column startPos strLen
-                    | SubstringWithLength(SqlInt startPos,SqlCol(al2, col2)) -> sprintf "Mid(%s, %i, %s)" column startPos (fieldNotation al2 col2)
-                    | SubstringWithLength(SqlCol(al2, col2),SqlInt strLen) -> sprintf "Mid(%s, %s, %i)" column (fieldNotation al2 col2) strLen
-                    | SubstringWithLength(SqlCol(al2, col2),SqlCol(al3, col3)) -> sprintf "Mid(%s, %s, %s)" column (fieldNotation al2 col2) (fieldNotation al3 col3)
+                    | SubstringWithLength(SqlConstant startPos, SqlConstant strLen) -> sprintf "Mid(%s, %s, %s)" column (fieldParam startPos) (fieldParam strLen)
+                    | SubstringWithLength(SqlConstant startPos,SqlCol(al2, col2)) -> sprintf "Mid(%s, %s, %s)" column (fieldParam startPos) (fieldNotation al2 col2)
+                    | SubstringWithLength(SqlCol(al2, col2), SqlConstant strLen) -> sprintf "Mid(%s, %s, %s)" column (fieldNotation al2 col2) (fieldParam strLen)
+                    | SubstringWithLength(SqlCol(al2, col2), SqlCol(al3, col3)) -> sprintf "Mid(%s, %s, %s)" column (fieldNotation al2 col2) (fieldNotation al3 col3)
                     | Trim -> sprintf "Trim(%s)" column
                     | Length -> sprintf "Len(%s)" column
-                    | IndexOf(SqlStr search) -> sprintf "InStr(%s,%s)" (fieldParam (box search)) column
+                    | IndexOf(SqlConstant search) -> sprintf "InStr(%s,%s)" (fieldParam search) column
                     | IndexOf(SqlCol(al2, col2)) -> sprintf "InStr(%s,%s)" (fieldNotation al2 col2) column
-                    | IndexOfStart(SqlStr(search),(SqlInt startPos)) -> sprintf "InStr(%d,%s,%s)" startPos (fieldParam (box search)) column
-                    | IndexOfStart(SqlStr(search),SqlCol(al2, col2)) -> sprintf "InStr(%s,%s,%s)" (fieldNotation al2 col2) (fieldParam (box search)) column
-                    | IndexOfStart(SqlCol(al2, col2),(SqlInt startPos)) -> sprintf "InStr(%d,%s,%s)" startPos (fieldNotation al2 col2) column
-                    | IndexOfStart(SqlCol(al2, col2),SqlCol(al3, col3)) -> sprintf "InStr(%s,%s,%s)" (fieldNotation al3 col3) (fieldNotation al2 col2) column
+                    | IndexOfStart(SqlConstant search, SqlConstant startPos) -> sprintf "InStr(%s,%s,%s)" (fieldParam startPos) (fieldParam search) column
+                    | IndexOfStart(SqlConstant search, SqlCol(al2, col2)) -> sprintf "InStr(%s,%s,%s)" (fieldNotation al2 col2) (fieldParam search) column
+                    | IndexOfStart(SqlCol(al2, col2), SqlConstant startPos) -> sprintf "InStr(%s,%s,%s)" (fieldParam startPos) (fieldNotation al2 col2) column
+                    | IndexOfStart(SqlCol(al2, col2), SqlCol(al3, col3)) -> sprintf "InStr(%s,%s,%s)" (fieldNotation al3 col3) (fieldNotation al2 col2) column
                     | ToUpper -> sprintf "UCase(%s)" column
                     | ToLower -> sprintf "LCase(%s)" column
                     // Date functions
@@ -357,13 +358,13 @@ type internal MSAccessProvider() =
                     | Hour -> sprintf "Hour(%s)" column
                     | Minute -> sprintf "Minute(%s)" column
                     | Second -> sprintf "Second(%s)" column
-                    | AddYears(SqlInt x) -> sprintf "DateAdd(\"yyyy\", %d, %s)" x column
+                    | AddYears(SqlConstant x) -> sprintf "DateAdd(\"yyyy\", %s, %s)" (fieldParam x) column
                     | AddYears(SqlCol(al2, col2)) -> sprintf "DateAdd(\"yyyy\", %s, %s)" (fieldNotation al2 col2) column
                     | AddMonths x -> sprintf "DateAdd(\"m\", %d, %s)" x column
-                    | AddDays(SqlFloat x) -> sprintf "DateAdd(\"d\", %f, %s)" x column // SQL ignores decimal part :-(
+                    | AddDays(SqlConstant x) -> sprintf "DateAdd(\"d\", %s, %s)" (fieldParam x) column // SQL ignores decimal part :-(
                     | AddDays(SqlCol(al2, col2)) -> sprintf "DateAdd(\"d\", %s, %s)" (fieldNotation al2 col2) column
                     | AddHours x -> sprintf "DateAdd(\"h\", %f, %s)" x column
-                    | AddMinutes(SqlFloat x) -> sprintf "DateAdd(\"n\", %f, %s)" x column
+                    | AddMinutes(SqlConstant x) -> sprintf "DateAdd(\"n\", %s, %s)" (fieldParam x) column
                     | AddMinutes(SqlCol(al2, col2)) -> sprintf "DateAdd(\"n\", %s, %s)" (fieldNotation al2 col2) column
                     | AddSeconds x -> sprintf "DateAdd(\"s\", %f, %s)" x column
                     // Math functions
@@ -375,25 +376,16 @@ type internal MSAccessProvider() =
                     | ASin -> sprintf "Atn(%s / Sqr(1 - %s * %s))" column column column
                     | ACos -> sprintf "Atn(-%s / Sqr(-%s * %s + 1)) + 2 * Atn(1)" column column column
                     | BasicMathOfColumns(o, a, c) -> sprintf "(%s %s %s)" column (o.Replace("||", "&")) (fieldNotation a c)
-                    | BasicMath(o, par) when (par :? String || par :? Char) -> sprintf "(%s %s %s)" column (o.Replace("||", "&")) (fieldParam (box par))
-                    | Greatest(SqlDecimal x) -> sprintf "(iif(%M > %s, %M, %s))" x column x column
+                    | BasicMath(o, par) when (par :? String || par :? Char) -> sprintf "(%s %s %s)" column (o.Replace("||", "&")) (fieldParam par)
+                    | Greatest(SqlConstant x) -> sprintf "(iif(%s > %s, %s, %s))" (fieldParam x) column (fieldParam x) column
                     | Greatest(SqlCol(al2, col2)) -> sprintf "(iif(%s > %s, %s, %s))" (fieldNotation al2 col2) column (fieldNotation al2 col2) column
-                    | Least(SqlDecimal x) -> sprintf "(iif(%M < %s, %M, %s)" x column x column
+                    | Least(SqlConstant x) -> sprintf "(iif(%s < %s, %s, %s)" (fieldParam x) column (fieldParam x) column
                     | Least(SqlCol(al2, col2)) -> sprintf "(iif(%s < %s, %s, %s))" (fieldNotation al2 col2) column (fieldNotation al2 col2) column
                     //if-then-else
                     | CaseSql(f, SqlCol(al2, col2)) -> sprintf "iif(%s, %s, %s)" (buildf f) column (fieldNotation al2 col2)
-                    | CaseSql(f, SqlInt(itm)) -> sprintf "iif(%s, %s, %d)" (buildf f) column itm
-                    | CaseSql(f, SqlDecimal(itm)) -> sprintf "iif(%s, %s, %M)" (buildf f) column itm
-                    | CaseSql(f, SqlDateTime(itm)) -> sprintf "iif(%s, %s, %s)" (buildf f) column (fieldParam (box itm))
-                    | CaseSql(f, SqlStr(itm)) -> sprintf "iif(%s, %s, %s)" (buildf f) column (fieldParam (box itm))
-                    | CaseNotSql(f, SqlInt(itm)) -> sprintf "iif(%s, %d, %s)" (buildf f) itm column
-                    | CaseNotSql(f, SqlDecimal(itm)) -> sprintf "iif(%s, %M, %s)" (buildf f) itm column
-                    | CaseNotSql(f, SqlDateTime(itm)) -> sprintf "iif(%s, %s, %s)" (buildf f) (fieldParam (box itm)) column
-                    | CaseNotSql(f, SqlStr(itm)) -> sprintf "iif(%s, %s, %s)" (buildf f) (fieldParam (box itm)) column
-                    | CaseSqlPlain(f, SqlInt(itm), SqlInt(itm2)) -> sprintf "iif(%s, %d, %d)" (buildf f) itm itm2
-                    | CaseSqlPlain(f, SqlDecimal(itm), SqlDecimal(itm2)) -> sprintf "iif(%s,%M,%M)" (buildf f) itm itm2
-                    | CaseSqlPlain(f, SqlDateTime(itm), SqlDateTime(itm2)) -> sprintf "iif(%s,%s,%s)" (buildf f) (fieldParam (box itm)) (fieldParam (box itm2))
-                    | CaseSqlPlain(f, SqlStr(itm), SqlStr(itm2)) -> sprintf "iif(%s,%s,%s)" (buildf f) (fieldParam (box itm)) (fieldParam (box itm2))
+                    | CaseSql(f, SqlConstant itm) -> sprintf "iif(%s, %s, %s)" (buildf f) column (fieldParam itm)
+                    | CaseNotSql(f, SqlConstant itm) -> sprintf "iif(%s, %s, %s)" (buildf f) (fieldParam itm) column
+                    | CaseSqlPlain(f, SqlConstant itm, SqlConstant itm2) -> sprintf "iif(%s,%s,%s)" (buildf f) (fieldParam itm) (fieldParam itm2)
                     | _ -> Utilities.genericFieldNotation (fieldNotation al) colSprint c
                 | GroupColumn (StdDevOp key, KeyColumn _) -> sprintf "STDEV(%s)" (colSprint key)
                 | GroupColumn (StdDevOp _,x) -> sprintf "STDEV(%s)" (fieldNotation al x)

--- a/src/SQLProvider/Providers.MySql.fs
+++ b/src/SQLProvider/Providers.MySql.fs
@@ -102,23 +102,23 @@ module MySql =
             let column = fieldNotation al col
             match cf with
             // String functions
-            | Replace(SqlStr(searchItm),SqlStrCol(al2, col2)) -> sprintf "REPLACE(%s,'%s',%s)" column searchItm (fieldNotation al2 col2)
-            | Replace(SqlStrCol(al2, col2),SqlStr(toItm)) -> sprintf "REPLACE(%s,%s,'%s')" column (fieldNotation al2 col2) toItm
-            | Replace(SqlStrCol(al2, col2),SqlStrCol(al3, col3)) -> sprintf "REPLACE(%s,%s,%s)" column (fieldNotation al2 col2) (fieldNotation al3 col3)
+            | Replace(SqlStr(searchItm),SqlCol(al2, col2)) -> sprintf "REPLACE(%s,'%s',%s)" column searchItm (fieldNotation al2 col2)
+            | Replace(SqlCol(al2, col2),SqlStr(toItm)) -> sprintf "REPLACE(%s,%s,'%s')" column (fieldNotation al2 col2) toItm
+            | Replace(SqlCol(al2, col2),SqlCol(al3, col3)) -> sprintf "REPLACE(%s,%s,%s)" column (fieldNotation al2 col2) (fieldNotation al3 col3)
             | Substring(SqlInt startPos) -> sprintf "MID(%s, %i)" column startPos
-            | Substring(SqlIntCol(al2, col2)) -> sprintf "MID(%s, %s)" column (fieldNotation al2 col2)
+            | Substring(SqlCol(al2, col2)) -> sprintf "MID(%s, %s)" column (fieldNotation al2 col2)
             | SubstringWithLength(SqlInt startPos,SqlInt strLen) -> sprintf "MID(%s, %i, %i)" column startPos strLen
-            | SubstringWithLength(SqlInt startPos,SqlIntCol(al2, col2)) -> sprintf "MID(%s, %i, %s)" column startPos (fieldNotation al2 col2)
-            | SubstringWithLength(SqlIntCol(al2, col2),SqlInt strLen) -> sprintf "MID(%s, %s, %i)" column (fieldNotation al2 col2) strLen
-            | SubstringWithLength(SqlIntCol(al2, col2),SqlIntCol(al3, col3)) -> sprintf "MID(%s, %s, %s)" column (fieldNotation al2 col2) (fieldNotation al3 col3)
+            | SubstringWithLength(SqlInt startPos,SqlCol(al2, col2)) -> sprintf "MID(%s, %i, %s)" column startPos (fieldNotation al2 col2)
+            | SubstringWithLength(SqlCol(al2, col2),SqlInt strLen) -> sprintf "MID(%s, %s, %i)" column (fieldNotation al2 col2) strLen
+            | SubstringWithLength(SqlCol(al2, col2),SqlCol(al3, col3)) -> sprintf "MID(%s, %s, %s)" column (fieldNotation al2 col2) (fieldNotation al3 col3)
             | Trim -> sprintf "TRIM(%s)" column
             | Length -> sprintf "CHAR_LENGTH(%s)" column
             | IndexOf(SqlStr search) -> sprintf "LOCATE('%s',%s)" search column
-            | IndexOf(SqlStrCol(al2, col2)) -> sprintf "LOCATE(%s,%s)" (fieldNotation al2 col2) column
+            | IndexOf(SqlCol(al2, col2)) -> sprintf "LOCATE(%s,%s)" (fieldNotation al2 col2) column
             | IndexOfStart(SqlStr(search),(SqlInt startPos)) -> sprintf "LOCATE('%s',%s,%d)" search column startPos
-            | IndexOfStart(SqlStr(search),SqlIntCol(al2, col2)) -> sprintf "LOCATE('%s',%s,%s)" search column (fieldNotation al2 col2)
-            | IndexOfStart(SqlStrCol(al2, col2),(SqlInt startPos)) -> sprintf "LOCATE(%s,%s,%d)" (fieldNotation al2 col2) column startPos
-            | IndexOfStart(SqlStrCol(al2, col2),SqlIntCol(al3, col3)) -> sprintf "LOCATE(%s,%s,%s)" (fieldNotation al2 col2) column (fieldNotation al3 col3)
+            | IndexOfStart(SqlStr(search),SqlCol(al2, col2)) -> sprintf "LOCATE('%s',%s,%s)" search column (fieldNotation al2 col2)
+            | IndexOfStart(SqlCol(al2, col2),(SqlInt startPos)) -> sprintf "LOCATE(%s,%s,%d)" (fieldNotation al2 col2) column startPos
+            | IndexOfStart(SqlCol(al2, col2),SqlCol(al3, col3)) -> sprintf "LOCATE(%s,%s,%s)" (fieldNotation al2 col2) column (fieldNotation al3 col3)
             // Date functions
             | Date -> sprintf "DATE(%s)" column
             | Year -> sprintf "YEAR(%s)" column
@@ -128,22 +128,33 @@ module MySql =
             | Minute -> sprintf "MINUTE(%s)" column
             | Second -> sprintf "SECOND(%s)" column
             | AddYears(SqlInt x) -> sprintf "DATE_ADD(%s, INTERVAL %d YEAR)" column x
-            | AddYears(SqlIntCol(al2, col2)) -> sprintf "DATE_ADD(%s, INTERVAL %s YEAR)" column (fieldNotation al2 col2)
+            | AddYears(SqlCol(al2, col2)) -> sprintf "DATE_ADD(%s, INTERVAL %s YEAR)" column (fieldNotation al2 col2)
             | AddMonths x -> sprintf "DATE_ADD(%s, INTERVAL %d MONTH)" column x
             | AddDays(SqlFloat x) -> sprintf "DATE_ADD(%s, INTERVAL %f DAY)" column x // SQL ignores decimal part :-(
-            | AddDays(SqlNumCol(al2, col2)) -> sprintf "DATE_ADD(%s, INTERVAL %s DAY)" column (fieldNotation al2 col2)
+            | AddDays(SqlCol(al2, col2)) -> sprintf "DATE_ADD(%s, INTERVAL %s DAY)" column (fieldNotation al2 col2)
             | AddHours x -> sprintf "DATE_ADD(%s, INTERVAL %f HOUR)" column x
             | AddMinutes(SqlFloat x) -> sprintf "DATE_ADD(%s, INTERVAL %f MINUTE)" column x
-            | AddMinutes(SqlNumCol(al2, col2)) -> sprintf "DATE_ADD(%s, INTERVAL %s MINUTE)" column (fieldNotation al2 col2)
+            | AddMinutes(SqlCol(al2, col2)) -> sprintf "DATE_ADD(%s, INTERVAL %s MINUTE)" column (fieldNotation al2 col2)
             | AddSeconds x -> sprintf "DATE_ADD(%s, INTERVAL %f SECOND)" column x
             // Math functions
             | Truncate -> sprintf "TRUNCATE(%s)" column
             | BasicMathOfColumns(o, a, c) when o="||" -> sprintf "CONCAT(%s, %s)" column (fieldNotation a c)
             | BasicMath(o, par) when (par :? String || par :? Char) -> sprintf "CONCAT(%s, '%O')" column par
             | Greatest(SqlDecimal x) -> sprintf "GREATEST(%s, %M)" column x
-            | Greatest(SqlDecimalCol(al2, col2)) -> sprintf "GREATEST(%s, %s)" column (fieldNotation al2 col2)
+            | Greatest(SqlCol(al2, col2)) -> sprintf "GREATEST(%s, %s)" column (fieldNotation al2 col2)
             | Least(SqlDecimal x) -> sprintf "LEAST(%s, %M)" column x
-            | Least(SqlDecimalCol(al2, col2)) -> sprintf "LEAST(%s, %s)" column (fieldNotation al2 col2)
+            | Least(SqlCol(al2, col2)) -> sprintf "LEAST(%s, %s)" column (fieldNotation al2 col2)
+            //if-then-else
+            | CaseSql(SqlCol(al2, col2), SqlCol(al3, col3)) -> sprintf "IF(%s, %s, %s)" column (fieldNotation al2 col2) (fieldNotation al3 col3)
+            | CaseSql(SqlCol(al2, col2), SqlInt(itm)) -> sprintf "IF(%s, %s, %d)" column (fieldNotation al2 col2) itm
+            | CaseSql(SqlInt(itm), SqlCol(al2, col2)) -> sprintf "IF(%s, %d, %s)" column itm (fieldNotation al2 col2)
+            | CaseSql(SqlCol(al2, col2), SqlDecimal(itm)) -> sprintf "IF(%s, %s, %M)" column (fieldNotation al2 col2) itm
+            | CaseSql(SqlDecimal(itm), SqlCol(al2, col2)) -> sprintf "IF(%s, %M, %s)" column itm (fieldNotation al2 col2)
+            | CaseSql(SqlCol(al2, col2), SqlDateTime(itm)) -> sprintf "IF(%s, %s, '%s')" column (fieldNotation al2 col2) (itm.ToString("yyyy-MM-dd HH:mm:ss"))
+            | CaseSql(SqlDateTime(itm), SqlCol(al2, col2)) -> sprintf "IF(%s, '%s', %s)" column (itm.ToString("yyyy-MM-dd HH:mm:ss")) (fieldNotation al2 col2)
+            | CaseSql(SqlCol(al2, col2), SqlStr(itm)) -> sprintf "IF(%s, %s, '%s')" column (fieldNotation al2 col2) itm
+            | CaseSql(SqlStr(itm), SqlCol(al2, col2)) -> sprintf "IF(%s, '%s', %s)" column itm (fieldNotation al2 col2)
+
             | _ -> Utilities.genericFieldNotation (fieldNotation al) colSprint c
         | _ -> Utilities.genericFieldNotation (fieldNotation al) colSprint c
 

--- a/src/SQLProvider/Providers.Oracle.fs
+++ b/src/SQLProvider/Providers.Oracle.fs
@@ -77,23 +77,23 @@ module internal Oracle =
             let column = fieldNotation al col
             match cf with
             // String functions
-            | Replace(SqlStr(searchItm),SqlStrCol(al2, col2)) -> sprintf "REPLACE(%s,'%s',%s)" column searchItm (fieldNotation al2 col2)
-            | Replace(SqlStrCol(al2, col2),SqlStr(toItm)) -> sprintf "REPLACE(%s,%s,'%s')" column (fieldNotation al2 col2) toItm
-            | Replace(SqlStrCol(al2, col2),SqlStrCol(al3, col3)) -> sprintf "REPLACE(%s,%s,%s)" column (fieldNotation al2 col2) (fieldNotation al3 col3)
+            | Replace(SqlStr(searchItm),SqlCol(al2, col2)) -> sprintf "REPLACE(%s,'%s',%s)" column searchItm (fieldNotation al2 col2)
+            | Replace(SqlCol(al2, col2),SqlStr(toItm)) -> sprintf "REPLACE(%s,%s,'%s')" column (fieldNotation al2 col2) toItm
+            | Replace(SqlCol(al2, col2),SqlCol(al3, col3)) -> sprintf "REPLACE(%s,%s,%s)" column (fieldNotation al2 col2) (fieldNotation al3 col3)
             | Substring(SqlInt startPos) -> sprintf "SUBSTR(%s, %i)" column startPos
-            | Substring(SqlIntCol(al2, col2)) -> sprintf "SUBSTR(%s, %s)" column (fieldNotation al2 col2)
+            | Substring(SqlCol(al2, col2)) -> sprintf "SUBSTR(%s, %s)" column (fieldNotation al2 col2)
             | SubstringWithLength(SqlInt startPos,SqlInt strLen) -> sprintf "SUBSTR(%s, %i, %i)" column startPos strLen
-            | SubstringWithLength(SqlInt startPos,SqlIntCol(al2, col2)) -> sprintf "SUBSTR(%s, %i, %s)" column startPos (fieldNotation al2 col2)
-            | SubstringWithLength(SqlIntCol(al2, col2),SqlInt strLen) -> sprintf "SUBSTR(%s, %s, %i)" column (fieldNotation al2 col2) strLen
-            | SubstringWithLength(SqlIntCol(al2, col2),SqlIntCol(al3, col3)) -> sprintf "SUBSTR(%s, %s, %s)" column (fieldNotation al2 col2) (fieldNotation al3 col3)
+            | SubstringWithLength(SqlInt startPos,SqlCol(al2, col2)) -> sprintf "SUBSTR(%s, %i, %s)" column startPos (fieldNotation al2 col2)
+            | SubstringWithLength(SqlCol(al2, col2),SqlInt strLen) -> sprintf "SUBSTR(%s, %s, %i)" column (fieldNotation al2 col2) strLen
+            | SubstringWithLength(SqlCol(al2, col2),SqlCol(al3, col3)) -> sprintf "SUBSTR(%s, %s, %s)" column (fieldNotation al2 col2) (fieldNotation al3 col3)
             | Trim -> sprintf "TRIM(%s)" column
             | Length -> sprintf "LENGTH(%s)" column
             | IndexOf(SqlStr search) -> sprintf "INSTR(%s,'%s')" column search
-            | IndexOf(SqlStrCol(al2, col2)) -> sprintf "INSTR(%s,%s)" column (fieldNotation al2 col2)
+            | IndexOf(SqlCol(al2, col2)) -> sprintf "INSTR(%s,%s)" column (fieldNotation al2 col2)
             | IndexOfStart(SqlStr(search),(SqlInt startPos)) -> sprintf "INSTR(%s,'%s',%d)" column search startPos
-            | IndexOfStart(SqlStr(search), SqlIntCol(al2, col2)) -> sprintf "INSTR(%s,'%s',%s)" column search (fieldNotation al2 col2)
-            | IndexOfStart(SqlStrCol(al2, col2),(SqlInt startPos)) -> sprintf "INSTR(%s,%s,%d)" column (fieldNotation al2 col2) startPos
-            | IndexOfStart(SqlStrCol(al2, col2),SqlIntCol(al3, col3)) -> sprintf "INSTR(%s,%s,%s)" column (fieldNotation al2 col2) (fieldNotation al3 col3)
+            | IndexOfStart(SqlStr(search), SqlCol(al2, col2)) -> sprintf "INSTR(%s,'%s',%s)" column search (fieldNotation al2 col2)
+            | IndexOfStart(SqlCol(al2, col2),(SqlInt startPos)) -> sprintf "INSTR(%s,%s,%d)" column (fieldNotation al2 col2) startPos
+            | IndexOfStart(SqlCol(al2, col2),SqlCol(al3, col3)) -> sprintf "INSTR(%s,%s,%s)" column (fieldNotation al2 col2) (fieldNotation al3 col3)
             // Date functions
             | Date -> sprintf "TRUNC(%s)" column
             | Year -> sprintf "EXTRACT(YEAR FROM %s)" column
@@ -103,13 +103,13 @@ module internal Oracle =
             | Minute -> sprintf "EXTRACT(MINUTE FROM %s)" column
             | Second -> sprintf "EXTRACT(SECOND FROM %s)" column
             | AddYears(SqlInt x) -> sprintf "(%s + INTERVAL '%d' YEAR)" column x
-            | AddYears(SqlIntCol(al2, col2)) -> sprintf "(%s + INTERVAL %s YEAR)" column (fieldNotation al2 col2)
+            | AddYears(SqlCol(al2, col2)) -> sprintf "(%s + INTERVAL %s YEAR)" column (fieldNotation al2 col2)
             | AddMonths x -> sprintf "(%s + INTERVAL '%d' MONTH)" column x
             | AddDays(SqlFloat x) -> sprintf "(%s + INTERVAL '%f' DAY)" column x // SQL ignores decimal part :-(
-            | AddDays(SqlNumCol(al2, col2)) -> sprintf "(%s + INTERVAL %s DAY)" column (fieldNotation al2 col2)
+            | AddDays(SqlCol(al2, col2)) -> sprintf "(%s + INTERVAL %s DAY)" column (fieldNotation al2 col2)
             | AddHours x -> sprintf "(%s + INTERVAL '%f' HOUR)" column x
             | AddMinutes(SqlFloat x) -> sprintf "(%s + INTERVAL '%f' MINUTE)" column x
-            | AddMinutes(SqlNumCol(al2, col2)) -> sprintf "(%s + INTERVAL %s MINUTE)" column (fieldNotation al2 col2)
+            | AddMinutes(SqlCol(al2, col2)) -> sprintf "(%s + INTERVAL %s MINUTE)" column (fieldNotation al2 col2)
             | AddSeconds x -> sprintf "(%s + INTERVAL '%f' SECOND)" column x
             // Math functions
             | Truncate -> sprintf "TRUNC(%s)" column
@@ -117,9 +117,19 @@ module internal Oracle =
             | BasicMathOfColumns(o, a, c) -> sprintf "(%s %s %s)" column o (fieldNotation a c)
             | BasicMath(o, par) when (par :? String || par :? Char) -> sprintf "(%s %s '%O')" column o par
             | Greatest(SqlDecimal x) -> sprintf "GREATEST(%s, %M)" column x
-            | Greatest(SqlDecimalCol(al2, col2)) -> sprintf "GREATEST(%s, %s)" column (fieldNotation al2 col2)
+            | Greatest(SqlCol(al2, col2)) -> sprintf "GREATEST(%s, %s)" column (fieldNotation al2 col2)
             | Least(SqlDecimal x) -> sprintf "LEAST(%s, %M)" column x
-            | Least(SqlDecimalCol(al2, col2)) -> sprintf "LEAST(%s, %s)" column (fieldNotation al2 col2)
+            | Least(SqlCol(al2, col2)) -> sprintf "LEAST(%s, %s)" column (fieldNotation al2 col2)
+            //if-then-else
+            | CaseSql(SqlCol(al2, col2), SqlCol(al3, col3)) -> sprintf "CASE WHEN %s THEN %s ELSE %s END" column (fieldNotation al2 col2) (fieldNotation al3 col3)
+            | CaseSql(SqlCol(al2, col2), SqlInt(itm)) -> sprintf "CASE WHEN %s THEN %s ELSE %d END" column (fieldNotation al2 col2) itm
+            | CaseSql(SqlInt(itm), SqlCol(al2, col2)) -> sprintf "CASE WHEN %s THEN %d ELSE %s END" column itm (fieldNotation al2 col2)
+            | CaseSql(SqlCol(al2, col2), SqlDecimal(itm)) -> sprintf "CASE WHEN %s THEN %s ELSE %M END" column (fieldNotation al2 col2) itm
+            | CaseSql(SqlDecimal(itm), SqlCol(al2, col2)) -> sprintf "CASE WHEN %s THEN %M ELSE %s END" column itm (fieldNotation al2 col2)
+            | CaseSql(SqlCol(al2, col2), SqlDateTime(itm)) -> sprintf "CASE WHEN %s THEN %s ELSE '%s' END" column (fieldNotation al2 col2) (itm.ToString("yyyy-MM-dd HH:mm:ss"))
+            | CaseSql(SqlDateTime(itm), SqlCol(al2, col2)) -> sprintf "CASE WHEN %s THEN '%s' ELSE %s END" column (itm.ToString("yyyy-MM-dd HH:mm:ss")) (fieldNotation al2 col2)
+            | CaseSql(SqlCol(al2, col2), SqlStr(itm)) -> sprintf "CASE WHEN %s THEN %s ELSE '%s' END" column (fieldNotation al2 col2) itm
+            | CaseSql(SqlStr(itm), SqlCol(al2, col2)) -> sprintf "CASE WHEN %s THEN '%s' ELSE %s END" column itm (fieldNotation al2 col2)
             | _ -> Utilities.genericFieldNotation (fieldNotation al) colSprint c
         | _ -> Utilities.genericFieldNotation (fieldNotation al) colSprint c
 
@@ -1034,11 +1044,12 @@ type internal OracleProvider(resolutionPath, owner, referencedAssemblies, tableN
                                 if timeout.IsSome then
                                     cmd.CommandTimeout <- timeout.Value
                                 let! id = cmd.ExecuteScalarAsync() |> Async.AwaitTask
-                                match e.GetPkColumnOption primaryKeyColumn.[e.Table.Name].Column with
-                                | [] ->  e.SetPkColumnSilent(primaryKeyColumn.[e.Table.Name].Column, id)
-                                | _ -> () // if the primary key exists, do nothing
-                                                // this is because non-identity columns will have been set
-                                                // manually and in that case scope_identity would bring back 0 "" or whatever
+                                if primaryKeyColumn.ContainsKey(e.Table.Name) then
+                                    match e.GetPkColumnOption primaryKeyColumn.[e.Table.Name].Column with
+                                    | [] ->  e.SetPkColumnSilent(primaryKeyColumn.[e.Table.Name].Column, id)
+                                    | _ -> () // if the primary key exists, do nothing
+                                                    // this is because non-identity columns will have been set
+                                                    // manually and in that case scope_identity would bring back 0 "" or whatever
                                 e._State <- Unchanged
                             }
                         | Modified fields ->

--- a/src/SQLProvider/SqlRuntime.Linq.fs
+++ b/src/SQLProvider/SqlRuntime.Linq.fs
@@ -306,7 +306,6 @@ module internal QueryImplementation =
          static member val Provider =
 
              let parseWhere (meth:Reflection.MethodInfo) (source:IWithSqlService) (qual:Expression) =
-                let paramNames = HashSet<string>()
 
                 let isHaving = source.SqlExpression.hasGroupBy().IsSome
 
@@ -334,65 +333,14 @@ module internal QueryImplementation =
                             | true -> paramfixed.Substring(0, paramfixed.Length-1)
                         
                         Some(ti,key,op,Some (box (subquery, modified)))
-                    | SqlSpecialOpArr(ti,op,key,value)
-                    | SqlSpecialNegativeOpArr(ti,op,key,value) ->
-                        paramNames.Add(ti) |> ignore
-                        Some(ti,key,op,Some (box value))
-                    | SqlSpecialOp(ti,op,key,value) ->
-                        paramNames.Add(ti) |> ignore
-                        Some(ti,key,op,Some value)
-                    // if using nullable types
-                    | OptionIsSome(SqlColumnGet(ti,key,_)) ->
-                        paramNames.Add(ti) |> ignore
-                        Some(ti,key,ConditionOperator.NotNull,None)
-                    | OptionIsNone(SqlColumnGet(ti,key,_))
-                    | SqlCondOp(ConditionOperator.Equal,(OptionalConvertOrTypeAs(SqlColumnGet(ti,key,_))), (OptionNone | NullConstant)) 
-                    | SqlNegativeCondOp(ConditionOperator.Equal,(OptionalConvertOrTypeAs(SqlColumnGet(ti,key,_))),(OptionNone | NullConstant)) ->
-                        paramNames.Add(ti) |> ignore
-                        Some(ti,key,ConditionOperator.IsNull,None)
-                    | SqlCondOp(ConditionOperator.NotEqual,(OptionalConvertOrTypeAs(SqlColumnGet(ti,key,_))),(OptionNone | NullConstant)) 
-                    | SqlNegativeCondOp(ConditionOperator.NotEqual,(OptionalConvertOrTypeAs(SqlColumnGet(ti,key,_))),(OptionNone | NullConstant)) ->
-                        paramNames.Add(ti) |> ignore
-                        Some(ti,key,ConditionOperator.NotNull,None)
-                    // matches column to constant with any operator eg c.name = "john", c.age > 42
-                    | SqlCondOp(op,(OptionalConvertOrTypeAs(SqlColumnGet(ti,key,_))),OptionalConvertOrTypeAs(OptionalFSharpOptionValue(ConstantOrNullableConstant(c)))) 
-                    | SqlNegativeCondOp(op,(OptionalConvertOrTypeAs(SqlColumnGet(ti,key,_))),OptionalConvertOrTypeAs(OptionalFSharpOptionValue(ConstantOrNullableConstant(c))))
-                    | SqlCondOp(op,OptionalConvertOrTypeAs(OptionalFSharpOptionValue(ConstantOrNullableConstant(c))),(OptionalConvertOrTypeAs(SqlColumnGet(ti,key,_)))) 
-                    | SqlNegativeCondOp(op,OptionalConvertOrTypeAs(OptionalFSharpOptionValue(ConstantOrNullableConstant(c))),(OptionalConvertOrTypeAs(SqlColumnGet(ti,key,_)))) ->
-                        paramNames.Add(ti) |> ignore
-                        Some(ti,key,op,c)
-                    // matches column to column e.g. c.col1 > c.col2
-                    | SqlCondOp(op,(OptionalConvertOrTypeAs(SqlColumnGet(ti,key,_))),(OptionalConvertOrTypeAs(SqlColumnGet(ti2,key2,_)))) 
-                    | SqlNegativeCondOp(op,(OptionalConvertOrTypeAs(SqlColumnGet(ti,key,_))),(OptionalConvertOrTypeAs(SqlColumnGet(ti2,key2,_)))) ->
-                        let alias2 = resolveTuplePropertyName ti2 source.TupleIndex
-                        Some(ti,key,op,Some((alias2,key2) |> box))
-                    // matches to another property getter, method call or new expression
-                    | SqlCondOp(op,OptionalConvertOrTypeAs(SqlColumnGet(ti,key,_)),OptionalConvertOrTypeAs(OptionalFSharpOptionValue((((:? MemberExpression) | (:? MethodCallExpression) | (:? NewExpression)) as meth))))
-                    | SqlNegativeCondOp(op,OptionalConvertOrTypeAs(SqlColumnGet(ti,key,_)),OptionalConvertOrTypeAs(OptionalFSharpOptionValue((((:? MemberExpression) | (:? MethodCallExpression) | (:? NewExpression)) as meth))))
-                    | SqlCondOp(op,OptionalConvertOrTypeAs(OptionalFSharpOptionValue((((:? MemberExpression) | (:? MethodCallExpression) | (:? NewExpression)) as meth))),OptionalConvertOrTypeAs(SqlColumnGet(ti,key,_)))
-                    | SqlNegativeCondOp(op,OptionalConvertOrTypeAs(OptionalFSharpOptionValue((((:? MemberExpression) | (:? MethodCallExpression) | (:? NewExpression)) as meth))),OptionalConvertOrTypeAs(SqlColumnGet(ti,key,_))) ->
-
-                        paramNames.Add(ti) |> ignore
-                        let invokedResult = Expression.Lambda(meth).Compile().DynamicInvoke()
-
-                        let handleNullCompare() =
-                            match op with
-                            | ConditionOperator.Equal -> Some(ti,key,ConditionOperator.IsNull,None)
-                            | ConditionOperator.NotEqual -> Some(ti,key,ConditionOperator.NotNull,None)
-                            | _ -> Some(ti,key,op,Some(invokedResult))
-
-                        if invokedResult = null then handleNullCompare()
+                    | SimpleCondition ((ti,key,op,c) as x) -> 
+                        if c.IsNone then Some x
                         else
-                        let retType = invokedResult.GetType()
-                        if retType.IsGenericType && retType.FullName.StartsWith("Microsoft.FSharp.Core.FSharpOption") then
-                            let gotVal = retType.GetProperty("Value") // Option type Some should not be SQL-parameter.
-                            match gotVal.GetValue(invokedResult, [||]) with
-                            | null -> handleNullCompare()
-                            | r -> Some(ti,key,op,Some(r))
-                        else Some(ti,key,op,Some(invokedResult))
-                    | SqlColumnGet(ti,key,ret) when exp.Type.FullName = "System.Boolean" || ret = typeof<bool> -> 
-                        paramNames.Add(ti) |> ignore
-                        Some(ti,key,ConditionOperator.Equal, Some(true |> box))
+                        match c.Value with
+                        | :? Tuple<string,SqlColumnType> as t ->
+                            let alias2 = resolveTuplePropertyName (fst t) source.TupleIndex
+                            Some(ti,key,op,Some(box (alias2,(snd t))))
+                        | _ -> Some x
                     | _ -> None
 
                 let rec filterExpression (exp:Expression)  =
@@ -436,12 +384,7 @@ module internal QueryImplementation =
                             FilterClause(filter,BaseTable(name.Name,entity))
                         | current ->
                             if isHaving then HavingClause(filter,current)
-                            else
-
-                            // the following case can happen with multiple where clauses when only a single entity is selected
-                            //if (paramNames.Length > 0 && paramNames.First() = "") || source.TupleIndex.Count = 0 then FilterClause(filter,current)
-                            //else 
-                            FilterClause(filter,current)
+                            else FilterClause(filter,current)
 
                     let ty = typedefof<SqlQueryable<_>>.MakeGenericType(meth.GetGenericArguments().[0])
                     ty.GetConstructors().[0].Invoke [| source.DataContext; source.Provider; sqlExpression; source.TupleIndex; |] :?> IQueryable<_>

--- a/src/SQLProvider/SqlRuntime.Linq.fs
+++ b/src/SQLProvider/SqlRuntime.Linq.fs
@@ -334,13 +334,13 @@ module internal QueryImplementation =
                         
                         Some(ti,key,op,Some (box (subquery, modified)))
                     | SimpleCondition ((ti,key,op,c) as x) -> 
-                        if c.IsNone then Some x
-                        else
-                        match c.Value with
-                        | :? Tuple<string,SqlColumnType> as t ->
-                            let alias2 = resolveTuplePropertyName (fst t) source.TupleIndex
-                            Some(ti,key,op,Some(box (alias2,(snd t))))
-                        | _ -> Some x
+                        match c with
+                        | None -> Some x
+                        | Some t when (t :? (string*SqlColumnType)) ->
+                            let ti2, col = t :?> string*SqlColumnType
+                            let alias2 = resolveTuplePropertyName ti2 source.TupleIndex
+                            Some(ti,key,op,Some(box (alias2,col)))
+                        | Some _ -> Some x
                     | _ -> None
 
                 let rec filterExpression (exp:Expression)  =

--- a/src/SQLProvider/SqlRuntime.Patterns.fs
+++ b/src/SQLProvider/SqlRuntime.Patterns.fs
@@ -265,11 +265,11 @@ let rec (|SqlColumnGet|_|) (e:Expression) =
         match typ with
         | t when t = typeof<System.String> || t= typeof<Option<System.String>> -> // String functions
             match meth.Name, par with
-            | "Substring", [Int startPos] -> Some(alias, CanonicalOperation(CanonicalOp.Substring(SqlInt(startPos)), col), typ)
+            | "Substring", [Int startPos] -> Some(alias, CanonicalOperation(CanonicalOp.Substring(SqlConstant startPos), col), typ)
             | "Substring", [SqlColumnGet(al2,col2,typ2)] when integerTypes |> Seq.exists(fun t -> t = typ2) -> Some(alias, CanonicalOperation(CanonicalOp.Substring(SqlCol(al2,col2)), col), typ)
-            | "Substring", [Int startPos; Int strLen] -> Some(alias, CanonicalOperation(CanonicalOp.SubstringWithLength(SqlInt(startPos),SqlInt(strLen)), col), typ)
-            | "Substring", [SqlColumnGet(al2,col2,typ2); Int strLen] when integerTypes |> Seq.exists(fun t -> t = typ2) -> Some(alias, CanonicalOperation(CanonicalOp.SubstringWithLength(SqlCol(al2,col2),SqlInt(strLen)), col), typ)
-            | "Substring", [Int startPos; SqlColumnGet(al2,col2,typ2)] when integerTypes |> Seq.exists(fun t -> t = typ2) -> Some(alias, CanonicalOperation(CanonicalOp.SubstringWithLength(SqlInt(startPos),SqlCol(al2,col2)), col), typ)
+            | "Substring", [Int startPos; Int strLen] -> Some(alias, CanonicalOperation(CanonicalOp.SubstringWithLength(SqlConstant startPos,SqlConstant strLen), col), typ)
+            | "Substring", [SqlColumnGet(al2,col2,typ2); Int strLen] when integerTypes |> Seq.exists(fun t -> t = typ2) -> Some(alias, CanonicalOperation(CanonicalOp.SubstringWithLength(SqlCol(al2,col2),SqlConstant strLen), col), typ)
+            | "Substring", [Int startPos; SqlColumnGet(al2,col2,typ2)] when integerTypes |> Seq.exists(fun t -> t = typ2) -> Some(alias, CanonicalOperation(CanonicalOp.SubstringWithLength(SqlConstant startPos,SqlCol(al2,col2)), col), typ)
             | "Substring", [SqlColumnGet(al2,col2,ty2); SqlColumnGet(al3,col3,ty3)]  when integerTypes |> Seq.exists(fun t -> t = ty2) && integerTypes |> Seq.exists(fun t -> t = ty3) -> Some(alias, CanonicalOperation(CanonicalOp.SubstringWithLength(SqlCol(al2,col2),SqlCol(al3,col3)), col), typ)
             | "ToUpper", []
             | "ToUpperInvariant", [] -> Some(alias, CanonicalOperation(CanonicalOp.ToUpper, col), typ)
@@ -277,26 +277,26 @@ let rec (|SqlColumnGet|_|) (e:Expression) =
             | "ToLowerInvariant", [] -> Some(alias, CanonicalOperation(CanonicalOp.ToLower, col), typ)
             | "Trim", [] -> Some(alias, CanonicalOperation(CanonicalOp.Trim, col), typ)
             | "Length", [] -> Some(alias, CanonicalOperation(CanonicalOp.Length, col), intType typ)
-            | "Replace", [String itm1; String itm2] -> Some(alias, CanonicalOperation(CanonicalOp.Replace(SqlStr(itm1), SqlStr(itm2)), col), typ)
-            | "Replace", [SqlColumnGet(al2,col2,_); String itm2] -> Some(alias, CanonicalOperation(CanonicalOp.Replace(SqlCol(al2,col2), SqlStr(itm2)), col), typ)
-            | "Replace", [String itm1; SqlColumnGet(al2,col2,_)] -> Some(alias, CanonicalOperation(CanonicalOp.Replace(SqlStr(itm1), SqlCol(al2,col2)), col), typ)
+            | "Replace", [String itm1; String itm2] -> Some(alias, CanonicalOperation(CanonicalOp.Replace(SqlConstant(box itm1), SqlConstant itm2), col), typ)
+            | "Replace", [SqlColumnGet(al2,col2,_); String itm2] -> Some(alias, CanonicalOperation(CanonicalOp.Replace(SqlCol(al2,col2), SqlConstant itm2), col), typ)
+            | "Replace", [String itm1; SqlColumnGet(al2,col2,_)] -> Some(alias, CanonicalOperation(CanonicalOp.Replace(SqlConstant(box itm1), SqlCol(al2,col2)), col), typ)
             | "Replace", [SqlColumnGet(al2,col2,_); SqlColumnGet(al3,col3,_)] -> Some(alias, CanonicalOperation(CanonicalOp.Replace(SqlCol(al2,col2), SqlCol(al3,col3)), col), typ)
-            | "IndexOf", [String search] -> Some(alias, CanonicalOperation(CanonicalOp.IndexOf(SqlStr(search)), col), intType typ)
+            | "IndexOf", [String search] -> Some(alias, CanonicalOperation(CanonicalOp.IndexOf(SqlConstant search), col), intType typ)
             | "IndexOf", [SqlColumnGet(al2,col2,_)] -> Some(alias, CanonicalOperation(CanonicalOp.IndexOf(SqlCol(al2,col2)), col), intType typ)
-            | "IndexOf", [String search; Int startPos] -> Some(alias, CanonicalOperation(CanonicalOp.IndexOfStart(SqlStr(search), SqlInt(startPos)), col), intType typ)
-            | "IndexOf", [SqlColumnGet(al2,col2,_); Int startPos] -> Some(alias, CanonicalOperation(CanonicalOp.IndexOfStart(SqlCol(al2,col2), SqlInt(startPos)), col), intType typ)
-            | "IndexOf", [String search; SqlColumnGet(al2,col2,typ2)] when integerTypes |> Seq.exists(fun t -> t = typ2) -> Some(alias, CanonicalOperation(CanonicalOp.IndexOfStart(SqlStr(search), SqlCol(al2,col2)), col), intType typ)
+            | "IndexOf", [String search; Int startPos] -> Some(alias, CanonicalOperation(CanonicalOp.IndexOfStart(SqlConstant search, SqlConstant startPos), col), intType typ)
+            | "IndexOf", [SqlColumnGet(al2,col2,_); Int startPos] -> Some(alias, CanonicalOperation(CanonicalOp.IndexOfStart(SqlCol(al2,col2), SqlConstant startPos), col), intType typ)
+            | "IndexOf", [String search; SqlColumnGet(al2,col2,typ2)] when integerTypes |> Seq.exists(fun t -> t = typ2) -> Some(alias, CanonicalOperation(CanonicalOp.IndexOfStart(SqlConstant search, SqlCol(al2,col2)), col), intType typ)
             | "IndexOf", [SqlColumnGet(al2,col2,_); SqlColumnGet(al3,col3,typ2)] when integerTypes |> Seq.exists(fun t -> t = typ2) -> Some(alias, CanonicalOperation(CanonicalOp.IndexOfStart(SqlCol(al2,col2), SqlCol(al3,col3)), col), intType typ)
             | _ -> None
         | t when t = typeof<System.DateTime> || t = typeof<Option<System.DateTime>> -> // DateTime functions
             match meth.Name, par with
-            | "AddYears", [Int x] -> Some(alias, CanonicalOperation(CanonicalOp.AddYears(SqlInt(x)), col), typ)
+            | "AddYears", [Int x] -> Some(alias, CanonicalOperation(CanonicalOp.AddYears(SqlConstant(box x)), col), typ)
             | "AddYears", [SqlColumnGet(al2,col2,typ2)] when integerTypes |> Seq.exists(fun t -> t = typ2) -> Some(alias, CanonicalOperation(CanonicalOp.AddYears(SqlCol(al2,col2)), col), typ)
             | "AddMonths", [Int x] -> Some(alias, CanonicalOperation(CanonicalOp.AddMonths(x), col), typ)
-            | "AddDays", [Float x] -> Some(alias, CanonicalOperation(CanonicalOp.AddDays(SqlFloat(x)), col), typ)
+            | "AddDays", [Float x] -> Some(alias, CanonicalOperation(CanonicalOp.AddDays(SqlConstant(box x)), col), typ)
             | "AddDays", [OptionalConvertOrTypeAs(SqlColumnGet(al2,col2,typ2))] when integerTypes |> Seq.exists(fun t -> t = typ2) || decimalTypes |> Seq.exists(fun t -> t = typ2)  -> Some(alias, CanonicalOperation(CanonicalOp.AddDays(SqlCol(al2,col2)), col), typ)
             | "AddHours", [Float x] -> Some(alias, CanonicalOperation(CanonicalOp.AddHours(x), col), typ)
-            | "AddMinutes", [Float x] -> Some(alias, CanonicalOperation(CanonicalOp.AddMinutes(SqlFloat(x)), col), typ)
+            | "AddMinutes", [Float x] -> Some(alias, CanonicalOperation(CanonicalOp.AddMinutes(SqlConstant(box x)), col), typ)
             | "AddMinutes", [OptionalConvertOrTypeAs(SqlColumnGet(al2,col2,typ2))] when integerTypes |> Seq.exists(fun t -> t = typ2) || decimalTypes |> Seq.exists(fun t -> t = typ2)  -> Some(alias, CanonicalOperation(CanonicalOp.AddMinutes(SqlCol(al2,col2)), col), typ)
             | "AddSeconds", [Float x] -> Some(alias, CanonicalOperation(CanonicalOp.AddSeconds(x), col), typ)
             | _ -> None
@@ -347,8 +347,8 @@ let rec (|SqlColumnGet|_|) (e:Expression) =
             match meth.Name, par with
             | "Max", OptionalConvertOrTypeAs(SqlColumnGet(al2,col2,typ2)) when integerTypes |> Seq.exists(fun t -> t = typ2) || decimalTypes |> Seq.exists(fun t -> t = typ2)  -> Some(alias, CanonicalOperation(CanonicalOp.Greatest(SqlCol(al2,col2)), col), typ)
             | "Min", OptionalConvertOrTypeAs(SqlColumnGet(al2,col2,typ2)) when integerTypes |> Seq.exists(fun t -> t = typ2) || decimalTypes |> Seq.exists(fun t -> t = typ2)  -> Some(alias, CanonicalOperation(CanonicalOp.Least(SqlCol(al2,col2)), col), typ)
-            | "Max", Constant(c,_) -> Some(alias, CanonicalOperation(CanonicalOp.Greatest(SqlDecimal(Convert.ToDecimal c)), col), typ)
-            | "Min", Constant(c,_) -> Some(alias, CanonicalOperation(CanonicalOp.Least(SqlDecimal(Convert.ToDecimal c)), col), typ)
+            | "Max", Constant(c,_) -> Some(alias, CanonicalOperation(CanonicalOp.Greatest(SqlConstant(c)), col), typ)
+            | "Min", Constant(c,_) -> Some(alias, CanonicalOperation(CanonicalOp.Least(SqlConstant(c)), col), typ)
             | _ -> None
 
     // Basic math: (x.Column+1), (1+x.Column) and (x.Column1+y.Column2)
@@ -423,21 +423,11 @@ let rec (|SqlColumnGet|_|) (e:Expression) =
 
         match filter, ce.IfTrue, ce.IfFalse with
         | Condition.NotSupported(x), _, _ -> None
-        | _, OptionalConvertOrTypeAs(SqlColumnGet(al2,col2,typ2)), Constant(c, ct) when (integerTypes |> Array.exists((=) ct)) -> Some(al2, CanonicalOperation(CanonicalOp.CaseSql(filter, SqlInt(Convert.ToInt32(c))), col2), typ2)
-        | _, OptionalConvertOrTypeAs(SqlColumnGet(al2,col2,typ2)), Constant(c, ct) when (decimalTypes |> Array.exists((=) ct)) -> Some(al2, CanonicalOperation(CanonicalOp.CaseSql(filter, SqlDecimal(Convert.ToDecimal(c))), col2), typ2)
-        | _, OptionalConvertOrTypeAs(SqlColumnGet(al2,col2,typ2)), String c -> Some(al2, CanonicalOperation(CanonicalOp.CaseSql(filter, SqlStr(c.ToString())), col2), typ2)
-        | _, OptionalConvertOrTypeAs(SqlColumnGet(al2,col2,typ2)), Constant(c, ct) when (ct = typeof<DateTime>) -> Some(al2, CanonicalOperation(CanonicalOp.CaseSql(filter, SqlDateTime(unbox(c))), col2), typ2)
+        | _, OptionalConvertOrTypeAs(SqlColumnGet(al2,col2,typ2)), Constant(c, ct)  -> Some(al2, CanonicalOperation(CanonicalOp.CaseSql(filter, SqlConstant(c)), col2), typ2)
         | _, OptionalConvertOrTypeAs(SqlColumnGet(al2,col2,typ2)), OptionalConvertOrTypeAs(SqlColumnGet(al3,col3,typ3)) -> Some(al2, CanonicalOperation(CanonicalOp.CaseSql(filter, SqlCol(al3,col3)), col2), typ2)
+        | _, Constant(c, ct), OptionalConvertOrTypeAs(SqlColumnGet(al2,col2,typ2)) -> Some(al2, CanonicalOperation(CanonicalOp.CaseNotSql(filter, SqlConstant(c)), col2), typ2)
 
-        | _, Constant(c, ct), OptionalConvertOrTypeAs(SqlColumnGet(al2,col2,typ2)) when (integerTypes |> Array.exists((=) ct)) -> Some(al2, CanonicalOperation(CanonicalOp.CaseNotSql(filter, SqlInt(Convert.ToInt32(c))), col2), typ2)
-        | _, Constant(c, ct), OptionalConvertOrTypeAs(SqlColumnGet(al2,col2,typ2)) when (decimalTypes |> Array.exists((=) ct)) -> Some(al2, CanonicalOperation(CanonicalOp.CaseNotSql(filter, SqlDecimal(Convert.ToDecimal(c))), col2), typ2)
-        | _, String c, OptionalConvertOrTypeAs(SqlColumnGet(al2,col2,typ2)) -> Some(al2, CanonicalOperation(CanonicalOp.CaseNotSql(filter, SqlStr(c.ToString())), col2), typ2)
-        | _, Constant(c, ct), OptionalConvertOrTypeAs(SqlColumnGet(al2,col2,typ2)) when (ct = typeof<DateTime>) -> Some(al2, CanonicalOperation(CanonicalOp.CaseNotSql(filter, SqlDateTime(unbox(c))), col2), typ2)
-
-        | _, Constant(c1, ct1), Constant(c2, ct2) when (integerTypes |> Array.exists((=) ct1) && integerTypes |> Array.exists((=) ct2)) -> Some("", CanonicalOperation(CanonicalOp.CaseSqlPlain(filter, SqlInt(Convert.ToInt32(c1)), SqlInt(Convert.ToInt32(c2))), SqlColumnType.KeyColumn("constant")), ct1)
-        | _, Constant(c1, ct1), Constant(c2, ct2) when (decimalTypes |> Array.exists((=) ct1) && decimalTypes |> Array.exists((=) ct2)) -> Some("", CanonicalOperation(CanonicalOp.CaseSqlPlain(filter, SqlDecimal(Convert.ToDecimal(c1)), SqlDecimal(Convert.ToDecimal(c2))), SqlColumnType.KeyColumn("constant")), ct1)
-        | _, String c1, String c2 -> Some("", CanonicalOperation(CanonicalOp.CaseSqlPlain(filter, SqlStr(c1.ToString()), SqlStr(c2.ToString())), SqlColumnType.KeyColumn("constant")), typeof<string>)
-        | _, Constant(c1, ct1),  Constant(c2, ct2) when (ct1 = typeof<DateTime> && ct2 = typeof<DateTime>) -> Some("", CanonicalOperation(CanonicalOp.CaseSqlPlain(filter, SqlDateTime(unbox(c1)), SqlDateTime(unbox(c2))), SqlColumnType.KeyColumn("constant")), ct1)
+        | _, Constant(c1, ct1), Constant(c2, ct2) when ct1=ct2 -> Some("", CanonicalOperation(CanonicalOp.CaseSqlPlain(filter, SqlConstant(c1), SqlConstant(c2)), SqlColumnType.KeyColumn("constant")), ct1)
 
         | _ -> None
 
@@ -453,12 +443,12 @@ let rec (|SqlColumnGet|_|) (e:Expression) =
 //Simpler version of where Condition-pattern, used on case-when-clause
 and (|SimpleCondition|_|) exp =
     match exp with
-    // if using nullable types
     | SqlSpecialOpArr(ti,op,key,value)
     | SqlSpecialNegativeOpArr(ti,op,key,value) ->
         Some(ti,key,op,Some (box value))
     | SqlSpecialOp(ti,op,key,value) ->
         Some(ti,key,op,Some value)
+    // if using nullable types
     | OptionIsSome(SqlColumnGet(ti,key,_)) ->
         Some(ti,key,ConditionOperator.NotNull,None)
     | OptionIsNone(SqlColumnGet(ti,key,_))
@@ -477,7 +467,30 @@ and (|SimpleCondition|_|) exp =
     // matches column to column e.g. c.col1 > c.col2
     | SqlCondOp(op,(OptionalConvertOrTypeAs(SqlColumnGet(ti,key,_))),(OptionalConvertOrTypeAs(SqlColumnGet(ti2,key2,_)))) 
     | SqlNegativeCondOp(op,(OptionalConvertOrTypeAs(SqlColumnGet(ti,key,_))),(OptionalConvertOrTypeAs(SqlColumnGet(ti2,key2,_)))) ->
-        Some(ti,key,op,Some(("",key2) |> box))
+        Some(ti,key,op,Some((ti2,key2) |> box))
+    // matches to another property getter, method call or new expression
+    | SqlCondOp(op,OptionalConvertOrTypeAs(SqlColumnGet(ti,key,_)),OptionalConvertOrTypeAs(OptionalFSharpOptionValue((((:? MemberExpression) | (:? MethodCallExpression) | (:? NewExpression)) as meth))))
+    | SqlNegativeCondOp(op,OptionalConvertOrTypeAs(SqlColumnGet(ti,key,_)),OptionalConvertOrTypeAs(OptionalFSharpOptionValue((((:? MemberExpression) | (:? MethodCallExpression) | (:? NewExpression)) as meth))))
+    | SqlCondOp(op,OptionalConvertOrTypeAs(OptionalFSharpOptionValue((((:? MemberExpression) | (:? MethodCallExpression) | (:? NewExpression)) as meth))),OptionalConvertOrTypeAs(SqlColumnGet(ti,key,_)))
+    | SqlNegativeCondOp(op,OptionalConvertOrTypeAs(OptionalFSharpOptionValue((((:? MemberExpression) | (:? MethodCallExpression) | (:? NewExpression)) as meth))),OptionalConvertOrTypeAs(SqlColumnGet(ti,key,_))) ->
+
+        let invokedResult = Expression.Lambda(meth).Compile().DynamicInvoke()
+
+        let handleNullCompare() =
+            match op with
+            | ConditionOperator.Equal -> Some(ti,key,ConditionOperator.IsNull,None)
+            | ConditionOperator.NotEqual -> Some(ti,key,ConditionOperator.NotNull,None)
+            | _ -> Some(ti,key,op,Some(invokedResult))
+
+        if invokedResult = null then handleNullCompare()
+        else
+        let retType = invokedResult.GetType()
+        if retType.IsGenericType && retType.FullName.StartsWith("Microsoft.FSharp.Core.FSharpOption") then
+            let gotVal = retType.GetProperty("Value") // Option type Some should not be SQL-parameter.
+            match gotVal.GetValue(invokedResult, [||]) with
+            | null -> handleNullCompare()
+            | r -> Some(ti,key,op,Some(r))
+        else Some(ti,key,op,Some(invokedResult))
     | SqlColumnGet(ti,key,ret) when exp.Type.FullName = "System.Boolean" || ret = typeof<bool> -> 
         Some(ti,key,ConditionOperator.Equal, Some(true |> box))
     | _ -> None

--- a/src/SQLProvider/SqlRuntime.QueryExpression.fs
+++ b/src/SQLProvider/SqlRuntime.QueryExpression.fs
@@ -508,25 +508,33 @@ module internal QueryExpressionTransformer =
                 let resolvedSub =
                     match subItem with
                     | BasicMathOfColumns(op,al,col2) -> BasicMathOfColumns(op,resolver al, visitCanonicals resolverfunc col2)
-                    | Substring(SqlIntCol(al, col2)) -> Substring(SqlIntCol(resolver al, visitCanonicals resolverfunc col2))
+                    | Substring(SqlCol(al, col2)) -> Substring(SqlCol(resolver al, visitCanonicals resolverfunc col2))
 
-                    | SubstringWithLength(SqlIntCol(al2, col2),SqlIntCol(al3, col3)) -> SubstringWithLength(SqlIntCol(resolver al2, visitCanonicals resolver col2),SqlIntCol(resolver al3, visitCanonicals resolverfunc col3))
-                    | SubstringWithLength(x,SqlIntCol(al3, col3)) -> SubstringWithLength(x,SqlIntCol(resolver al3, visitCanonicals resolverfunc col3))
-                    | SubstringWithLength(SqlIntCol(al2, col2),x) -> SubstringWithLength(SqlIntCol(resolver al2, visitCanonicals resolverfunc col2),x)
+                    | SubstringWithLength(SqlCol(al2, col2),SqlCol(al3, col3)) -> SubstringWithLength(SqlCol(resolver al2, visitCanonicals resolver col2),SqlCol(resolver al3, visitCanonicals resolverfunc col3))
+                    | SubstringWithLength(x,SqlCol(al3, col3)) -> SubstringWithLength(x,SqlCol(resolver al3, visitCanonicals resolverfunc col3))
+                    | SubstringWithLength(SqlCol(al2, col2),x) -> SubstringWithLength(SqlCol(resolver al2, visitCanonicals resolverfunc col2),x)
 
-                    | Replace(SqlStrCol(al2, col2),SqlStrCol(al3, col3)) -> Replace(SqlStrCol(resolver al2, visitCanonicals resolver col2),SqlStrCol(resolver al3, visitCanonicals resolverfunc col3))
-                    | Replace(x,SqlStrCol(al3, col3)) -> Replace(x,SqlStrCol(resolver al3, visitCanonicals resolverfunc col3))
-                    | Replace(SqlStrCol(al2, col2),x) -> Replace(SqlStrCol(resolver al2, visitCanonicals resolverfunc col2),x)
+                    | Replace(SqlCol(al2, col2),SqlCol(al3, col3)) -> Replace(SqlCol(resolver al2, visitCanonicals resolver col2),SqlCol(resolver al3, visitCanonicals resolverfunc col3))
+                    | Replace(x,SqlCol(al3, col3)) -> Replace(x,SqlCol(resolver al3, visitCanonicals resolverfunc col3))
+                    | Replace(SqlCol(al2, col2),x) -> Replace(SqlCol(resolver al2, visitCanonicals resolverfunc col2),x)
 
-                    | IndexOfStart(SqlStrCol(al2, col2),SqlIntCol(al3, col3)) -> IndexOfStart(SqlStrCol(resolver al2, visitCanonicals resolver col2),SqlIntCol(resolver al3, visitCanonicals resolverfunc col3))
-                    | IndexOfStart(x,SqlIntCol(al3, col3)) -> IndexOfStart(x,SqlIntCol(resolver al3, visitCanonicals resolverfunc col3))
-                    | IndexOfStart(SqlStrCol(al2, col2),x) -> IndexOfStart(SqlStrCol(resolver al2, visitCanonicals resolverfunc col2),x)
+                    | IndexOfStart(SqlCol(al2, col2),SqlCol(al3, col3)) -> IndexOfStart(SqlCol(resolver al2, visitCanonicals resolver col2),SqlCol(resolver al3, visitCanonicals resolverfunc col3))
+                    | IndexOfStart(x,SqlCol(al3, col3)) -> IndexOfStart(x,SqlCol(resolver al3, visitCanonicals resolverfunc col3))
+                    | IndexOfStart(SqlCol(al2, col2),x) -> IndexOfStart(SqlCol(resolver al2, visitCanonicals resolverfunc col2),x)
 
-                    | IndexOf(SqlStrCol(al, col2)) -> IndexOf(SqlStrCol(resolver al, visitCanonicals resolverfunc col2))
+                    | IndexOf(SqlCol(al, col2)) -> IndexOf(SqlCol(resolver al, visitCanonicals resolverfunc col2))
 
-                    | AddYears(SqlIntCol(al, col2)) -> AddYears(SqlIntCol(resolver al, visitCanonicals resolverfunc col2))
-                    | AddDays(SqlNumCol(al, col2)) -> AddDays(SqlNumCol(resolver al, visitCanonicals resolverfunc col2))
-                    | AddMinutes(SqlNumCol(al, col2)) -> AddMinutes(SqlNumCol(resolver al, visitCanonicals resolverfunc col2))
+                    | AddYears(SqlCol(al, col2)) -> AddYears(SqlCol(resolver al, visitCanonicals resolverfunc col2))
+                    | AddDays(SqlCol(al, col2)) -> AddDays(SqlCol(resolver al, visitCanonicals resolverfunc col2))
+                    | AddMinutes(SqlCol(al, col2)) -> AddMinutes(SqlCol(resolver al, visitCanonicals resolverfunc col2))
+
+                    | Greatest(SqlCol(al, col)) -> Greatest(SqlCol(resolver al, visitCanonicals resolverfunc col))
+                    | Least(SqlCol(al, col)) -> Least(SqlCol(resolver al, visitCanonicals resolverfunc col))
+
+                    | CaseSql(SqlCol(al, col), SqlCol(al2, col2)) -> CaseSql(SqlCol(resolver al, visitCanonicals resolverfunc col), SqlCol(resolver al2, visitCanonicals resolverfunc col2))
+                    | CaseSql(SqlCol(al, col), x) -> CaseSql(SqlCol(resolver al, visitCanonicals resolverfunc col), x)
+                    | CaseSql(x, SqlCol(al, col)) -> CaseSql(x, SqlCol(resolver al, visitCanonicals resolverfunc col))
+
                     | x -> x
                 CanonicalOperation(resolvedSub, visitCanonicals resolverfunc col) 
             | x -> x

--- a/src/SQLProvider/Utils.fs
+++ b/src/SQLProvider/Utils.fs
@@ -107,7 +107,6 @@ module internal Utilities =
             match op with // These are very standard:
             | ToUpper -> sprintf "UPPER(%s)" column
             | ToLower -> sprintf "LOWER(%s)" column
-            | Replace(SqlStr(searchItm),SqlStr(toItm)) -> sprintf "REPLACE(%s,'%s','%s')" column searchItm toItm
             | Abs -> sprintf "ABS(%s)" column
             | Ceil -> sprintf "CEILING(%s)" column
             | Floor -> sprintf "FLOOR(%s)" column
@@ -157,6 +156,14 @@ module internal Utilities =
         | KeyColumn k -> k
         | CanonicalOperation(_, c) -> "c" + getBaseColumnName c
         | GroupColumn(_, c) -> "g" + getBaseColumnName c
+
+    let fieldConstant (value:obj) =
+        //Can we create named parameters in ODBC, and how?
+        match value with
+        | :? Guid
+        | :? DateTime
+        | :? String -> sprintf "'%s'" (value.ToString().Replace("'", ""))
+        | _ -> value.ToString()
 
 module ConfigHelpers = 
     

--- a/tests/SqlProvider.Tests/QueryTests.fs
+++ b/tests/SqlProvider.Tests/QueryTests.fs
@@ -1495,7 +1495,7 @@ let ``simple canonical operations case-when-elses``() =
             join emp in dc.Main.Employees on (cust.City.Trim() + "_" + cust.Country = emp.City.Trim() + "_" + emp.Country)
             where ((if box(emp.BirthDate)=null then 200 else 100) = 100) 
             where ((if emp.EmployeeId > 1L then 200 else 100) = 100) 
-            //where ((if emp.BirthDate > emp.BirthDate then 200 else 100) = 100) //doesn't work yet, alias resolving problem
+            where ((if emp.BirthDate > emp.BirthDate then 200 else 100) = 100)
             select (cust.CustomerId, cust.City, emp.BirthDate)
             distinct
         } |> Seq.toArray
@@ -1505,8 +1505,8 @@ let ``simple canonical operations case-when-elses``() =
     let qry2 = 
         query {
             for cust in dc.Main.Customers do
-            where ((if cust.City=cust.ContactName then cust.City else cust.Address)<>"x") //does work
-            where ( (if cust.City.Substring(0,3)<>"Lond" then cust.City else cust.Address) = "London") //does work
+            where ((if cust.City=cust.ContactName then cust.City else cust.Address)<>"x") 
+            where ( (if cust.City.Substring(0,3)<>"Lond" then cust.City else cust.Address) = "London")
             select (cust.City)
         } |> Seq.toArray
 

--- a/tests/SqlProvider.Tests/QueryTests.fs
+++ b/tests/SqlProvider.Tests/QueryTests.fs
@@ -1485,6 +1485,22 @@ let ``simple canonical operations query``() =
     Assert.AreEqual(12, qry.Length)
     Assert.IsTrue(qry.[0] |> fun (id,c,b) -> c="London" && b.Month>2)
 
+[<Test; Ignore("Not supported") >]
+let ``simple canonical operations case-when-else``() =
+    let dc = sql.GetDataContext()
+
+    let qry = 
+        query {
+            for cust in dc.Main.Customers do
+            join emp in dc.Main.Employees on (cust.City.Trim() + "_" + cust.Country = emp.City.Trim() + "_" + emp.Country)
+            where ((if emp.BirthDate.Year > 1000 then "a" else "b") = "a")
+            select (cust.CustomerId, cust.City, emp.BirthDate)
+            distinct
+        } |> Seq.toArray
+
+    CollectionAssert.IsNotEmpty qry
+    Assert.AreEqual(24, qry.Length)
+    Assert.IsTrue(qry.[0] |> fun (id,c,b) -> c="London" && b.Month>2)
 
 [<Test >]
 let ``simple operations in select query``() =


### PR DESCRIPTION
Progressing slowly towards #390 ... Sorry that I had to re-order some functions again.
We could start with simple "if this is a column or columns or entity -> use the current functionality, else if this is a SQL-canonical-operation-tree, serialize that for the select-clause". Or maybe even more simple for a start.

* [x] Move filterBuilder functions to be allowed to use also on `case when filter then x else y`
* [x] Add parametrized SQL possibility to canonical operations
* [x] Parse IIF-ConditionExpressions from LINQ-trees
* [x] Add support SQL support for Case-when-select-clauses to where-clauses
* [x] Create SimpleCondition to case-pattern to replicate the current where Condition -active pattern 
* [x] Change projection columns from string arrays to strongly typed ProjectionParameter
* [ ] Populate ProjectionParameter canonical operation trees in ProjectionItem pattern of transform-function in SqlRuntime.QueryExpression
* [ ] Parse ProjectionParameter canonical operation trees in columns of select-clauses
* [ ] Ensure projection lambda parameter types work also for the new canonical oprations
* [x] Ensure all canonical operations are producing parametrized SQL
* [x] Merge SimpleCondition and Condition if possible
* [ ] Update code comments

So the case-when-else is already supported in where-clause, but not yet parsed as an option from projection lambdas