### PR TITLE
Simple implementation of left join with non-foreign keys

### DIFF
--- a/src/SQLProvider/Operators.fs
+++ b/src/SQLProvider/Operators.fs
@@ -149,7 +149,8 @@ module Operators =
     /// Not Like
     let (<>%) (a:'a) (b:string) = false
     /// Left join
-    let (!!) (a:IQueryable<_>) = a
+    let private leftJoin (a:'a) = a
+    let (!!) (a:IQueryable<'a>) = query { for x in a do select (leftJoin x) } 
     
     /// Standard Deviation
     let StdDev (a:'a) = 1m

--- a/tests/SqlProvider.Tests/QueryTests.fs
+++ b/tests/SqlProvider.Tests/QueryTests.fs
@@ -1573,10 +1573,10 @@ let ``simple select query with left join``() =
     CollectionAssert.IsNotEmpty qry
     CollectionAssert.AreEquivalent(
         [|
-            "VINET", None
-            "TOMSP", None
-            "HANAR", None
-            "VICTE", None
+            "ALFKI", None
+            "ANATR", None
+            "ANTON", None
+            "AROUT", None
         |], qry.[0..3])
 
 

--- a/tests/SqlProvider.Tests/QueryTests.fs
+++ b/tests/SqlProvider.Tests/QueryTests.fs
@@ -1560,6 +1560,26 @@ let ``simple async sum with option operations``() =
         } |> Seq.sumAsync |> Async.RunSynchronously
     Assert.That(qry, Is.EqualTo(603221955M).Within(10M))
 
+[<Test >]
+let ``simple select query with left join``() = 
+    let dc = sqlOption.GetDataContext()
+    let qry = 
+        query {
+            for cust in dc.Main.Customers do
+            join order in (!!) dc.Main.Orders on (cust.CustomerId = order.OrderId.ToString())
+            select (cust.CustomerId, order.OrderDate)
+        } |> Seq.toArray
+    
+    CollectionAssert.IsNotEmpty qry
+    CollectionAssert.AreEquivalent(
+        [|
+            "VINET", None
+            "TOMSP", None
+            "HANAR", None
+            "VICTE", None
+        |], qry.[0..3])
+
+
 
 [<Test>]
 let ``simple math operations query``() =

--- a/tests/SqlProvider.Tests/QueryTests.fs
+++ b/tests/SqlProvider.Tests/QueryTests.fs
@@ -1571,15 +1571,7 @@ let ``simple select query with left join``() =
         } |> Seq.toArray
     
     CollectionAssert.IsNotEmpty qry
-    CollectionAssert.AreEquivalent(
-        [|
-            "ALFKI", None
-            "ANATR", None
-            "ANTON", None
-            "AROUT", None
-        |], qry.[0..3])
-
-
+    Assert.AreEqual(91, qry.Length)
 
 [<Test>]
 let ``simple math operations query``() =


### PR DESCRIPTION
This is proposed fix for #588

It's not having support of leftOuterJoin Linq-operator nor making working with F# `query { ... }` simple.

But it does allow left join to non-foreign-key columns with op_bangbang `(!!)`.

```fsharp
        query {
            for cust in dc.Main.Customers do
            join ord in (!!) dc.Main.Orders on (cust.CustomerId = ord.CustomerId)
            select (cust.CustomerId, ord.OrderDate)
        } |> Seq.toList
```