### PR TITLE
Upsert support for SQLite and PostgreSQL

### DIFF
--- a/.paket/Paket.Restore.targets
+++ b/.paket/Paket.Restore.targets
@@ -18,6 +18,14 @@
     <PaketExePath Condition=" '$(PaketExePath)' == '' ">$(PaketToolsPath)paket.exe</PaketExePath>
     <PaketCommand Condition=" '$(OS)' == 'Windows_NT'">"$(PaketExePath)"</PaketCommand>
     <PaketCommand Condition=" '$(OS)' != 'Windows_NT' ">$(MonoPath) --runtime=v4.0.30319 "$(PaketExePath)"</PaketCommand>
+
+    <!-- .net core fdd -->
+    <_PaketExeExtension>$([System.IO.Path]::GetExtension("$(PaketExePath)"))</_PaketExeExtension>
+    <PaketCommand Condition=" '$(_PaketExeExtension)' == '.dll' ">dotnet "$(PaketExePath)"</PaketCommand>
+
+    <!-- no extension is a shell script -->
+    <PaketCommand Condition=" '$(_PaketExeExtension)' == '' ">"$(PaketExePath)"</PaketCommand>
+
     <PaketBootStrapperExePath Condition=" '$(PaketBootStrapperExePath)' == '' AND Exists('$(PaketRootPath)paket.bootstrapper.exe')">$(PaketRootPath)paket.bootstrapper.exe</PaketBootStrapperExePath>
     <PaketBootStrapperExePath Condition=" '$(PaketBootStrapperExePath)' == '' ">$(PaketToolsPath)paket.bootstrapper.exe</PaketBootStrapperExePath>
     <PaketBootStrapperCommand Condition=" '$(OS)' == 'Windows_NT'">"$(PaketBootStrapperExePath)"</PaketBootStrapperCommand>
@@ -35,22 +43,48 @@
     <!-- Step 1 Check if lockfile is properly restored -->
     <PropertyGroup>
       <PaketRestoreRequired>true</PaketRestoreRequired>
-      <NoWarn>$(NoWarn);NU1603</NoWarn>
+      <NoWarn>$(NoWarn);NU1603;NU1604;NU1605;NU1608</NoWarn>
     </PropertyGroup>
 
+    <!-- Because ReadAllText is slow on osx/linux, try to find shasum and awk -->
+    <PropertyGroup>
+      <PaketRestoreCachedHasher Condition="'$(OS)' != 'Windows_NT' And '$(PaketRestoreCachedHasher)' == '' And Exists('/usr/bin/shasum') And Exists('/usr/bin/awk')">/usr/bin/shasum "$(PaketRestoreCacheFile)" | /usr/bin/awk '{ print $1 }'</PaketRestoreCachedHasher>
+      <PaketRestoreLockFileHasher Condition="'$(OS)' != 'Windows_NT' And '$(PaketRestoreLockFileHash)' == '' And Exists('/usr/bin/shasum') And Exists('/usr/bin/awk')">/usr/bin/shasum "$(PaketLockFilePath)" | /usr/bin/awk '{ print $1 }'</PaketRestoreLockFileHasher>
+    </PropertyGroup>
+
+    <!-- If shasum and awk exist get the hashes -->
+    <Exec StandardOutputImportance="Low" Condition=" '$(PaketRestoreCachedHasher)' != '' " Command="$(PaketRestoreCachedHasher)" ConsoleToMSBuild='true'>
+      <Output TaskParameter="ConsoleOutput" PropertyName="PaketRestoreCachedHash" />
+    </Exec>
+    <Exec StandardOutputImportance="Low" Condition=" '$(PaketRestoreLockFileHasher)' != '' " Command="$(PaketRestoreLockFileHasher)" ConsoleToMSBuild='true'>
+      <Output TaskParameter="ConsoleOutput" PropertyName="PaketRestoreLockFileHash" />
+    </Exec>
+
+    <!-- Debug whats going on -->
+    <Message Importance="low" Text="calling paket restore with targetframework=$(TargetFramework) targetframeworks=$(TargetFrameworks)" />
+
     <PropertyGroup Condition="Exists('$(PaketRestoreCacheFile)') ">
-      <PaketRestoreCachedHash>$([System.IO.File]::ReadAllText('$(PaketRestoreCacheFile)'))</PaketRestoreCachedHash>
-      <PaketRestoreLockFileHash>$([System.IO.File]::ReadAllText('$(PaketLockFilePath)'))</PaketRestoreLockFileHash>
+      <!-- if no hash has been done yet fall back to just reading in the files and comparing them -->
+      <PaketRestoreCachedHash Condition=" '$(PaketRestoreCachedHash)' == '' ">$([System.IO.File]::ReadAllText('$(PaketRestoreCacheFile)'))</PaketRestoreCachedHash>
+      <PaketRestoreLockFileHash Condition=" '$(PaketRestoreLockFileHash)' == '' ">$([System.IO.File]::ReadAllText('$(PaketLockFilePath)'))</PaketRestoreLockFileHash>
       <PaketRestoreRequired>true</PaketRestoreRequired>
       <PaketRestoreRequired Condition=" '$(PaketRestoreLockFileHash)' == '$(PaketRestoreCachedHash)' ">false</PaketRestoreRequired>
       <PaketRestoreRequired Condition=" '$(PaketRestoreLockFileHash)' == '' ">true</PaketRestoreRequired>
     </PropertyGroup>
+
 
     <!-- Do a global restore if required -->
     <Exec Command='$(PaketBootStrapperCommand)' Condition="Exists('$(PaketBootStrapperExePath)') AND !(Exists('$(PaketExePath)'))" ContinueOnError="false" />
     <Exec Command='$(PaketCommand) restore' Condition=" '$(PaketRestoreRequired)' == 'true' " ContinueOnError="false" />
 
     <!-- Step 2 Detect project specific changes -->
+    <ItemGroup>
+      <MyTargetFrameworks Condition="'$(TargetFramework)' != '' " Include="$(TargetFramework)"></MyTargetFrameworks>
+      <!-- Don't include all frameworks when msbuild explicitly asks for a single one -->
+      <MyTargetFrameworks Condition="'$(TargetFrameworks)' != '' AND '$(TargetFramework)' == '' " Include="$(TargetFrameworks)"></MyTargetFrameworks>
+      <PaketResolvedFilePaths Include="@(MyTargetFrameworks -> '$(MSBuildProjectDirectory)\obj\$(MSBuildProjectFile).%(Identity).paket.resolved')"></PaketResolvedFilePaths>
+    </ItemGroup>
+    <Message Importance="low" Text="MyTargetFrameworks=@(MyTargetFrameworks) PaketResolvedFilePaths=@(PaketResolvedFilePaths)" />
     <PropertyGroup>
       <PaketReferencesCachedFilePath>$(MSBuildProjectDirectory)\obj\$(MSBuildProjectFile).paket.references.cached</PaketReferencesCachedFilePath>
       <!-- MyProject.fsproj.paket.references has the highest precedence -->
@@ -59,7 +93,9 @@
       <PaketOriginalReferencesFilePath Condition=" !Exists('$(PaketOriginalReferencesFilePath)')">$(MSBuildProjectDirectory)\$(MSBuildProjectName).paket.references</PaketOriginalReferencesFilePath>
       <!-- paket.references -->
       <PaketOriginalReferencesFilePath Condition=" !Exists('$(PaketOriginalReferencesFilePath)')">$(MSBuildProjectDirectory)\paket.references</PaketOriginalReferencesFilePath>
-      <PaketResolvedFilePath>$(MSBuildProjectDirectory)\obj\$(MSBuildProjectFile).$(TargetFramework).paket.resolved</PaketResolvedFilePath>
+      
+      <DoAllResolvedFilesExist>false</DoAllResolvedFilesExist>
+      <DoAllResolvedFilesExist Condition="Exists(%(PaketResolvedFilePaths.Identity))">true</DoAllResolvedFilesExist>
       <PaketRestoreRequired>true</PaketRestoreRequired>
       <PaketRestoreRequiredReason>references-file-or-cache-not-found</PaketRestoreRequiredReason>
     </PropertyGroup>
@@ -78,30 +114,39 @@
     </PropertyGroup>
 
     <!-- Step 2 b detect relevant changes in project file (new targetframework) -->
-    <PropertyGroup Condition=" !Exists('$(PaketResolvedFilePath)') AND '$(TargetFramework)' != '' ">
+    <PropertyGroup Condition=" '$(DoAllResolvedFilesExist)' != 'true' ">
       <PaketRestoreRequired>true</PaketRestoreRequired>
-      <PaketRestoreRequiredReason>target-framework '$(TargetFramework)'</PaketRestoreRequiredReason>
+      <PaketRestoreRequiredReason>target-framework '$(TargetFramework)' or '$(TargetFrameworks)' files @(PaketResolvedFilePaths)</PaketRestoreRequiredReason>
     </PropertyGroup>
 
     <!-- Step 3 Restore project specific stuff if required -->
     <Message Condition=" '$(PaketRestoreRequired)' == 'true' " Importance="low" Text="Detected a change ('$(PaketRestoreRequiredReason)') in the project file '$(MSBuildProjectFullPath)', calling paket restore" />
-    <Exec Command='$(PaketCommand) restore --project "$(MSBuildProjectFullPath)"' Condition=" '$(PaketRestoreRequired)' == 'true' " ContinueOnError="false" />
+    <Exec Command='$(PaketCommand) restore --project "$(MSBuildProjectFullPath)" --target-framework "$(TargetFrameworks)"' Condition=" '$(PaketRestoreRequired)' == 'true' AND '$(TargetFramework)' == '' " ContinueOnError="false" />
+    <Exec Command='$(PaketCommand) restore --project "$(MSBuildProjectFullPath)" --target-framework "$(TargetFramework)"' Condition=" '$(PaketRestoreRequired)' == 'true' AND '$(TargetFramework)' != '' " ContinueOnError="false" />
 
     <!-- This shouldn't actually happen, but just to be sure. -->
-    <Error Condition=" !Exists('$(PaketResolvedFilePath)') AND '$(TargetFramework)' != '' AND '$(ResolveNuGetPackages)' != 'False' " Text="Paket file '$(PaketResolvedFilePath)' is missing while restoring $(MSBuildProjectFile). Please delete 'paket-files/paket.restore.cached' and call 'paket restore'." />
+    <PropertyGroup>
+      <DoAllResolvedFilesExist>false</DoAllResolvedFilesExist>
+      <DoAllResolvedFilesExist Condition="Exists(%(PaketResolvedFilePaths.Identity))">true</DoAllResolvedFilesExist>
+    </PropertyGroup>
+    <Error Condition=" '$(DoAllResolvedFilesExist)' != 'true' AND '$(ResolveNuGetPackages)' != 'False' " Text="One Paket file '@(PaketResolvedFilePaths)' is missing while restoring $(MSBuildProjectFile). Please delete 'paket-files/paket.restore.cached' and call 'paket restore'." />
 
     <!-- Step 4 forward all msbuild properties (PackageReference, DotNetCliToolReference) to msbuild -->
-    <ReadLinesFromFile Condition="Exists('$(PaketResolvedFilePath)')" File="$(PaketResolvedFilePath)" >
+    <ReadLinesFromFile Condition="'@(PaketResolvedFilePaths)' != ''" File="%(PaketResolvedFilePaths.Identity)" ><!--Condition="Exists('%(PaketResolvedFilePaths.Identity)')"-->
       <Output TaskParameter="Lines" ItemName="PaketReferencesFileLines"/>
     </ReadLinesFromFile>
 
-    <ItemGroup Condition=" Exists('$(PaketResolvedFilePath)') AND '@(PaketReferencesFileLines)' != '' " >
+    <ItemGroup Condition=" '@(PaketReferencesFileLines)' != '' " >
       <PaketReferencesFileLinesInfo Include="@(PaketReferencesFileLines)" >
         <PackageName>$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[0])</PackageName>
         <PackageVersion>$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[1])</PackageVersion>
+        <AllPrivateAssets>$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[4])</AllPrivateAssets>
       </PaketReferencesFileLinesInfo>
       <PackageReference Include="%(PaketReferencesFileLinesInfo.PackageName)">
         <Version>%(PaketReferencesFileLinesInfo.PackageVersion)</Version>
+        <PrivateAssets Condition=" ('%(PaketReferencesFileLinesInfo.AllPrivateAssets)' == 'true') Or ('$(PackAsTool)' == 'true') ">All</PrivateAssets>
+        <ExcludeAssets Condition="%(PaketReferencesFileLinesInfo.AllPrivateAssets) == 'exclude'">runtime</ExcludeAssets>
+        <Publish Condition=" '$(PackAsTool)' == 'true' ">true</Publish>
       </PackageReference>
     </ItemGroup>
 
@@ -123,9 +168,10 @@
       </DotNetCliToolReference>
     </ItemGroup>
 
+    <!-- Disabled for now until we know what to do with runtime deps - https://github.com/fsprojects/Paket/issues/2964
     <PropertyGroup>
       <RestoreConfigFile>$(MSBuildProjectDirectory)/obj/$(MSBuildProjectFile).NuGet.Config</RestoreConfigFile>
-    </PropertyGroup>
+    </PropertyGroup> -->
 
   </Target>
 
@@ -137,7 +183,7 @@
 
   <Target Name="PaketOverrideNuspec" AfterTargets="GenerateNuspec" Condition="('$(IsPackable)' == '' Or '$(IsPackable)' == 'true') And Exists('$(MSBuildProjectDirectory)/obj/$(MSBuildProjectFile).references')" >
     <ItemGroup>
-      <_NuspecFilesNewLocation Include="$(BaseIntermediateOutputPath)$(Configuration)/*.nuspec"/>
+      <_NuspecFilesNewLocation Include="$(BaseIntermediateOutputPath)$(Configuration)\*.nuspec"/>
     </ItemGroup>
 
     <PropertyGroup>
@@ -145,12 +191,12 @@
       <ContinuePackingAfterGeneratingNuspec>true</ContinuePackingAfterGeneratingNuspec>
       <UseNewPack>false</UseNewPack>
       <UseNewPack Condition=" '$(NuGetToolVersion)' != '4.0.0' ">true</UseNewPack>
-      <AdjustedNuspecOutputPath>$(BaseIntermediateOutputPath)$(Configuration)/</AdjustedNuspecOutputPath>
+      <AdjustedNuspecOutputPath>$(BaseIntermediateOutputPath)$(Configuration)</AdjustedNuspecOutputPath>
       <AdjustedNuspecOutputPath Condition="@(_NuspecFilesNewLocation) == ''">$(BaseIntermediateOutputPath)</AdjustedNuspecOutputPath>
     </PropertyGroup>
 
     <ItemGroup>
-      <_NuspecFiles Include="$(AdjustedNuspecOutputPath)*.nuspec"/>
+      <_NuspecFiles Include="$(AdjustedNuspecOutputPath)\*.nuspec"/>
     </ItemGroup>
 
     <Exec Command='$(PaketCommand) fix-nuspecs files "@(_NuspecFiles)" project-file "$(PaketProjectFile)" ' Condition="@(_NuspecFiles) != ''" />
@@ -158,6 +204,7 @@
     <ConvertToAbsolutePath Condition="@(_NuspecFiles) != ''" Paths="@(_NuspecFiles)">
       <Output TaskParameter="AbsolutePaths" PropertyName="NuspecFileAbsolutePath" />
     </ConvertToAbsolutePath>
+
 
     <!-- Call Pack -->
     <PackTask Condition="$(UseNewPack)"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+### 1.1.43 - 12.06.2018
+* Comparison being flipped around when a constant comes first #553
+
 ### 1.1.42 - 03.05.2018
 * Context schema cache support PR #545
 * Improved option type support in convertTypes. PR #544

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+### 1.1.44 - 25.06.2018
+* Extend SQLEntity.MapTo to allow mapping when field names are different than column names, PR #556
+
 ### 1.1.43 - 12.06.2018
 * Comparison being flipped around when a constant comes first #553
 

--- a/docs/content/core/crud.fsx
+++ b/docs/content/core/crud.fsx
@@ -189,6 +189,31 @@ SQLProvider also supports async database operations:
 *)
 
 ctx.SubmitUpdatesAsync() |> Async.StartAsTask
+        
+(**
+### OnConflict
+
+The [SQLite](http://sqlite.org/lang_conflict.html) and [PostgreSQL 9.5+](https://www.postgresql.org/docs/current/static/sql-insert.html#SQL-ON-CONFLICT) providers support conflict resolution for INSERT statements.
+
+They allow the user to specify if a unique constraint violation should be solved by ignoring the statement (DO NOTHING) or updating existing rows (DO UPDATE).
+
+You can leverage this feature by setting the `OnConflict` property on a row object:
+ * Setting it to `DoNothing` will add the DO NOTHING clause (PostgreSQL) or the OR IGNORE clause (SQLite). 
+ * Setting it to `Update` will add a DO UPDATE clause on the primary key constraint for all columns (PostgreSQL) or a OR REPLACE clause (SQLite).
+
+Sql Server has a similar feature in the form of the MERGE statement. This is not yet supported.
+*)
+
+let ctx = sql.GetDataContext()
+
+let emp = ctx.Main.Employees.Create()
+emp.Id <- 1
+emp.FirstName <- "Jane"
+emp.LastName <- "Doe"
+
+emp.OnConflict <- FSharp.Data.Sql.Common.OnConflict.Update
+
+ctx.SubmitUpdates()
 
 (**
 

--- a/docs/content/core/mappers.fsx
+++ b/docs/content/core/mappers.fsx
@@ -66,6 +66,21 @@ type Employee2 = {
 let qry = query { for row in employees do
                   select row} |> Seq.map (fun x -> x.MapTo<Employee2>())
 
+(**
+The target type can be a record (as in the example) or a class type with properties named as the source columns and with a paremeterless setter.
+The target field name can also be different than the column name; in this case it must be decorated with the MappedColumnAttribute custom attribute:
+*)
+
+open FSharp.Data.Sql.Common
+
+type Employee3 = {
+    [<MappedColumn("FirstName")>] GivenName:string
+    [<MappedColumn("LastName")>] FamilyName:string
+    }
+
+let qry = query { for row in employees do
+                  select row} |> Seq.map (fun x -> x.MapTo<Employee3>())
+
 
 (**
 Or alternatively the ColumnValues from  SQLEntity can be used to create a map, with the
@@ -77,8 +92,4 @@ let rows = query { for row in employees do
 
 let employees2map = rows |> Seq.map(fun i -> i.ColumnValues |> Map.ofSeq)
 let firstNames = employees2map |> Seq.map (fun x -> x.["FirstName"])
-
-
-
-
 

--- a/docs/content/core/postgresql.fsx
+++ b/docs/content/core/postgresql.fsx
@@ -103,3 +103,35 @@ type sql =
         indivAmount,
         useOptTypes,
         owner>
+
+        
+(**
+### OnConflict
+
+Beginning with version 9.5, [PostgreSQL supports the ON CONFLICT clause to INSERT statements.](https://www.postgresql.org/docs/current/static/sql-insert.html#SQL-ON-CONFLICT)
+It allows the user to specify if a unique constraint violation should be solved by ignoring the statement (DO NOTHING) or updating existing rows (DO UPDATE).
+SqlProvider can leverage this feature by setting the `OnConflict` property on a row object. Setting it to `DoNothing` will add the DO NOTHING clause. Setting it to `Update` will add a DO UPDATE clause that updates all existing columns if the conflict happened on the primary key constraint.
+
+It is not currently supported to emit a DO UPDATE clause for non-primary key unique constraints.
+*)
+
+let ctx = sql.GetDataContext()
+
+let orders = ctx.Main.Orders
+
+let row = orders.Create()
+row.CustomerId <- customer.CustomerId
+row.EmployeeId <- employee.EmployeeId
+row.Freight <- 10M
+row.OrderDate <- now.AddDays(-1.0)
+row.RequiredDate <- now.AddDays(1.0)
+row.ShipAddress <- "10 Downing St"
+row.ShipCity <- "London"
+row.ShipName <- "Dragons den"
+row.ShipPostalCode <- "SW1A 2AA"
+row.ShipRegion <- "UK"
+row.ShippedDate <- now
+
+row.OnConflict <- FSharp.Data.Sql.Common.OnConflict.Update
+
+ctx.SubmitUpdates()

--- a/docs/content/core/postgresql.fsx
+++ b/docs/content/core/postgresql.fsx
@@ -104,34 +104,3 @@ type sql =
         useOptTypes,
         owner>
 
-        
-(**
-### OnConflict
-
-Beginning with version 9.5, [PostgreSQL supports the ON CONFLICT clause to INSERT statements.](https://www.postgresql.org/docs/current/static/sql-insert.html#SQL-ON-CONFLICT)
-It allows the user to specify if a unique constraint violation should be solved by ignoring the statement (DO NOTHING) or updating existing rows (DO UPDATE).
-SqlProvider can leverage this feature by setting the `OnConflict` property on a row object. Setting it to `DoNothing` will add the DO NOTHING clause. Setting it to `Update` will add a DO UPDATE clause that updates all existing columns if the conflict happened on the primary key constraint.
-
-It is not currently supported to emit a DO UPDATE clause for non-primary key unique constraints.
-*)
-
-let ctx = sql.GetDataContext()
-
-let orders = ctx.Main.Orders
-
-let row = orders.Create()
-row.CustomerId <- customer.CustomerId
-row.EmployeeId <- employee.EmployeeId
-row.Freight <- 10M
-row.OrderDate <- now.AddDays(-1.0)
-row.RequiredDate <- now.AddDays(1.0)
-row.ShipAddress <- "10 Downing St"
-row.ShipCity <- "London"
-row.ShipName <- "Dragons den"
-row.ShipPostalCode <- "SW1A 2AA"
-row.ShipRegion <- "UK"
-row.ShippedDate <- now
-
-row.OnConflict <- FSharp.Data.Sql.Common.OnConflict.Update
-
-ctx.SubmitUpdates()

--- a/docs/content/core/querying.fsx
+++ b/docs/content/core/querying.fsx
@@ -649,3 +649,13 @@ let qry =
 		groupBy 1 into g
 		select (g.Count(), g.Sum(fun p -> p.UnitPrice))
 	} |> Seq.head
+
+(**
+
+For more info see:
+
+ * [Composable Query](core/composable.html)
+ * [Mapping to record types](core/mappers.html)
+ * [CRUD operations](core/crud.html)
+
+*)

--- a/docs/content/core/querying.fsx
+++ b/docs/content/core/querying.fsx
@@ -654,8 +654,8 @@ let qry =
 
 For more info see:
 
- * [Composable Query](core/composable.html)
- * [Mapping to record types](core/mappers.html)
- * [CRUD operations](core/crud.html)
+ * [Composable Query](composable.html)
+ * [Mapping to record types](mappers.html)
+ * [CRUD operations](crud.html)
 
 *)

--- a/src/SQLProvider/AssemblyInfo.fs
+++ b/src/SQLProvider/AssemblyInfo.fs
@@ -5,13 +5,13 @@ open System.Reflection
 [<assembly: AssemblyTitleAttribute("SQLProvider")>]
 [<assembly: AssemblyProductAttribute("SQLProvider")>]
 [<assembly: AssemblyDescriptionAttribute("Type providers for SQL database access.")>]
-[<assembly: AssemblyVersionAttribute("1.1.42")>]
-[<assembly: AssemblyFileVersionAttribute("1.1.42")>]
+[<assembly: AssemblyVersionAttribute("1.1.43")>]
+[<assembly: AssemblyFileVersionAttribute("1.1.43")>]
 do ()
 
 module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyTitle = "SQLProvider"
     let [<Literal>] AssemblyProduct = "SQLProvider"
     let [<Literal>] AssemblyDescription = "Type providers for SQL database access."
-    let [<Literal>] AssemblyVersion = "1.1.42"
-    let [<Literal>] AssemblyFileVersion = "1.1.42"
+    let [<Literal>] AssemblyVersion = "1.1.43"
+    let [<Literal>] AssemblyFileVersion = "1.1.43"

--- a/src/SQLProvider/AssemblyInfo.fs
+++ b/src/SQLProvider/AssemblyInfo.fs
@@ -5,13 +5,13 @@ open System.Reflection
 [<assembly: AssemblyTitleAttribute("SQLProvider")>]
 [<assembly: AssemblyProductAttribute("SQLProvider")>]
 [<assembly: AssemblyDescriptionAttribute("Type providers for SQL database access.")>]
-[<assembly: AssemblyVersionAttribute("1.1.43")>]
-[<assembly: AssemblyFileVersionAttribute("1.1.43")>]
+[<assembly: AssemblyVersionAttribute("1.1.44")>]
+[<assembly: AssemblyFileVersionAttribute("1.1.44")>]
 do ()
 
 module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyTitle = "SQLProvider"
     let [<Literal>] AssemblyProduct = "SQLProvider"
     let [<Literal>] AssemblyDescription = "Type providers for SQL database access."
-    let [<Literal>] AssemblyVersion = "1.1.43"
-    let [<Literal>] AssemblyFileVersion = "1.1.43"
+    let [<Literal>] AssemblyVersion = "1.1.44"
+    let [<Literal>] AssemblyFileVersion = "1.1.44"

--- a/src/SQLProvider/Providers.Postgresql.fs
+++ b/src/SQLProvider/Providers.Postgresql.fs
@@ -504,6 +504,8 @@ type internal PostgresqlProvider(resolutionPath, contextSchemaPath, owner, refer
           ~~(sprintf " ON CONFLICT (%s) DO UPDATE SET %s "                
                 (String.Join(",", pk |> List.map (sprintf "\"%s\"")))
                 (String.Join(",", columnNamesWithValues |> List.map(fun (c,p) -> sprintf "\"%s\" = %s" c p.ParameterName ) )))
+        | DoNothing ->
+          ~~(sprintf " ON CONFLICT DO NOTHING ")
 
         match haspk, pk with
         | true, [itm] -> ~~(sprintf " RETURNING \"%s\";" itm)

--- a/src/SQLProvider/Providers.SQLite.fs
+++ b/src/SQLProvider/Providers.SQLite.fs
@@ -240,8 +240,15 @@ type internal SQLiteProvider(resolutionPath, contextSchemaPath, referencedAssemb
             |> List.toArray
             |> Array.unzip
 
+        let conflictClause =
+          match entity.OnConflict with
+          | Throw -> ""
+          | Update -> " OR REPLACE "
+          | DoNothing -> " OR IGNORE "
+
         sb.Clear() |> ignore
-        ~~(sprintf "INSERT INTO %s (%s) VALUES (%s); SELECT last_insert_rowid();"
+        ~~(sprintf "INSERT %s INTO %s (%s) VALUES (%s); SELECT last_insert_rowid();"
+            conflictClause
             entity.Table.FullName
             (String.Join(",",columnNames))
             (String.Join(",",values |> Array.map(fun p -> p.ParameterName))))

--- a/src/SQLProvider/SqlRuntime.Common.fs
+++ b/src/SQLProvider/SqlRuntime.Common.fs
@@ -127,6 +127,16 @@ type EntityState =
     | Delete
     | Deleted
 
+type OnConflict = 
+    /// Throws an exception if the primary key already exists. Default behaviour
+    | Throw
+    /// If the primary key already exists, updates the existing row's columns to match the new entity.
+    /// Currently supported only on PostgreSQL 9.5+
+    | Update
+    /// TODO: implement
+    /// If the primary key already exists, leaves the existing row unchanged
+    /// | DoNothing
+
 type MappedColumnAttribute(name: string) = 
     inherit Attribute()
     member x.Name with get() = name
@@ -329,6 +339,9 @@ type SqlEntity(dc: ISqlDataContext, tableName, columns: ColumnLookup) =
                         |> Seq.map(fun kvp -> kvp.Key, kvp.Value))
         newItem._State <- Created
         newItem
+
+    /// Determines what should happen when saving this entity if it is newly-created but another entity with the same primary key already exists
+    member val OnConflict = Throw with get, set
 
     interface System.ComponentModel.INotifyPropertyChanged with
         [<CLIEvent>] member __.PropertyChanged = propertyChanged.Publish

--- a/src/SQLProvider/SqlRuntime.Common.fs
+++ b/src/SQLProvider/SqlRuntime.Common.fs
@@ -128,14 +128,14 @@ type EntityState =
     | Deleted
 
 type OnConflict = 
-    /// Throws an exception if the primary key already exists. Default behaviour
+    /// Throws an exception if the primary key already exists (default behaviour).
     | Throw
     /// If the primary key already exists, updates the existing row's columns to match the new entity.
     /// Currently supported only on PostgreSQL 9.5+
     | Update
-    /// TODO: implement
-    /// If the primary key already exists, leaves the existing row unchanged
-    /// | DoNothing
+    /// If the primary key already exists, leaves the existing row unchanged.
+    /// Currently supported only on PostgreSQL 9.5+
+    | DoNothing
 
 type MappedColumnAttribute(name: string) = 
     inherit Attribute()

--- a/tests/SqlProvider.Tests/CrudTests.fs
+++ b/tests/SqlProvider.Tests/CrudTests.fs
@@ -151,7 +151,7 @@ let ``Can enlist in a transaction scope and rollback changes without complete``(
 
 
 [<Test>]
-let ``Insert on conflict replace applies correctly``() = 
+let ``Conflict resolution is correctly applied``() = 
     let dc = sql.GetDataContext()
     
     let getCustomer = 
@@ -187,28 +187,3 @@ let ``Insert on conflict replace applies correctly``() =
     let notUpdatedCustomer = getCustomer |> Seq.head
 
     Assert.AreEqual(notUpdatedCustomer.Address, newAddress)
-
-    // let's create new context just to test that it is actually there.
-    let dc2 = sql.GetDataContext()
- 
-    let newCustomers = 
-        query { for cust in dc2.Main.Customers do
-                select cust  }
-        |> Seq.toList
-    
-    let created = 
-        newCustomers |> List.find (fun x -> x.CustomerId = "SQLPROVIDER")
-
-    Assert.AreEqual(originalCustomers.Length, newCustomers.Length - 1)
-
-    Assert.AreEqual("Updated Number", created.Phone)
-    created.Delete()
-    dc2.SubmitUpdates()    
-    dc2.SubmitUpdates()
-
-    let reallyDeleted = 
-        query { for cust in dc2.Main.Customers do
-                select cust  }
-        |> Seq.toList
-
-    Assert.AreEqual(originalCustomers.Length, reallyDeleted.Length)

--- a/tests/SqlProvider.Tests/CrudTests.fs
+++ b/tests/SqlProvider.Tests/CrudTests.fs
@@ -156,7 +156,9 @@ let ``Conflict resolution is correctly applied``() =
     
     let getCustomer = 
         query { for cust in dc.Main.Customers do
-                select cust }
+                where (cust.CustomerId = "SQLPROVIDER")
+                select cust
+        }
      
     let originalCustomer = getCustomer |> Seq.head
 

--- a/tests/SqlProvider.Tests/CrudTests.fs
+++ b/tests/SqlProvider.Tests/CrudTests.fs
@@ -166,16 +166,16 @@ let ``Conflict resolution is correctly applied``() =
     // Works when reusing the same entity with changed properties    
     let newAddress = "FsProjects 2.0"    
     ent.Address <- newAddress
-    ent.OnConflict <- FSharp.Data.Sql.Common.OnConflict.Update
+    ent.OnConflict <- Common.OnConflict.Update
     dc.SubmitUpdates()    
     
-    Assert.AreEqual(getCurrentAddress |> Seq.head, newerAddress)
+    Assert.AreEqual(getCurrentAddress |> Seq.head, newAddress)
 
     // Works when creating a fresh entity
     let ent2 = createCustomer dc
     let newerAddress = "FsProjects 3.0"    
-    ent.Address <- newerAddress
-    ent.OnConflict <- FSharp.Data.Sql.Common.OnConflict.Update
+    ent2.Address <- newerAddress
+    ent2.OnConflict <- Common.OnConflict.Update
     dc.SubmitUpdates()    
     
     Assert.AreEqual(getCurrentAddress |> Seq.head, newerAddress)
@@ -183,7 +183,7 @@ let ``Conflict resolution is correctly applied``() =
     // DoNothing doesn't update the address
     let ent3 = createCustomer dc        
     ent3.Address <- "asdkjskdjsldjskjdls"
-    ent3.OnConflict <- FSharp.Data.Sql.Common.OnConflict.DoNothing
+    ent3.OnConflict <- Common.OnConflict.DoNothing
     dc.SubmitUpdates()
 
     Assert.AreEqual(getCurrentAddress |> Seq.head, newerAddress)

--- a/tests/SqlProvider.Tests/PostgreSQLTests.fs
+++ b/tests/SqlProvider.Tests/PostgreSQLTests.fs
@@ -513,4 +513,30 @@ let ``Access a different schema than the default one``() =
   testRow.ColumnInOtherSchema <- 42  
   ctx.SubmitUpdates()
 
+//********************** Upsert ***************************//
+
+
+[<Test>]
+let ``Access a different schema than the default one``() = 
+  let ctx = HR.GetDataContext()
+  
+  let wg = ctx.Public.Countries.Create()
+  wg.CountryId <- "DE"
+  wg.Name <- "West Germany"
+  wg.RegionId <- 1
+  wg.OnConflict <- Update
+  ctx.SubmitUpdates()
+
+  let readGermany =
+    query { 
+      for country in ctx.Public.Countries do 
+      where (country.CountryId = "DE") 
+      select country.Name
+    }
+
+  Assert.AreEqual(Seq.head readGermany = "West Germany")
+
+
+
+
 #endif

--- a/tests/SqlProvider.Tests/PostgreSQLTests.fs
+++ b/tests/SqlProvider.Tests/PostgreSQLTests.fs
@@ -524,7 +524,7 @@ let ``Upsert on table with single primary key``() =
     query { 
       for country in ctx.Public.Countries do 
       where (country.CountryId = "DE") 
-      select country.CountryName
+      select country.CountryName.Value
     }
     
   let oldGermany = Seq.head readGermany

--- a/tests/SqlProvider.Tests/PostgreSQLTests.fs
+++ b/tests/SqlProvider.Tests/PostgreSQLTests.fs
@@ -522,8 +522,8 @@ let ``Access a different schema than the default one``() =
   
   let wg = ctx.Public.Countries.Create()
   wg.CountryId <- "DE"
-  wg.Name <- "West Germany"
-  wg.RegionId <- 1
+  wg.CountryName <- Some "West Germany"
+  wg.RegionId <- Some 1
   wg.OnConflict <- Update
   ctx.SubmitUpdates()
 
@@ -531,10 +531,10 @@ let ``Access a different schema than the default one``() =
     query { 
       for country in ctx.Public.Countries do 
       where (country.CountryId = "DE") 
-      select country.Name
+      select country.CountryName
     }
 
-  Assert.AreEqual(Seq.head readGermany = "West Germany")
+  Assert.AreEqual(Seq.head readGermany = Some "West Germany")
 
 
 

--- a/tests/SqlProvider.Tests/PostgreSQLTests.fs
+++ b/tests/SqlProvider.Tests/PostgreSQLTests.fs
@@ -524,7 +524,7 @@ let ``Upsert on table with single primary key``() =
   wg.CountryId <- "DE"
   wg.CountryName <- Some "West Germany"
   wg.RegionId <- Some 1
-  wg.OnConflict <- Update
+  wg.OnConflict <- Common.OnConflict.Update
   ctx.SubmitUpdates()
 
   let readGermany =
@@ -534,7 +534,7 @@ let ``Upsert on table with single primary key``() =
       select country.CountryName
     }
 
-  Assert.AreEqual(Seq.head readGermany = Some "West Germany")
+  Assert.AreEqual(Seq.head readGermany, Some "West Germany")
 
 [<Test>]
 let ``Upsert on table with composite primary key``() = 
@@ -546,8 +546,8 @@ let ``Upsert on table with composite primary key``() =
       select (jobHistory.EmployeeId, jobHistory.StartDate, jobHistory.JobId, jobHistory.EndDate)
     }
     |> Seq.head
-
-  let newEndDate = oldEndDate.AddDays(1)
+  
+  let newEndDate = oldEndDate.AddDays(1.0)
     
   let jh = ctx.Public.JobHistory.Create()
   jh.EmployeeId <- employeeId
@@ -555,7 +555,7 @@ let ``Upsert on table with composite primary key``() =
   jh.EndDate <- newEndDate
   jh.JobId <- jobId
 
-  jh.OnConflict <- Update
+  jh.OnConflict <- Common.OnConflict.Update
   ctx.SubmitUpdates()
 
   let newEndDateDb =

--- a/tests/SqlProvider.Tests/QueryTests.fs
+++ b/tests/SqlProvider.Tests/QueryTests.fs
@@ -1529,6 +1529,19 @@ let ``simple canonical operation substing query``() =
     Assert.IsTrue(qry.Contains("ANATR"))
 
 [<Test >]
+let ``simple canonical operation inverted operations query``() =
+    let dc = sql.GetDataContext()
+    let qry = 
+        query {
+            for o in dc.Main.Orders do
+            where (500m < o.Freight)
+            select o.OrderId
+        } |> Seq.toArray
+
+    CollectionAssert.IsNotEmpty qry
+    Assert.AreEqual(13, qry.Length)
+
+[<Test >]
 let ``simple canonical operations query``() =
     let dc = sql.GetDataContext()
 


### PR DESCRIPTION
I know I've got some other PRs to finish, but this one was rather straightforward and it would significantly improve (some parts of) my project, by removing the fake upserts I currently do with if-select-then-update-else-insert (which are slow and vulnerable to race conditions).

You just set `myRow.OnConflict <- OnConflict.Update` or `myRow.OnConflict <- OnConflict.DoNothing` and, if the provider supports it, the INSERT query will be handled appropriately by either updating the existing record with the new record's values, or by ignoring the conflict without throwing an exception. Not much to it.

UX consideration: currently the `OnConflict` type is conservatively placed the `FSharp.Data.Sql.Common` namespace. Since its use could be somewhat pervasive, might there be a better place? I think the only namespace that currently gets imported frequently is `FSharp.Data.Sql.Operators`, where it doesn't fit.

For other providers: SQL Server and Oracle have upsert support in the form of the MERGE statement, but they're a little trickier to format, so I intend to try them it after I get the CI integration working for it. Also, they apparently aren't 100% safe against race conditions, so I'm not quite clear on what they offer over a classic "UPDATE.... IF @@ROWCOUNT = 0 THEN INSERT".
