### PR TITLE
Add ConnectionStringHash property to SqlEventData

### DIFF
--- a/.paket/Paket.Restore.targets
+++ b/.paket/Paket.Restore.targets
@@ -53,10 +53,10 @@
     </PropertyGroup>
 
     <!-- If shasum and awk exist get the hashes -->
-    <Exec Condition=" '$(PaketRestoreCachedHasher)' != '' " Command="$(PaketRestoreCachedHasher)" ConsoleToMSBuild='true'>
+    <Exec StandardOutputImportance="Low" Condition=" '$(PaketRestoreCachedHasher)' != '' " Command="$(PaketRestoreCachedHasher)" ConsoleToMSBuild='true'>
         <Output TaskParameter="ConsoleOutput" PropertyName="PaketRestoreCachedHash" />
     </Exec>
-    <Exec Condition=" '$(PaketRestoreLockFileHasher)' != '' " Command="$(PaketRestoreLockFileHasher)" ConsoleToMSBuild='true'>
+    <Exec StandardOutputImportance="Low" Condition=" '$(PaketRestoreLockFileHasher)' != '' " Command="$(PaketRestoreLockFileHasher)" ConsoleToMSBuild='true'>
         <Output TaskParameter="ConsoleOutput" PropertyName="PaketRestoreLockFileHash" />
     </Exec>
 

--- a/src/SQLProvider/Providers.Firebird.fs
+++ b/src/SQLProvider/Providers.Firebird.fs
@@ -1026,7 +1026,7 @@ type internal FirebirdProvider(resolutionPath, owner, referencedAssemblies, quot
                     match e._State with
                     | Created ->
                         let cmd = createInsertCommand con sb e
-                        Common.QueryEvents.PublishSqlQueryICol cmd.CommandText cmd.Parameters
+                        Common.QueryEvents.PublishSqlQueryICol con.ConnectionString cmd.CommandText cmd.Parameters
                         if timeout.IsSome then
                             cmd.CommandTimeout <- timeout.Value
                         let id = cmd.ExecuteScalar()
@@ -1034,14 +1034,14 @@ type internal FirebirdProvider(resolutionPath, owner, referencedAssemblies, quot
                         e._State <- Unchanged
                     | Modified fields ->
                         let cmd = createUpdateCommand con sb e fields
-                        Common.QueryEvents.PublishSqlQueryICol cmd.CommandText cmd.Parameters
+                        Common.QueryEvents.PublishSqlQueryICol con.ConnectionString cmd.CommandText cmd.Parameters
                         if timeout.IsSome then
                             cmd.CommandTimeout <- timeout.Value
                         cmd.ExecuteNonQuery() |> ignore
                         e._State <- Unchanged
                     | Delete ->
                         let cmd = createDeleteCommand con sb e
-                        Common.QueryEvents.PublishSqlQueryICol cmd.CommandText cmd.Parameters
+                        Common.QueryEvents.PublishSqlQueryICol con.ConnectionString cmd.CommandText cmd.Parameters
                         if timeout.IsSome then
                             cmd.CommandTimeout <- timeout.Value
                         cmd.ExecuteNonQuery() |> ignore
@@ -1078,7 +1078,7 @@ type internal FirebirdProvider(resolutionPath, owner, referencedAssemblies, quot
                         | Created ->
                             async {
                                 let cmd = createInsertCommand con sb e :?> System.Data.Common.DbCommand
-                                Common.QueryEvents.PublishSqlQueryICol cmd.CommandText cmd.Parameters
+                                Common.QueryEvents.PublishSqlQueryICol con.ConnectionString cmd.CommandText cmd.Parameters
                                 if timeout.IsSome then
                                     cmd.CommandTimeout <- timeout.Value
                                 let! id = cmd.ExecuteScalarAsync() |> Async.AwaitTask
@@ -1088,7 +1088,7 @@ type internal FirebirdProvider(resolutionPath, owner, referencedAssemblies, quot
                         | Modified fields ->
                             async {
                                 let cmd = createUpdateCommand con sb e fields :?> System.Data.Common.DbCommand
-                                Common.QueryEvents.PublishSqlQueryICol cmd.CommandText cmd.Parameters
+                                Common.QueryEvents.PublishSqlQueryICol con.ConnectionString cmd.CommandText cmd.Parameters
                                 if timeout.IsSome then
                                     cmd.CommandTimeout <- timeout.Value
                                 do! cmd.ExecuteNonQueryAsync() |> Async.AwaitTask |> Async.Ignore
@@ -1097,7 +1097,7 @@ type internal FirebirdProvider(resolutionPath, owner, referencedAssemblies, quot
                         | Delete ->
                             async {
                                 let cmd = createDeleteCommand con sb e :?> System.Data.Common.DbCommand
-                                Common.QueryEvents.PublishSqlQueryICol cmd.CommandText cmd.Parameters
+                                Common.QueryEvents.PublishSqlQueryICol con.ConnectionString cmd.CommandText cmd.Parameters
                                 if timeout.IsSome then
                                     cmd.CommandTimeout <- timeout.Value
                                 do! cmd.ExecuteNonQueryAsync() |> Async.AwaitTask |> Async.Ignore

--- a/src/SQLProvider/Providers.MSAccess.fs
+++ b/src/SQLProvider/Providers.MSAccess.fs
@@ -640,7 +640,7 @@ type internal MSAccessProvider() =
                         | Created ->
                             let cmd = createInsertCommand con sb e
                             cmd.Transaction <- trnsx :?> OleDbTransaction
-                            Common.QueryEvents.PublishSqlQueryCol cmd.CommandText cmd.Parameters
+                            Common.QueryEvents.PublishSqlQueryCol con.ConnectionString cmd.CommandText cmd.Parameters
                             if timeout.IsSome then
                                 cmd.CommandTimeout <- timeout.Value
                             let id = cmd.ExecuteScalar()
@@ -649,7 +649,7 @@ type internal MSAccessProvider() =
                         | Modified fields ->
                             let cmd = createUpdateCommand con sb e fields
                             cmd.Transaction <- trnsx :?> OleDbTransaction
-                            Common.QueryEvents.PublishSqlQueryCol cmd.CommandText cmd.Parameters
+                            Common.QueryEvents.PublishSqlQueryCol con.ConnectionString cmd.CommandText cmd.Parameters
                             if timeout.IsSome then
                                 cmd.CommandTimeout <- timeout.Value
                             cmd.ExecuteNonQuery() |> ignore
@@ -657,7 +657,7 @@ type internal MSAccessProvider() =
                         | Delete ->
                             let cmd = createDeleteCommand con sb e
                             cmd.Transaction <- trnsx :?> OleDbTransaction
-                            Common.QueryEvents.PublishSqlQueryCol cmd.CommandText cmd.Parameters
+                            Common.QueryEvents.PublishSqlQueryCol con.ConnectionString cmd.CommandText cmd.Parameters
                             if timeout.IsSome then
                                 cmd.CommandTimeout <- timeout.Value
                             cmd.ExecuteNonQuery() |> ignore
@@ -699,7 +699,7 @@ type internal MSAccessProvider() =
                                 async {
                                     let cmd = createInsertCommand con sb e
                                     cmd.Transaction <- trnsx :?> OleDbTransaction
-                                    Common.QueryEvents.PublishSqlQueryCol cmd.CommandText cmd.Parameters
+                                    Common.QueryEvents.PublishSqlQueryCol con.ConnectionString cmd.CommandText cmd.Parameters
                                     if timeout.IsSome then
                                         cmd.CommandTimeout <- timeout.Value
                                     let! id = cmd.ExecuteScalarAsync() |> Async.AwaitTask
@@ -710,7 +710,7 @@ type internal MSAccessProvider() =
                                 async {
                                     let cmd = createUpdateCommand con sb e fields
                                     cmd.Transaction <- trnsx :?> OleDbTransaction
-                                    Common.QueryEvents.PublishSqlQueryCol cmd.CommandText cmd.Parameters
+                                    Common.QueryEvents.PublishSqlQueryCol con.ConnectionString cmd.CommandText cmd.Parameters
                                     if timeout.IsSome then
                                         cmd.CommandTimeout <- timeout.Value
                                     do! cmd.ExecuteNonQueryAsync() |> Async.AwaitTask |> Async.Ignore
@@ -720,7 +720,7 @@ type internal MSAccessProvider() =
                                 async {
                                     let cmd = createDeleteCommand con sb e
                                     cmd.Transaction <- trnsx :?> OleDbTransaction
-                                    Common.QueryEvents.PublishSqlQueryCol cmd.CommandText cmd.Parameters
+                                    Common.QueryEvents.PublishSqlQueryCol con.ConnectionString cmd.CommandText cmd.Parameters
                                     if timeout.IsSome then
                                         cmd.CommandTimeout <- timeout.Value
                                     do! cmd.ExecuteNonQueryAsync() |> Async.AwaitTask |> Async.Ignore

--- a/src/SQLProvider/Providers.MsSqlServer.fs
+++ b/src/SQLProvider/Providers.MsSqlServer.fs
@@ -969,7 +969,7 @@ type internal MSSqlServerProvider(tableNames:string) =
                     match e._State with
                     | Created ->
                         let cmd = createInsertCommand con sb e
-                        Common.QueryEvents.PublishSqlQueryCol cmd.CommandText cmd.Parameters
+                        Common.QueryEvents.PublishSqlQueryCol con.ConnectionString cmd.CommandText cmd.Parameters
                         if timeout.IsSome then
                             cmd.CommandTimeout <- timeout.Value
                         let id = cmd.ExecuteScalar()
@@ -977,14 +977,14 @@ type internal MSSqlServerProvider(tableNames:string) =
                         e._State <- Unchanged
                     | Modified fields ->
                         let cmd = createUpdateCommand con sb e fields
-                        Common.QueryEvents.PublishSqlQueryCol cmd.CommandText cmd.Parameters
+                        Common.QueryEvents.PublishSqlQueryCol con.ConnectionString cmd.CommandText cmd.Parameters
                         if timeout.IsSome then
                             cmd.CommandTimeout <- timeout.Value
                         cmd.ExecuteNonQuery() |> ignore
                         e._State <- Unchanged
                     | Delete ->
                         let cmd = createDeleteCommand con sb e
-                        Common.QueryEvents.PublishSqlQueryCol cmd.CommandText cmd.Parameters
+                        Common.QueryEvents.PublishSqlQueryCol con.ConnectionString cmd.CommandText cmd.Parameters
                         if timeout.IsSome then
                             cmd.CommandTimeout <- timeout.Value
                         cmd.ExecuteNonQuery() |> ignore
@@ -1019,7 +1019,7 @@ type internal MSSqlServerProvider(tableNames:string) =
                         | Created ->
                             async {
                                 let cmd = createInsertCommand con sb e
-                                Common.QueryEvents.PublishSqlQueryCol cmd.CommandText cmd.Parameters
+                                Common.QueryEvents.PublishSqlQueryCol con.ConnectionString cmd.CommandText cmd.Parameters
                                 if timeout.IsSome then
                                     cmd.CommandTimeout <- timeout.Value
                                 let! id = cmd.ExecuteScalarAsync() |> Async.AwaitTask
@@ -1029,7 +1029,7 @@ type internal MSSqlServerProvider(tableNames:string) =
                         | Modified fields ->
                             async {
                                 let cmd = createUpdateCommand con sb e fields
-                                Common.QueryEvents.PublishSqlQueryCol cmd.CommandText cmd.Parameters
+                                Common.QueryEvents.PublishSqlQueryCol con.ConnectionString cmd.CommandText cmd.Parameters
                                 if timeout.IsSome then
                                     cmd.CommandTimeout <- timeout.Value
                                 do! cmd.ExecuteNonQueryAsync() |> Async.AwaitTask |> Async.Ignore
@@ -1038,7 +1038,7 @@ type internal MSSqlServerProvider(tableNames:string) =
                         | Delete ->
                             async {
                                 let cmd = createDeleteCommand con sb e
-                                Common.QueryEvents.PublishSqlQueryCol cmd.CommandText cmd.Parameters
+                                Common.QueryEvents.PublishSqlQueryCol con.ConnectionString cmd.CommandText cmd.Parameters
                                 if timeout.IsSome then
                                     cmd.CommandTimeout <- timeout.Value
                                 do! cmd.ExecuteNonQueryAsync() |> Async.AwaitTask |> Async.Ignore

--- a/src/SQLProvider/Providers.MySql.fs
+++ b/src/SQLProvider/Providers.MySql.fs
@@ -945,7 +945,7 @@ type internal MySqlProvider(resolutionPath, owner, referencedAssemblies) as this
                     match e._State with
                     | Created ->
                         let cmd = createInsertCommand con sb e
-                        Common.QueryEvents.PublishSqlQueryICol cmd.CommandText cmd.Parameters
+                        Common.QueryEvents.PublishSqlQueryICol con.ConnectionString cmd.CommandText cmd.Parameters
                         if timeout.IsSome then
                             cmd.CommandTimeout <- timeout.Value
                         let id = cmd.ExecuteScalar()
@@ -953,14 +953,14 @@ type internal MySqlProvider(resolutionPath, owner, referencedAssemblies) as this
                         e._State <- Unchanged
                     | Modified fields ->
                         let cmd = createUpdateCommand con sb e fields
-                        Common.QueryEvents.PublishSqlQueryICol cmd.CommandText cmd.Parameters
+                        Common.QueryEvents.PublishSqlQueryICol con.ConnectionString cmd.CommandText cmd.Parameters
                         if timeout.IsSome then
                             cmd.CommandTimeout <- timeout.Value
                         cmd.ExecuteNonQuery() |> ignore
                         e._State <- Unchanged
                     | Delete ->
                         let cmd = createDeleteCommand con sb e
-                        Common.QueryEvents.PublishSqlQueryICol cmd.CommandText cmd.Parameters
+                        Common.QueryEvents.PublishSqlQueryICol con.ConnectionString cmd.CommandText cmd.Parameters
                         if timeout.IsSome then
                             cmd.CommandTimeout <- timeout.Value
                         cmd.ExecuteNonQuery() |> ignore
@@ -997,7 +997,7 @@ type internal MySqlProvider(resolutionPath, owner, referencedAssemblies) as this
                         | Created ->
                             async {
                                 let cmd = createInsertCommand con sb e :?> System.Data.Common.DbCommand
-                                Common.QueryEvents.PublishSqlQueryICol cmd.CommandText cmd.Parameters
+                                Common.QueryEvents.PublishSqlQueryICol con.ConnectionString cmd.CommandText cmd.Parameters
                                 if timeout.IsSome then
                                     cmd.CommandTimeout <- timeout.Value
                                 let! id = cmd.ExecuteScalarAsync() |> Async.AwaitTask
@@ -1007,7 +1007,7 @@ type internal MySqlProvider(resolutionPath, owner, referencedAssemblies) as this
                         | Modified fields ->
                             async {
                                 let cmd = createUpdateCommand con sb e fields :?> System.Data.Common.DbCommand
-                                Common.QueryEvents.PublishSqlQueryICol cmd.CommandText cmd.Parameters
+                                Common.QueryEvents.PublishSqlQueryICol con.ConnectionString cmd.CommandText cmd.Parameters
                                 if timeout.IsSome then
                                     cmd.CommandTimeout <- timeout.Value
                                 do! cmd.ExecuteNonQueryAsync() |> Async.AwaitTask |> Async.Ignore
@@ -1016,7 +1016,7 @@ type internal MySqlProvider(resolutionPath, owner, referencedAssemblies) as this
                         | Delete ->
                             async {
                                 let cmd = createDeleteCommand con sb e :?> System.Data.Common.DbCommand
-                                Common.QueryEvents.PublishSqlQueryICol cmd.CommandText cmd.Parameters
+                                Common.QueryEvents.PublishSqlQueryICol con.ConnectionString cmd.CommandText cmd.Parameters
                                 if timeout.IsSome then
                                     cmd.CommandTimeout <- timeout.Value
                                 do! cmd.ExecuteNonQueryAsync() |> Async.AwaitTask |> Async.Ignore

--- a/src/SQLProvider/Providers.Odbc.fs
+++ b/src/SQLProvider/Providers.Odbc.fs
@@ -647,7 +647,7 @@ type internal OdbcProvider(quotechar : OdbcQuoteCharacter) =
                     match e._State with
                     | Created ->
                         let cmd = createInsertCommand con sb e
-                        Common.QueryEvents.PublishSqlQueryCol cmd.CommandText cmd.Parameters
+                        Common.QueryEvents.PublishSqlQueryCol con.ConnectionString cmd.CommandText cmd.Parameters
                         if timeout.IsSome then
                             cmd.CommandTimeout <- timeout.Value
                         cmd.ExecuteNonQuery() |> ignore
@@ -656,14 +656,14 @@ type internal OdbcProvider(quotechar : OdbcQuoteCharacter) =
                         e._State <- Unchanged
                     | Modified fields ->
                         let cmd = createUpdateCommand con sb e fields
-                        Common.QueryEvents.PublishSqlQueryCol cmd.CommandText cmd.Parameters
+                        Common.QueryEvents.PublishSqlQueryCol con.ConnectionString cmd.CommandText cmd.Parameters
                         if timeout.IsSome then
                             cmd.CommandTimeout <- timeout.Value
                         cmd.ExecuteNonQuery() |> ignore
                         e._State <- Unchanged
                     | Delete ->
                         let cmd = createDeleteCommand con sb e
-                        Common.QueryEvents.PublishSqlQueryCol cmd.CommandText cmd.Parameters
+                        Common.QueryEvents.PublishSqlQueryCol con.ConnectionString cmd.CommandText cmd.Parameters
                         if timeout.IsSome then
                             cmd.CommandTimeout <- timeout.Value
                         cmd.ExecuteNonQuery() |> ignore
@@ -698,7 +698,7 @@ type internal OdbcProvider(quotechar : OdbcQuoteCharacter) =
                         | Created ->
                             async {
                                 let cmd = createInsertCommand con sb e
-                                Common.QueryEvents.PublishSqlQueryCol cmd.CommandText cmd.Parameters
+                                Common.QueryEvents.PublishSqlQueryCol con.ConnectionString cmd.CommandText cmd.Parameters
                                 if timeout.IsSome then
                                     cmd.CommandTimeout <- timeout.Value
                                 do! cmd.ExecuteNonQueryAsync() |> Async.AwaitTask |> Async.Ignore
@@ -709,7 +709,7 @@ type internal OdbcProvider(quotechar : OdbcQuoteCharacter) =
                         | Modified fields ->
                             async {
                                 let cmd = createUpdateCommand con sb e fields
-                                Common.QueryEvents.PublishSqlQueryCol cmd.CommandText cmd.Parameters
+                                Common.QueryEvents.PublishSqlQueryCol con.ConnectionString cmd.CommandText cmd.Parameters
                                 if timeout.IsSome then
                                     cmd.CommandTimeout <- timeout.Value
                                 do! cmd.ExecuteNonQueryAsync() |> Async.AwaitTask |> Async.Ignore
@@ -718,7 +718,7 @@ type internal OdbcProvider(quotechar : OdbcQuoteCharacter) =
                         | Delete ->
                             async {
                                 let cmd = createDeleteCommand con sb e
-                                Common.QueryEvents.PublishSqlQueryCol cmd.CommandText cmd.Parameters
+                                Common.QueryEvents.PublishSqlQueryCol con.ConnectionString cmd.CommandText cmd.Parameters
                                 if timeout.IsSome then
                                     cmd.CommandTimeout <- timeout.Value
                                 do! cmd.ExecuteNonQueryAsync() |> Async.AwaitTask |> Async.Ignore

--- a/src/SQLProvider/Providers.Oracle.fs
+++ b/src/SQLProvider/Providers.Oracle.fs
@@ -1005,7 +1005,7 @@ type internal OracleProvider(resolutionPath, owner, referencedAssemblies, tableN
                     match e._State with
                     | Created ->
                         let cmd = createInsertCommand provider con sb e
-                        Common.QueryEvents.PublishSqlQueryICol cmd.CommandText cmd.Parameters
+                        Common.QueryEvents.PublishSqlQueryICol con.ConnectionString cmd.CommandText cmd.Parameters
                         if timeout.IsSome then
                             cmd.CommandTimeout <- timeout.Value
                         let id = cmd.ExecuteScalar()
@@ -1018,14 +1018,14 @@ type internal OracleProvider(resolutionPath, owner, referencedAssemblies, tableN
                         e._State <- Unchanged
                     | Modified fields ->
                         let cmd = createUpdateCommand provider con sb e fields
-                        Common.QueryEvents.PublishSqlQueryICol cmd.CommandText cmd.Parameters
+                        Common.QueryEvents.PublishSqlQueryICol con.ConnectionString cmd.CommandText cmd.Parameters
                         if timeout.IsSome then
                             cmd.CommandTimeout <- timeout.Value
                         cmd.ExecuteNonQuery() |> ignore
                         e._State <- Unchanged
                     | Delete ->
                         let cmd = createDeleteCommand provider con sb e
-                        Common.QueryEvents.PublishSqlQueryICol cmd.CommandText cmd.Parameters
+                        Common.QueryEvents.PublishSqlQueryICol con.ConnectionString cmd.CommandText cmd.Parameters
                         if timeout.IsSome then
                             cmd.CommandTimeout <- timeout.Value
                         cmd.ExecuteNonQuery() |> ignore
@@ -1062,7 +1062,7 @@ type internal OracleProvider(resolutionPath, owner, referencedAssemblies, tableN
                         | Created ->
                             async {
                                 let cmd = createInsertCommand provider con sb e :?> System.Data.Common.DbCommand
-                                Common.QueryEvents.PublishSqlQueryICol cmd.CommandText cmd.Parameters
+                                Common.QueryEvents.PublishSqlQueryICol cmd.CommandText con.ConnectionString cmd.Parameters
                                 if timeout.IsSome then
                                     cmd.CommandTimeout <- timeout.Value
                                 let! id = cmd.ExecuteScalarAsync() |> Async.AwaitTask
@@ -1077,7 +1077,7 @@ type internal OracleProvider(resolutionPath, owner, referencedAssemblies, tableN
                         | Modified fields ->
                             async {
                                 let cmd = createUpdateCommand provider con sb e fields :?> System.Data.Common.DbCommand
-                                Common.QueryEvents.PublishSqlQueryICol cmd.CommandText cmd.Parameters
+                                Common.QueryEvents.PublishSqlQueryICol cmd.CommandText con.ConnectionString cmd.Parameters
                                 if timeout.IsSome then
                                     cmd.CommandTimeout <- timeout.Value
                                 do! cmd.ExecuteNonQueryAsync() |> Async.AwaitTask |> Async.Ignore
@@ -1086,7 +1086,7 @@ type internal OracleProvider(resolutionPath, owner, referencedAssemblies, tableN
                         | Delete ->
                             async {
                                 let cmd = createDeleteCommand provider con sb e :?> System.Data.Common.DbCommand
-                                Common.QueryEvents.PublishSqlQueryICol cmd.CommandText cmd.Parameters
+                                Common.QueryEvents.PublishSqlQueryICol cmd.CommandText con.ConnectionString cmd.Parameters
                                 if timeout.IsSome then
                                     cmd.CommandTimeout <- timeout.Value
                                 do! cmd.ExecuteNonQueryAsync() |> Async.AwaitTask |> Async.Ignore

--- a/src/SQLProvider/Providers.Oracle.fs
+++ b/src/SQLProvider/Providers.Oracle.fs
@@ -1062,7 +1062,7 @@ type internal OracleProvider(resolutionPath, owner, referencedAssemblies, tableN
                         | Created ->
                             async {
                                 let cmd = createInsertCommand provider con sb e :?> System.Data.Common.DbCommand
-                                Common.QueryEvents.PublishSqlQueryICol cmd.CommandText con.ConnectionString cmd.Parameters
+                                Common.QueryEvents.PublishSqlQueryICol con.ConnectionString cmd.CommandText cmd.Parameters
                                 if timeout.IsSome then
                                     cmd.CommandTimeout <- timeout.Value
                                 let! id = cmd.ExecuteScalarAsync() |> Async.AwaitTask
@@ -1077,7 +1077,7 @@ type internal OracleProvider(resolutionPath, owner, referencedAssemblies, tableN
                         | Modified fields ->
                             async {
                                 let cmd = createUpdateCommand provider con sb e fields :?> System.Data.Common.DbCommand
-                                Common.QueryEvents.PublishSqlQueryICol cmd.CommandText con.ConnectionString cmd.Parameters
+                                Common.QueryEvents.PublishSqlQueryICol con.ConnectionString cmd.CommandText cmd.Parameters
                                 if timeout.IsSome then
                                     cmd.CommandTimeout <- timeout.Value
                                 do! cmd.ExecuteNonQueryAsync() |> Async.AwaitTask |> Async.Ignore
@@ -1086,7 +1086,7 @@ type internal OracleProvider(resolutionPath, owner, referencedAssemblies, tableN
                         | Delete ->
                             async {
                                 let cmd = createDeleteCommand provider con sb e :?> System.Data.Common.DbCommand
-                                Common.QueryEvents.PublishSqlQueryICol cmd.CommandText con.ConnectionString cmd.Parameters
+                                Common.QueryEvents.PublishSqlQueryICol con.ConnectionString cmd.CommandText cmd.Parameters
                                 if timeout.IsSome then
                                     cmd.CommandTimeout <- timeout.Value
                                 do! cmd.ExecuteNonQueryAsync() |> Async.AwaitTask |> Async.Ignore

--- a/src/SQLProvider/Providers.Postgresql.fs
+++ b/src/SQLProvider/Providers.Postgresql.fs
@@ -1152,7 +1152,7 @@ type internal PostgresqlProvider(resolutionPath, owner, referencedAssemblies) =
                     match e._State with
                     | Created ->
                         let cmd = createInsertCommand con sb e
-                        Common.QueryEvents.PublishSqlQueryICol cmd.CommandText cmd.Parameters
+                        Common.QueryEvents.PublishSqlQueryICol con.ConnectionString cmd.CommandText cmd.Parameters
                         if timeout.IsSome then
                             cmd.CommandTimeout <- timeout.Value
                         let id = cmd.ExecuteScalar()
@@ -1160,14 +1160,14 @@ type internal PostgresqlProvider(resolutionPath, owner, referencedAssemblies) =
                         e._State <- Unchanged
                     | Modified fields ->
                         let cmd = createUpdateCommand con sb e fields
-                        Common.QueryEvents.PublishSqlQueryICol cmd.CommandText cmd.Parameters
+                        Common.QueryEvents.PublishSqlQueryICol con.ConnectionString cmd.CommandText cmd.Parameters
                         if timeout.IsSome then
                             cmd.CommandTimeout <- timeout.Value
                         cmd.ExecuteNonQuery() |> ignore
                         e._State <- Unchanged
                     | Delete ->
                         let cmd = createDeleteCommand con sb e
-                        Common.QueryEvents.PublishSqlQueryICol cmd.CommandText cmd.Parameters
+                        Common.QueryEvents.PublishSqlQueryICol con.ConnectionString cmd.CommandText cmd.Parameters
                         if timeout.IsSome then
                             cmd.CommandTimeout <- timeout.Value
                         cmd.ExecuteNonQuery() |> ignore
@@ -1203,7 +1203,7 @@ type internal PostgresqlProvider(resolutionPath, owner, referencedAssemblies) =
                         | Created ->
                             async {
                                 let cmd = createInsertCommand con sb e :?> System.Data.Common.DbCommand
-                                Common.QueryEvents.PublishSqlQueryICol cmd.CommandText cmd.Parameters
+                                Common.QueryEvents.PublishSqlQueryICol con.ConnectionString cmd.CommandText cmd.Parameters
                                 if timeout.IsSome then
                                     cmd.CommandTimeout <- timeout.Value
                                 let! id = cmd.ExecuteScalarAsync() |> Async.AwaitTask
@@ -1213,7 +1213,7 @@ type internal PostgresqlProvider(resolutionPath, owner, referencedAssemblies) =
                         | Modified fields ->
                             async {
                                 let cmd = createUpdateCommand con sb e fields :?> System.Data.Common.DbCommand
-                                Common.QueryEvents.PublishSqlQueryICol cmd.CommandText cmd.Parameters
+                                Common.QueryEvents.PublishSqlQueryICol con.ConnectionString cmd.CommandText cmd.Parameters
                                 if timeout.IsSome then
                                     cmd.CommandTimeout <- timeout.Value
                                 do! cmd.ExecuteNonQueryAsync() |> Async.AwaitTask |> Async.Ignore
@@ -1222,7 +1222,7 @@ type internal PostgresqlProvider(resolutionPath, owner, referencedAssemblies) =
                         | Delete ->
                             async {
                                 let cmd = createDeleteCommand con sb e :?> System.Data.Common.DbCommand
-                                Common.QueryEvents.PublishSqlQueryICol cmd.CommandText cmd.Parameters
+                                Common.QueryEvents.PublishSqlQueryICol con.ConnectionString cmd.CommandText cmd.Parameters
                                 if timeout.IsSome then
                                     cmd.CommandTimeout <- timeout.Value
                                 do! cmd.ExecuteNonQueryAsync() |> Async.AwaitTask |> Async.Ignore

--- a/src/SQLProvider/Providers.SQLite.fs
+++ b/src/SQLProvider/Providers.SQLite.fs
@@ -843,7 +843,7 @@ type internal SQLiteProvider(resolutionPath, referencedAssemblies, runtimeAssemb
                     match e._State with
                     | Created ->
                         use cmd = createInsertCommand con sb e
-                        Common.QueryEvents.PublishSqlQueryICol cmd.CommandText cmd.Parameters
+                        Common.QueryEvents.PublishSqlQueryICol con.ConnectionString cmd.CommandText cmd.Parameters
                         if timeout.IsSome then
                             cmd.CommandTimeout <- timeout.Value
                         let id = cmd.ExecuteScalar()
@@ -851,14 +851,14 @@ type internal SQLiteProvider(resolutionPath, referencedAssemblies, runtimeAssemb
                         e._State <- Unchanged
                     | Modified fields ->
                         use cmd = createUpdateCommand con sb e fields
-                        Common.QueryEvents.PublishSqlQueryICol cmd.CommandText cmd.Parameters
+                        Common.QueryEvents.PublishSqlQueryICol con.ConnectionString cmd.CommandText cmd.Parameters
                         if timeout.IsSome then
                             cmd.CommandTimeout <- timeout.Value
                         cmd.ExecuteNonQuery() |> ignore
                         e._State <- Unchanged
                     | Delete ->
                         use cmd = createDeleteCommand con sb e
-                        Common.QueryEvents.PublishSqlQueryICol cmd.CommandText cmd.Parameters
+                        Common.QueryEvents.PublishSqlQueryICol con.ConnectionString cmd.CommandText cmd.Parameters
                         if timeout.IsSome then
                             cmd.CommandTimeout <- timeout.Value
                         cmd.ExecuteNonQuery() |> ignore
@@ -892,7 +892,7 @@ type internal SQLiteProvider(resolutionPath, referencedAssemblies, runtimeAssemb
                         | Created ->
                             async {
                                 use cmd = createInsertCommand con sb e :?> System.Data.Common.DbCommand
-                                Common.QueryEvents.PublishSqlQueryICol cmd.CommandText cmd.Parameters
+                                Common.QueryEvents.PublishSqlQueryICol con.ConnectionString cmd.CommandText cmd.Parameters
                                 if timeout.IsSome then
                                     cmd.CommandTimeout <- timeout.Value
                                 let! id = cmd.ExecuteScalarAsync() |> Async.AwaitTask
@@ -902,7 +902,7 @@ type internal SQLiteProvider(resolutionPath, referencedAssemblies, runtimeAssemb
                         | Modified fields ->
                             async {
                                 use cmd = createUpdateCommand con sb e fields :?> System.Data.Common.DbCommand
-                                Common.QueryEvents.PublishSqlQueryICol cmd.CommandText cmd.Parameters
+                                Common.QueryEvents.PublishSqlQueryICol con.ConnectionString cmd.CommandText cmd.Parameters
                                 if timeout.IsSome then
                                     cmd.CommandTimeout <- timeout.Value
                                 do! cmd.ExecuteNonQueryAsync() |> Async.AwaitTask |> Async.Ignore
@@ -911,7 +911,7 @@ type internal SQLiteProvider(resolutionPath, referencedAssemblies, runtimeAssemb
                         | Delete ->
                             async {
                                 use cmd = createDeleteCommand con sb e :?> System.Data.Common.DbCommand
-                                Common.QueryEvents.PublishSqlQueryICol cmd.CommandText cmd.Parameters
+                                Common.QueryEvents.PublishSqlQueryICol con.ConnectionString cmd.CommandText cmd.Parameters
                                 if timeout.IsSome then
                                     cmd.CommandTimeout <- timeout.Value
                                 do! cmd.ExecuteNonQueryAsync() |> Async.AwaitTask |> Async.Ignore

--- a/src/SQLProvider/SqlRuntime.Common.fs
+++ b/src/SQLProvider/SqlRuntime.Common.fs
@@ -98,13 +98,13 @@ module public QueryEvents =
                            Parameters = parameters
                          }
 
-   let PublishSqlQuery connStr qry (spc:IDbDataParameter seq) = 
+   let internal PublishSqlQuery connStr qry (spc:IDbDataParameter seq) = 
       publishSqlQuery connStr qry (spc |> Seq.map(fun p -> p.ParameterName, p.Value))
 
-   let PublishSqlQueryCol connStr qry (spc:DbParameterCollection) = 
+   let internal PublishSqlQueryCol connStr qry (spc:DbParameterCollection) = 
       publishSqlQuery connStr qry [ for p in spc -> (p.ParameterName, p.Value) ]
 
-   let PublishSqlQueryICol connStr qry (spc:IDataParameterCollection) = 
+   let internal PublishSqlQueryICol connStr qry (spc:IDataParameterCollection) = 
       publishSqlQuery connStr qry [ for op in spc do
                                       let p = op :?> IDataParameter
                                       yield (p.ParameterName, p.Value)]
@@ -115,7 +115,7 @@ module public QueryEvents =
    [<CLIEvent>]
    let LinqExpressionEvent = expressionEvent.Publish
 
-   let PublishExpression(e) = expressionEvent.Trigger(e)
+   let internal PublishExpression(e) = expressionEvent.Trigger(e)
 
    
 type EntityState =

--- a/src/SQLProvider/SqlRuntime.Common.fs
+++ b/src/SQLProvider/SqlRuntime.Common.fs
@@ -59,6 +59,7 @@ module public QueryEvents =
    
    type SqlEventData = {
        Command: string
+       ConnectionString: string
        Parameters: (string*obj) seq
    }
    with 
@@ -83,12 +84,13 @@ module public QueryEvents =
    let SqlQueryEvent = sqlEvent.Publish
 
    let PublishExpression(e) = expressionEvent.Trigger(e)
-   let PublishSqlQuery qry (spc:IDbDataParameter seq) = sqlEvent.Trigger( {Command = qry; Parameters = spc |> Seq.map(fun p -> p.ParameterName, p.Value) })
-   let PublishSqlQueryCol qry (spc:DbParameterCollection) = 
-        sqlEvent.Trigger( {Command = qry; Parameters = [for p in spc do yield (p.ParameterName, p.Value)] })
-   let PublishSqlQueryICol qry (spc:IDataParameterCollection) = 
+   let PublishSqlQuery connStr qry (spc:IDbDataParameter seq) = sqlEvent.Trigger( {Command = qry; ConnectionString = connStr; Parameters = spc |> Seq.map(fun p -> p.ParameterName, p.Value) })
+   let PublishSqlQueryCol connStr qry (spc:DbParameterCollection) = 
+        sqlEvent.Trigger( {Command = qry; ConnectionString = connStr; Parameters = [for p in spc do yield (p.ParameterName, p.Value)] })
+   let PublishSqlQueryICol connStr qry (spc:IDataParameterCollection) = 
         sqlEvent.Trigger(
             { Command = qry; 
+              ConnectionString = connStr;
               Parameters = [ for op in spc do
                                let p = op :?> IDataParameter
                                yield (p.ParameterName, p.Value)] })

--- a/src/SQLProvider/SqlRuntime.DataContext.fs
+++ b/src/SQLProvider/SqlRuntime.DataContext.fs
@@ -45,7 +45,7 @@ type public SqlDataContext (typeName, connectionString:string, providerType, res
                 if (providerType <> DatabaseProviderTypes.MSACCESS && providerType.GetType() <> typeof<Providers.MSAccessProvider>) then con.Close()
                 prov)
 
-    let initCallSproc (dc:SqlDataContext) (def:RunTimeSprocDefinition) (values:obj array) (con:IDbConnection) (com:IDbCommand) =
+    let initCallSproc (dc:ISqlDataContext) (def:RunTimeSprocDefinition) (values:obj array) (con:IDbConnection) (com:IDbCommand) =
         
         if (providerType <> DatabaseProviderTypes.SQLITE) then 
             com.CommandType <- CommandType.StoredProcedure
@@ -67,7 +67,7 @@ type public SqlDataContext (typeName, connectionString:string, providerType, res
 
         let param = def.Params |> List.toArray
 
-        Common.QueryEvents.PublishSqlQuery (sprintf "EXEC %s(%s)" com.CommandText (String.Join(", ", (values |> Seq.map (sprintf "%A"))))) []
+        Common.QueryEvents.PublishSqlQuery dc.ConnectionString (sprintf "EXEC %s(%s)" com.CommandText (String.Join(", ", (values |> Seq.map (sprintf "%A"))))) []
         param, entity, toEntityArray
 
     interface ISqlDataContext with

--- a/src/SQLProvider/SqlRuntime.Linq.fs
+++ b/src/SQLProvider/SqlRuntime.Linq.fs
@@ -107,7 +107,7 @@ module internal QueryImplementation =
     let executeQuery (dc:ISqlDataContext) (provider:ISqlProvider) sqlExp ti =
         use con = provider.CreateConnection(dc.ConnectionString)
         let (query,parameters,projector,baseTable) = QueryExpressionTransformer.convertExpression sqlExp ti con provider false (dc.SqlOperationsInSelect=SelectOperations.DatabaseSide)
-        Common.QueryEvents.PublishSqlQuery query parameters
+        Common.QueryEvents.PublishSqlQuery con.ConnectionString query parameters
         // todo: make this lazily evaluated? or optionally so. but have to deal with disposing stuff somehow
         use cmd = provider.CreateCommand(con,query)
         if dc.CommandTimeout.IsSome then
@@ -125,7 +125,7 @@ module internal QueryImplementation =
        async {
            use con = provider.CreateConnection(dc.ConnectionString) :?> System.Data.Common.DbConnection
            let (query,parameters,projector,baseTable) = QueryExpressionTransformer.convertExpression sqlExp ti con provider false (dc.SqlOperationsInSelect=SelectOperations.DatabaseSide)
-           Common.QueryEvents.PublishSqlQuery query parameters
+           Common.QueryEvents.PublishSqlQuery con.ConnectionString  query parameters
            // todo: make this lazily evaluated? or optionally so. but have to deal with disposing stuff somehow
            use cmd = provider.CreateCommand(con,query) :?> System.Data.Common.DbCommand
            if dc.CommandTimeout.IsSome then
@@ -148,7 +148,7 @@ module internal QueryImplementation =
        use con = provider.CreateConnection(dc.ConnectionString)
        con.Open()
        let (query,parameters,_,_) = QueryExpressionTransformer.convertExpression sqlExp ti con provider false true
-       Common.QueryEvents.PublishSqlQuery query parameters
+       Common.QueryEvents.PublishSqlQuery con.ConnectionString  query parameters
        use cmd = provider.CreateCommand(con,query)
        if dc.CommandTimeout.IsSome then
            cmd.CommandTimeout <- dc.CommandTimeout.Value
@@ -164,7 +164,7 @@ module internal QueryImplementation =
            use con = provider.CreateConnection(dc.ConnectionString) :?> System.Data.Common.DbConnection
            do! con.OpenAsync() |> Async.AwaitIAsyncResult |> Async.Ignore
            let (query,parameters,_,_) = QueryExpressionTransformer.convertExpression sqlExp ti con provider false true
-           Common.QueryEvents.PublishSqlQuery query parameters
+           Common.QueryEvents.PublishSqlQuery con.ConnectionString query parameters
            use cmd = provider.CreateCommand(con,query) :?> System.Data.Common.DbCommand
            if dc.CommandTimeout.IsSome then
                cmd.CommandTimeout <- dc.CommandTimeout.Value
@@ -196,7 +196,7 @@ module internal QueryImplementation =
            use con = provider.CreateConnection(dc.ConnectionString) :?> System.Data.Common.DbConnection
            do! con.OpenAsync() |> Async.AwaitIAsyncResult |> Async.Ignore
            let (query,parameters,_,_) = QueryExpressionTransformer.convertExpression sqlExp ti con provider true true
-           Common.QueryEvents.PublishSqlQuery query parameters
+           Common.QueryEvents.PublishSqlQuery con.ConnectionString query parameters
            use cmd = provider.CreateCommand(con,query) :?> System.Data.Common.DbCommand
            if dc.CommandTimeout.IsSome then
                cmd.CommandTimeout <- dc.CommandTimeout.Value

--- a/src/SQLProvider/Utils.fs
+++ b/src/SQLProvider/Utils.fs
@@ -533,15 +533,6 @@ module Bytes =
   open System.IO
   open System.Security.Cryptography
 
-  let hmacAtOffset (key : byte []) offset count (data : byte[]) =
-#if NETSTANDARD2_0
-    use hmac = new HMACSHA256()
-#else
-    use hmac = HMAC.Create("HMACSHA256")
-#endif
-    hmac.Key <- key
-    hmac.ComputeHash (data, offset, count)
-
   let hash (algo : unit -> #HashAlgorithm) (bs : byte[]) =
     use ms = new MemoryStream()
     ms.Write(bs, 0, bs.Length)
@@ -549,16 +540,6 @@ module Bytes =
     use sha = algo ()
     sha.ComputeHash ms
 
-  let sha1 =
-#if DNXCORE50
-    hash (fun () -> SHA1.Create())
-#else
-    hash (fun () -> new SHA1Managed())
-#endif
+  let sha1 = hash (fun () -> SHA1.Create())
 
-  let sha256 =
-#if DNXCORE50
-    hash (fun () -> SHA256.Create())
-#else
-    hash (fun () -> new SHA256Managed())
-#endif
+  let sha256 = hash (fun () -> SHA256.Create())


### PR DESCRIPTION
This PR adds a `ConnectionString` property to the `SqlQueryEvent` payload.

It shouldn't be a breaking change, unless a user is for some reason creating his own instances of the `SqlQueryData` record.

It also shouldn't be a security issue, since anybody that can read the payload can already read all input parameters to all queries, which is much more sensitive information.

Adding this property allows us to figure out which connection generated a particular query. This can have several uses; in my case, [I have one connection on a tight polling loop and I want to exclude it from ordinary query logs](https://github.com/npgsql/npgsql/issues/1786).

(Note: I considered including the `Connection` object directly, instead. The upside is that it would provide more information, depending on the particular `IDbConnection` implementation in use, such as ongoing transactions, connector IDs, etc. - or you could simply compare the connection object by reference. The downside is that I can easily imagine a user doing all kinds of awful hacks like changing connection targets in mid-query, or just accidentally disposing the connection.)