### PR TITLE
[MSSQL] Add brackets around the OUTPUT column name of the INSERT command to …

### DIFF
--- a/src/SQLProvider/Providers.MsSqlServer.fs
+++ b/src/SQLProvider/Providers.MsSqlServer.fs
@@ -361,9 +361,9 @@ type internal MSSqlServerProvider(contextSchemaPath, tableNames:string) =
         match haspk, pk with
         | true, [itm] ->
             if values |> Array.isEmpty then
-                ~~(sprintf "INSERT INTO [%s].[%s] OUTPUT inserted.%s DEFAULT VALUES;" entity.Table.Schema entity.Table.Name itm)
+                ~~(sprintf "INSERT INTO [%s].[%s] OUTPUT inserted.[%s] DEFAULT VALUES;" entity.Table.Schema entity.Table.Name itm)
             else
-                ~~(sprintf "INSERT INTO [%s].[%s] (%s) OUTPUT inserted.%s VALUES (%s);"
+                ~~(sprintf "INSERT INTO [%s].[%s] (%s) OUTPUT inserted.[%s] VALUES (%s);"
                     entity.Table.Schema entity.Table.Name
                     (String.Join(",",columnNames))
                     itm


### PR DESCRIPTION
…avoid error on columns with reserved names.

For example a SQL-Table has a id column named "key" (I think it was the backing table of the identity server 3). The insert command produce an error, because "key" is a reserved key word in SQL.

To avoid that, using brackets around the colmun name.