### PR TITLE
[HACK] Replace references to `None` basetype to `Some typeof<obj>`

### DIFF
--- a/src/SQLProvider/SqlDesignTime.fs
+++ b/src/SQLProvider/SqlDesignTime.fs
@@ -13,15 +13,15 @@ open FSharp.Data.Sql
 open ProviderImplementation.ProvidedTypes
 
 type internal SqlRuntimeInfo (config : TypeProviderConfig) =
-    let runtimeAssembly = 
+    let runtimeAssembly =
         Assembly.GetExecutingAssembly()
         //let r = Reflection.tryLoadAssemblyFrom "" [||] [config.RuntimeAssembly]
         //match r with
         //| Choice1Of2(assembly) -> assembly
         //| Choice2Of2(paths, errors) -> Assembly.GetExecutingAssembly()
-    member __.RuntimeAssembly = runtimeAssembly 
+    member __.RuntimeAssembly = runtimeAssembly
 
-module internal DesignTimeCache = 
+module internal DesignTimeCache =
     let cache = System.Collections.Concurrent.ConcurrentDictionary<_,ProvidedTypeDefinition>()
 
 type internal ParameterValue =
@@ -29,38 +29,38 @@ type internal ParameterValue =
   | Default of Expr
 
 [<TypeProvider>]
-type SqlTypeProvider(config: TypeProviderConfig) as this =     
+type SqlTypeProvider(config: TypeProviderConfig) as this =
     inherit TypeProviderForNamespaces(config)
     let sqlRuntimeInfo = SqlRuntimeInfo(config)
     let mySaveLock = new Object();
-    
+
     let [<Literal>] FSHARP_DATA_SQL = "FSharp.Data.Sql"
     let empty = fun (_:Expr list) -> <@@ () @@>
-    
-    let createTypes(connectionString, conStringName,dbVendor,resolutionPath,individualsAmount,useOptionTypes,owner,caseSensitivity, tableNames, contextSchemaPath, odbcquote, sqliteLibrary, rootTypeName) = 
-        let resolutionPath = 
+
+    let createTypes(connectionString, conStringName,dbVendor,resolutionPath,individualsAmount,useOptionTypes,owner,caseSensitivity, tableNames, contextSchemaPath, odbcquote, sqliteLibrary, rootTypeName) =
+        let resolutionPath =
             if String.IsNullOrWhiteSpace resolutionPath
             then config.ResolutionFolder
             else resolutionPath
 
-        let caseInsensitivityCheck = 
+        let caseInsensitivityCheck =
             match caseSensitivity with
             | CaseSensitivityChange.TOLOWER -> (fun (x:string) -> x.ToLower())
             | CaseSensitivityChange.TOUPPER -> (fun (x:string) -> x.ToUpper())
             | _ -> (fun x -> x)
 
-        let conString = 
+        let conString =
             match ConfigHelpers.tryGetConnectionString false config.ResolutionFolder conStringName connectionString with
             | "" -> failwithf "No connection string specified or could not find a connection string with name %s" conStringName
             | cs -> cs
-                    
-        let rootType, prov, con = 
+
+        let rootType, prov, con =
             let rootType = ProvidedTypeDefinition(sqlRuntimeInfo.RuntimeAssembly,FSHARP_DATA_SQL,rootTypeName,Some typeof<obj>, isErased=true)
             let prov = ProviderBuilder.createProvider dbVendor resolutionPath config.ReferencedAssemblies config.RuntimeAssembly owner tableNames contextSchemaPath odbcquote sqliteLibrary
             match prov.GetSchemaCache().IsOffline with
             | false ->
                 let con = prov.CreateConnection conString
-                this.Disposing.Add(fun _ -> 
+                this.Disposing.Add(fun _ ->
                     if con <> Unchecked.defaultof<IDbConnection> && dbVendor <> DatabaseProviderTypes.MSACCESS then
                         con.Dispose())
                 con.Open()
@@ -68,8 +68,8 @@ type SqlTypeProvider(config: TypeProviderConfig) as this =
                 rootType, prov, Some con
             | true ->
             rootType, prov, None
-        
-        let tables = 
+
+        let tables =
             lazy
                 match con with
                 | Some con -> prov.GetTables(con,caseSensitivity)
@@ -79,15 +79,15 @@ type SqlTypeProvider(config: TypeProviderConfig) as this =
             lazy
                 dict
                     [for t in tables.Force() do
-                        yield( t.FullName, 
+                        yield( t.FullName,
                             lazy
                                 match con with
                                 | Some con ->
                                     let cols = prov.GetColumns(con,t)
                                     let rel = prov.GetRelationships(con,t)
                                     (cols,rel)
-                                | None -> 
-                                    let cols = 
+                                | None ->
+                                    let cols =
                                         match prov.GetSchemaCache().Columns.TryGetValue(t.FullName) with
                                         | true,cols -> cols
                                         | false,_ -> Map.empty
@@ -97,7 +97,7 @@ type SqlTypeProvider(config: TypeProviderConfig) as this =
                                         | false,_ -> ([],[])
                                     (cols,rel))]
 
-        let sprocData = 
+        let sprocData =
             lazy
                 match con with
                 | Some con -> prov.GetSprocs con
@@ -105,18 +105,18 @@ type SqlTypeProvider(config: TypeProviderConfig) as this =
 
         let getSprocReturnColumns sprocname (sprocDefinition: CompileTimeSprocDefinition) param =
             match con with
-            | Some con -> 
+            | Some con ->
                 let returnParams = sprocDefinition.ReturnColumns con param
                 prov.GetSchemaCache().SprocsParams.AddOrUpdate(sprocname, returnParams, fun _ inputParams -> inputParams @ returnParams) |> ignore
                 returnParams
-            | None -> 
+            | None ->
                 let ok, pars = prov.GetSchemaCache().SprocsParams.TryGetValue sprocname
                 if ok then
                     pars |> List.filter (fun p -> p.Direction = ParameterDirection.Output)
                 else []
 
         let getTableData name = tableColumns.Force().[name].Force()
-        let serviceType = ProvidedTypeDefinition( "dataContext", None, isErased=true)
+        let serviceType = ProvidedTypeDefinition( "dataContext", Some typeof<obj>, isErased=true)
         let transactionOptions = TransactionOptions.Default
         let designTimeDc = SqlDataContext(rootTypeName, conString, dbVendor, resolutionPath, config.ReferencedAssemblies, config.RuntimeAssembly, owner, caseSensitivity, tableNames, contextSchemaPath, odbcquote, sqliteLibrary, transactionOptions, None, SelectOperations.DotNetSide)
         // first create all the types so we are able to recursively reference them in each other's definitions
@@ -131,20 +131,20 @@ type SqlTypeProvider(config: TypeProviderConfig) as this =
                                     | CaseSensitivityChange.ORIGINAL | CaseSensitivityChange.TOLOWER
                                             when prov.GetTables(con,CaseSensitivityChange.TOUPPER).Length > 0 ->
                                         ". Try adding parameter SqlDataProvider<CaseSensitivityChange=Common.CaseSensitivityChange.TOUPPER, ...> \r\nConnection: " + connectionString
-                                    | CaseSensitivityChange.ORIGINAL | CaseSensitivityChange.TOUPPER 
+                                    | CaseSensitivityChange.ORIGINAL | CaseSensitivityChange.TOUPPER
                                             when prov.GetTables(con,CaseSensitivityChange.TOLOWER).Length > 0 ->
                                         ". Try adding parameter SqlDataProvider<CaseSensitivityChange=Common.CaseSensitivityChange.TOLOWER, ...> \r\nConnection: " + connectionString
                                     | _ when owner = "" -> ". Try adding parameter SqlDataProvider<Owner=...> where Owner value is database name or schema. \r\nConnection: " + connectionString
                                     | _ -> " for schema or database " + owner + ". Connection: " + connectionString
                                 | None -> ""
                             let possibleError = "Tables not found" + hint
-                            let errInfo = 
+                            let errInfo =
                                 ProvidedProperty("PossibleError", typeof<String>, getterCode = fun _ -> <@@ possibleError @@>)
-                            errInfo.AddXmlDocDelayed(fun () -> 
+                            errInfo.AddXmlDocDelayed(fun () ->
                                 this.Invalidate()
                                 "You have possible configuration error. \r\n " + possibleError)
                             serviceType.AddMember errInfo
-                       else                
+                       else
                        for table in tablesforced do
                         let t = ProvidedTypeDefinition(table.FullName + "Entity", Some typeof<SqlEntity>, isErased=true)
                         t.AddMemberDelayed(fun () -> ProvidedConstructor([ProvidedParameter("dataContext",typeof<ISqlDataContext>)],
@@ -155,14 +155,14 @@ type SqlTypeProvider(config: TypeProviderConfig) as this =
 
         let createIndividualsType (table:Table) =
             let tableTypeDef,_,_,_ = baseTypes.Force().[table.FullName]
-            let t = ProvidedTypeDefinition(table.Schema + "." + table.Name + "." + "Individuals", None, isErased=true)
+            let t = ProvidedTypeDefinition(table.Schema + "." + table.Name + "." + "Individuals", Some typeof<obj>, isErased=true)
             let individualsTypes = ResizeArray<_>()
             individualsTypes.Add t
-            
+
             t.AddXmlDocDelayed(fun _ -> sprintf "<summary>A sample of %s individuals from the SQL object as supplied in the static parameters</summary>" table.Name)
             t.AddMember(ProvidedConstructor([ProvidedParameter("dataContext", typeof<ISqlDataContext>)], empty))
             t.AddMembersDelayed( fun _ ->
-               let columns = 
+               let columns =
                 match con with
                 | Some con -> prov.GetColumns(con,table)
                 | None -> prov.GetSchemaCache().Columns.TryGetValue(table.FullName) |> function | true,cols -> cols | false, _ -> Map.empty
@@ -176,34 +176,34 @@ type SqlTypeProvider(config: TypeProviderConfig) as this =
                             use reader = com.ExecuteReader()
                             let ret = (designTimeDc :> ISqlDataContext).ReadEntities(table.FullName, columns, reader)
                             if (dbVendor <> DatabaseProviderTypes.MSACCESS) then con.Close()
-                            if ret.Length > 0 then 
+                            if ret.Length > 0 then
                                 prov.GetSchemaCache().Individuals.AddRange ret
                             ret
                         | None -> prov.GetSchemaCache().Individuals |> Seq.toArray
                    if Array.isEmpty entities then [] else
                    // for each column in the entity except the primary key, create a new type that will read ``As Column 1`` etc
-                   // inside that type the individuals will be listed again but with the text for the relevant column as the name 
+                   // inside that type the individuals will be listed again but with the text for the relevant column as the name
                    // of the property and the primary key e.g. ``1, Dennis The Squirrel``
                    let buildFieldName = SchemaProjections.buildFieldName
                    let propertyMap =
                       match con with
                       | Some con -> prov.GetColumns(con,table)
                       | None -> prov.GetSchemaCache().Columns.TryGetValue(table.FullName) |> function | true,cols -> cols | false, _ -> Map.empty
-                      |> Seq.choose(fun col -> 
+                      |> Seq.choose(fun col ->
                         if col.Key = pkName then None else
                         let name = table.Schema + "." + table.Name + "." + col.Key + "Individuals"
-                        let ty = ProvidedTypeDefinition(name, None, isErased=true)
+                        let ty = ProvidedTypeDefinition(name, Some typeof<obj>, isErased=true)
                         ty.AddMember(ProvidedConstructor([ProvidedParameter("sqlService", typeof<ISqlDataContext>)], empty))
                         individualsTypes.Add ty
                         Some(col.Key,(ty,ProvidedProperty(sprintf "As %s" (buildFieldName col.Key),ty, getterCode = fun args -> <@@ ((%%args.[0] : obj) :?> ISqlDataContext)@@> ))))
                       |> Map.ofSeq
-                 
-                   let rec (|FixedType|_|) (o:obj) = 
+
+                   let rec (|FixedType|_|) (o:obj) =
                       match o, o.GetType().IsValueType with
                       // watch out for normal strings
                       | :? string, _ -> Some o
                       // special case for guids as they are not a supported quotable constant in the TP mechanics,
-                      // but we can deal with them as strings.                 
+                      // but we can deal with them as strings.
                       | :? Guid, _ -> Some (box (o.ToString()))
                       // Postgres also supports arrays
                       | :? Array as arr, _ when dbVendor = DatabaseProviderTypes.POSTGRESQL -> Some (box arr)
@@ -212,30 +212,30 @@ type SqlTypeProvider(config: TypeProviderConfig) as this =
                       // can't support any other types
                       | _, _ -> None
 
-                   
+
                    let prettyPrint (value : obj) =
-                       let dirtyName = 
+                       let dirtyName =
                            match value with
                            | null -> "<null>"
                            | :? Array as a -> (sprintf "%A" a)
-                           | x -> x.ToString()                       
+                           | x -> x.ToString()
                        dirtyName.Replace("\r", "").Replace("\n", "").Replace("\t", "")
 
-                   // on the main object create a property for each entity simply using the primary key 
+                   // on the main object create a property for each entity simply using the primary key
                    let props =
                       entities
-                      |> Array.choose(fun e -> 
+                      |> Array.choose(fun e ->
                          match e.GetColumn pkName with
-                         | FixedType pkValue -> 
-                            
+                         | FixedType pkValue ->
+
                             let tableName = table.FullName
-                            let getterCode (args : Expr list) = <@@ ((%%args.[0] : obj) :?> ISqlDataContext).GetIndividual(tableName, pkValue) @@> 
+                            let getterCode (args : Expr list) = <@@ ((%%args.[0] : obj) :?> ISqlDataContext).GetIndividual(tableName, pkValue) @@>
 
                             // this next bit is just side effect to populate the "As Column" types for the supported columns
-                            for colName, colValue in e.ColumnValues do                                         
+                            for colName, colValue in e.ColumnValues do
                                 if colName <> pkName then
                                     let colDefinition, _ = propertyMap.[colName]
-                                    colDefinition.AddMemberDelayed(fun() -> 
+                                    colDefinition.AddMemberDelayed(fun() ->
                                         ProvidedProperty( sprintf "%s, %s" (prettyPrint pkValue) (prettyPrint colValue)
                                                         , tableTypeDef
                                                         , getterCode = getterCode
@@ -249,76 +249,76 @@ type SqlTypeProvider(config: TypeProviderConfig) as this =
                          | _ -> None)
                       |> Array.append( propertyMap |> Map.toArray |> Array.map (snd >> snd))
 
-                   propertyMap 
+                   propertyMap
                    |> Map.toSeq
-                   |> Seq.map (snd >> fst) 
+                   |> Seq.map (snd >> fst)
                    |> Seq.cast<MemberInfo>
                    |> Seq.append (props |> Seq.cast<MemberInfo>)
                    |> Seq.toList
 
                | None -> [])
-            individualsTypes :> seq<_> 
-            
+            individualsTypes :> seq<_>
+
         let baseCollectionTypes =
             lazy
-                dict [ for table in tables.Force() do  
+                dict [ for table in tables.Force() do
                         let name = table.FullName
                         let (et,_,_,_) = baseTypes.Force().[name]
-                        let ct = ProvidedTypeDefinition(table.FullName, None ,isErased=true)                        
+                        let ct = ProvidedTypeDefinition(table.FullName, Some typeof<obj>,isErased=true)
                         ct.AddInterfaceImplementationsDelayed( fun () -> [ProvidedTypeBuilder.MakeGenericType(typedefof<System.Linq.IQueryable<_>>,[et :> Type]); typeof<ISqlDataContext>])
-                        let it = createIndividualsType table 
+                        let it = createIndividualsType table
                         yield table.FullName,(ct,it) ]
-        
+
         // add the attributes and relationships
-        for KeyValue(key,(t,_,_,_)) in baseTypes.Force() do 
-            t.AddMembersDelayed(fun () -> 
+        for KeyValue(key,(t,_,_,_)) in baseTypes.Force() do
+            t.AddMembersDelayed(fun () ->
                 let (columns,(children,parents)) = getTableData key
-                let attProps = 
+                let attProps =
                     let createColumnProperty (c:Column) =
                         let nullable = useOptionTypes && c.IsNullable
                         let ty = Type.GetType c.TypeMapping.ClrType
                         let propTy = if nullable then typedefof<option<_>>.MakeGenericType(ty) else ty
                         let name = c.Name
-                        let prop = 
+                        let prop =
                             ProvidedProperty(
-                                SchemaProjections.buildFieldName(name),propTy, 
+                                SchemaProjections.buildFieldName(name),propTy,
                                 getterCode = (fun (args:Expr list) ->
                                     let meth = if nullable then typeof<SqlEntity>.GetMethod("GetColumnOption").MakeGenericMethod([|ty|])
                                                else  typeof<SqlEntity>.GetMethod("GetColumn").MakeGenericMethod([|ty|])
                                     Expr.Call(args.[0],meth,[Expr.Value name])
                                 ),
                                 setterCode = (fun (args:Expr list) ->
-                                    if nullable then 
+                                    if nullable then
                                         let meth = typeof<SqlEntity>.GetMethod("SetColumnOption").MakeGenericMethod([|ty|])
                                         Expr.Call(args.[0],meth,[Expr.Value name;args.[1]])
-                                    else      
+                                    else
                                         let meth = typeof<SqlEntity>.GetMethod("SetColumn").MakeGenericMethod([|ty|])
                                         Expr.Call(args.[0],meth,[Expr.Value name;args.[1]]))
                                  )
                         let nfo = c.TypeInfo
-                        let typeInfo = match nfo with None -> "" | Some x -> x.ToString() 
+                        let typeInfo = match nfo with None -> "" | Some x -> x.ToString()
                         match con with
                         | Some con ->
-                            prop.AddXmlDocDelayed(fun () -> 
+                            prop.AddXmlDocDelayed(fun () ->
                                 let details = prov.GetColumnDescription(con, key, name).Replace("<","&lt;").Replace(">","&gt;")
                                 let separator = if (String.IsNullOrWhiteSpace typeInfo) || (String.IsNullOrWhiteSpace details) then "" else "/"
                                 sprintf "<summary>%s %s %s</summary>" (String.Join(": ", [|name; details|])) separator typeInfo)
-                        | None -> 
+                        | None ->
                             prop.AddXmlDocDelayed(fun () -> sprintf "<summary>Offline mode. %s</summary>" typeInfo)
                             ()
                         prop
                     List.map createColumnProperty (columns |> Seq.map (fun kvp -> kvp.Value) |> Seq.toList)
-                let relProps = 
-                    let getRelationshipName = Utilities.uniqueName() 
-                    let bts = baseTypes.Force()       
-                    [ for r in children do       
+                let relProps =
+                    let getRelationshipName = Utilities.uniqueName()
+                    let bts = baseTypes.Force()
+                    [ for r in children do
                        if bts.ContainsKey(r.ForeignTable) then
                         let (tt,_,_,_) = bts.[r.ForeignTable]
                         let ty = typedefof<System.Linq.IQueryable<_>>
                         let ty = ty.MakeGenericType tt
                         let constraintName = r.Name
-                        let niceName = getRelationshipName (sprintf "%s by %s" r.ForeignTable r.PrimaryKey) 
-                        let prop = ProvidedProperty(niceName,ty, getterCode = fun args -> 
+                        let niceName = getRelationshipName (sprintf "%s by %s" r.ForeignTable r.PrimaryKey)
+                        let prop = ProvidedProperty(niceName,ty, getterCode = fun args ->
                             let pt = r.PrimaryTable
                             let pk = r.PrimaryKey
                             let ft = r.ForeignTable
@@ -333,7 +333,7 @@ type SqlTypeProvider(config: TypeProviderConfig) as this =
                         let ty = ty.MakeGenericType tt
                         let constraintName = r.Name
                         let niceName = getRelationshipName (sprintf "%s by %s" r.PrimaryTable r.PrimaryKey)
-                        let prop = ProvidedProperty(niceName,ty, getterCode = fun args -> 
+                        let prop = ProvidedProperty(niceName,ty, getterCode = fun args ->
                             let pt = r.PrimaryTable
                             let pk = r.PrimaryKey
                             let ft = r.ForeignTable
@@ -342,29 +342,29 @@ type SqlTypeProvider(config: TypeProviderConfig) as this =
                         prop.AddXmlDoc(sprintf "Related %s entities from the primary side of the relationship, where the primary key is %s and the foreign key is %s. Constraint: %s" r.PrimaryTable r.PrimaryKey r.ForeignKey constraintName)
                         yield prop ]
                 attProps @ relProps)
-        
-        let generateSprocMethod (container:ProvidedTypeDefinition) (con:IDbConnection option) (sproc:CompileTimeSprocDefinition) =    
-            
-            let sprocname = SchemaProjections.buildSprocName(sproc.Name.DbName) 
+
+        let generateSprocMethod (container:ProvidedTypeDefinition) (con:IDbConnection option) (sproc:CompileTimeSprocDefinition) =
+
+            let sprocname = SchemaProjections.buildSprocName(sproc.Name.DbName)
                             |> SchemaProjections.avoidNameClashBy (container.GetMember >> Array.isEmpty >> not)
 
-            let rt = ProvidedTypeDefinition(sprocname,None, isErased=true)
-            let resultType = ProvidedTypeDefinition("Result", None, isErased=true)
+            let rt = ProvidedTypeDefinition(sprocname, Some typeof<obj>, isErased=true)
+            let resultType = ProvidedTypeDefinition("Result", Some typeof<obj>, isErased=true)
             resultType.AddMember(ProvidedConstructor([ProvidedParameter("sqlDataContext", typeof<ISqlDataContext>)], empty))
             rt.AddMember resultType
             container.AddMember(rt)
-            
+
             resultType.AddMembersDelayed(fun () ->
-                    let sprocParameters = 
+                    let sprocParameters =
                         let cache = prov.GetSchemaCache()
                         match con with
-                        | None -> 
+                        | None ->
                             match cache.SprocsParams.TryGetValue sprocname with
                             | true, x -> x
                             | false, _ -> []
                         | Some con ->
                             Sql.ensureOpen con
-                            let ps = sproc.Params con  
+                            let ps = sproc.Params con
                             cache.SprocsParams.AddOrUpdate(sprocname, ps, fun _ _ -> ps) |> ignore
                             ps
 
@@ -374,17 +374,17 @@ type SqlTypeProvider(config: TypeProviderConfig) as this =
                         |> List.map(fun p -> ProvidedParameter(p.Name,Type.GetType p.TypeMapping.ClrType))
                     let retCols = getSprocReturnColumns sprocname sproc sprocParameters |> List.toArray
                     let runtimeSproc = {Name = sproc.Name; Params = sprocParameters} : RunTimeSprocDefinition
-                    let returnType = 
+                    let returnType =
                         match retCols.Length with
                         | 0 -> typeof<Unit>
-                        | _ -> 
+                        | _ ->
                               let rt = ProvidedTypeDefinition("SprocResult",Some typeof<SqlEntity>, isErased=true)
                               rt.AddMember(ProvidedConstructor([], empty))
                               retCols
                               |> Array.iter(fun col ->
                                   let name = col.Name
                                   let ty = Type.GetType col.TypeMapping.ClrType
-                                  let prop = 
+                                  let prop =
                                       ProvidedProperty(
                                           name,ty,
                                           getterCode = (fun (args:Expr list) ->
@@ -399,10 +399,10 @@ type SqlTypeProvider(config: TypeProviderConfig) as this =
                     let retColsExpr =
                         QuotationHelpers.arrayExpr retCols |> snd
                     let asyncRet = typedefof<Async<_>>.MakeGenericType([| returnType |])
-                    [ProvidedMethod("Invoke", parameters, returnType, invokeCode = QuotationHelpers.quoteRecord runtimeSproc (fun args var -> 
+                    [ProvidedMethod("Invoke", parameters, returnType, invokeCode = QuotationHelpers.quoteRecord runtimeSproc (fun args var ->
                         <@@ (((%%args.[0] : obj):?>ISqlDataContext)).CallSproc(%%var, %%retColsExpr,  %%Expr.NewArray(typeof<obj>,List.map(fun e -> Expr.Coerce(e,typeof<obj>)) args.Tail)) @@>));
-                     ProvidedMethod("InvokeAsync", parameters, asyncRet, invokeCode = QuotationHelpers.quoteRecord runtimeSproc (fun args var -> 
-                        if returnType = typeof<unit> then 
+                     ProvidedMethod("InvokeAsync", parameters, asyncRet, invokeCode = QuotationHelpers.quoteRecord runtimeSproc (fun args var ->
+                        if returnType = typeof<unit> then
                             <@@ async {
                                     let! r = (((%%args.[0] : obj):?>ISqlDataContext)).CallSprocAsync(%%var, %%retColsExpr,  %%Expr.NewArray(typeof<obj>,List.map(fun e -> Expr.Coerce(e,typeof<obj>)) args.Tail))
                                     return ()
@@ -411,62 +411,62 @@ type SqlTypeProvider(config: TypeProviderConfig) as this =
                            <@@ (((%%args.[0] : obj):?>ISqlDataContext)).CallSprocAsync(%%var, %%retColsExpr,  %%Expr.NewArray(typeof<obj>,List.map(fun e -> Expr.Coerce(e,typeof<obj>)) args.Tail))  @@>
                         ))]
             )
-                              
-            let niceUniqueSprocName = 
+
+            let niceUniqueSprocName =
                 SchemaProjections.buildSprocName(sproc.Name.ProcName)
                 |> SchemaProjections.avoidNameClashBy (container.GetProperty >> (<>) null)
 
-            let p = ProvidedProperty(niceUniqueSprocName, resultType, getterCode = (fun args -> <@@ ((%%args.[0] : obj) :?>ISqlDataContext) @@>) ) 
+            let p = ProvidedProperty(niceUniqueSprocName, resultType, getterCode = (fun args -> <@@ ((%%args.[0] : obj) :?>ISqlDataContext) @@>) )
             let dbName = sproc.Name.DbName
             p.AddXmlDocDelayed(fun _ -> sprintf "<summary>%s</summary>" dbName)
             p
-            
-        
+
+
         let rec walkSproc con (path:string list) (parent:ProvidedTypeDefinition option) (createdTypes:Map<string list,ProvidedTypeDefinition>) (sproc:Sproc) =
             match sproc with
-            | Root(typeName, next) -> 
+            | Root(typeName, next) ->
                 let path = (path @ [typeName])
                 match createdTypes.TryFind path with
-                | Some(typ) -> 
-                    walkSproc con path (Some typ) createdTypes next 
+                | Some(typ) ->
+                    walkSproc con path (Some typ) createdTypes next
                 | None ->
-                    let typ = ProvidedTypeDefinition(typeName, None, isErased=true)
+                    let typ = ProvidedTypeDefinition(typeName, Some typeof<obj>, isErased=true)
                     typ.AddMember(ProvidedConstructor([ProvidedParameter("sqlDataContext", typeof<ISqlDataContext>)], empty))
-                    walkSproc con path (Some typ) (createdTypes.Add(path, typ)) next 
-            | Package(typeName, packageDefn) ->       
+                    walkSproc con path (Some typ) (createdTypes.Add(path, typ)) next
+            | Package(typeName, packageDefn) ->
                 match parent with
                 | Some(parent) ->
                     let path = (path @ [typeName])
-                    let typ = ProvidedTypeDefinition(typeName, None, isErased=true)
+                    let typ = ProvidedTypeDefinition(typeName, Some typeof<obj>, isErased=true)
                     parent.AddMember(typ)
                     parent.AddMember(ProvidedProperty(SchemaProjections.nicePascalName typeName, typ, getterCode = fun args -> <@@ ((%%args.[0] : obj) :?> ISqlDataContext) @@>))
                     typ.AddMember(ProvidedConstructor([ProvidedParameter("sqlDataContext", typeof<ISqlDataContext>)], empty))
                     match con with
                     | Some co ->
-                        typ.AddMembersDelayed(fun () -> 
+                        typ.AddMembersDelayed(fun () ->
                             Sql.ensureOpen co
-                            let p = (packageDefn.Sprocs co) 
+                            let p = (packageDefn.Sprocs co)
                             prov.GetSchemaCache().Packages.AddRange p
-                            p |> List.map (generateSprocMethod typ con)) 
-                    | None -> 
-                        typ.AddMembersDelayed(fun () ->  
-                        prov.GetSchemaCache().Packages |> Seq.toList |> List.map (generateSprocMethod typ con)) 
+                            p |> List.map (generateSprocMethod typ con))
+                    | None ->
+                        typ.AddMembersDelayed(fun () ->
+                        prov.GetSchemaCache().Packages |> Seq.toList |> List.map (generateSprocMethod typ con))
                     createdTypes.Add(path, typ)
-                | _ -> failwithf "Could not generate package path type undefined root or previous type"    
+                | _ -> failwithf "Could not generate package path type undefined root or previous type"
             | Sproc(sproc) ->
                     match parent with
                     | Some(parent) ->
                         match con with
                         | Some co ->
                             parent.AddMemberDelayed(fun () -> Sql.ensureOpen co;  generateSprocMethod parent con sproc); createdTypes
-                        | None -> 
+                        | None ->
                             parent.AddMemberDelayed(fun () -> generateSprocMethod parent con sproc); createdTypes
                     | _ -> failwithf "Could not generate sproc undefined root or previous type"
             | Empty -> createdTypes
 
-        let rec generateTypeTree con (createdTypes:Map<string list, ProvidedTypeDefinition>) (sprocs:Sproc list) = 
+        let rec generateTypeTree con (createdTypes:Map<string list, ProvidedTypeDefinition>) (sprocs:Sproc list) =
             match sprocs with
-            | [] -> 
+            | [] ->
                 Map.filter (fun (k:string list) _ -> match k with [_] -> true | _ -> false) createdTypes
                 |> Map.toSeq
                 |> Seq.map snd
@@ -474,16 +474,16 @@ type SqlTypeProvider(config: TypeProviderConfig) as this =
 
         serviceType.AddMembersDelayed( fun () ->
             let schemaMap = new System.Collections.Generic.Dictionary<string, ProvidedTypeDefinition>()
-            let getOrAddSchema name = 
+            let getOrAddSchema name =
                 match schemaMap.TryGetValue name with
                 | true, pt -> pt
-                | false, _  -> 
+                | false, _  ->
                     let pt = ProvidedTypeDefinition(name + "Schema", Some typeof<obj>, isErased=true)
                     schemaMap.Add(name, pt)
                     pt
-            [ 
-              let containers = 
-                    let sprocs = 
+            [
+              let containers =
+                    let sprocs =
                         match con with
                         | None -> prov.GetSchemaCache().Sprocs |> Seq.toList
                         | Some _ ->
@@ -497,11 +497,11 @@ type SqlTypeProvider(config: TypeProviderConfig) as this =
                 // collection type, individuals type
                 let (ct,it) = baseCollectionTypes.Force().[key]
                 let schemaType = getOrAddSchema schema
-                
-                ct.AddMembersDelayed( fun () -> 
+
+                ct.AddMembersDelayed( fun () ->
                     // creation methods.
-                    // we are forced to load the columns here, but this is ok as the user has already 
-                    // pressed . on an IQueryable type so they are obviously interested in using this entity..                    
+                    // we are forced to load the columns here, but this is ok as the user has already
+                    // pressed . on an IQueryable type so they are obviously interested in using this entity..
                     let columns, _ = getTableData key
 
                     let requiredColumns =
@@ -517,26 +517,26 @@ type SqlTypeProvider(config: TypeProviderConfig) as this =
                         |> Array.sortBy(fun p -> p.Name)
                         |> Array.toList
 
-                    let normalParameters = 
-                        requiredColumns 
+                    let normalParameters =
+                        requiredColumns
                         |> Array.map(fun c -> ProvidedParameter(c.Name,Type.GetType c.TypeMapping.ClrType))
                         |> Array.sortBy(fun p -> p.Name)
                         |> Array.toList
 
-                    // Create: unit -> SqlEntity 
-                    let create1 = ProvidedMethod("Create", [], entityType, invokeCode = fun args ->                         
-                        <@@ 
+                    // Create: unit -> SqlEntity
+                    let create1 = ProvidedMethod("Create", [], entityType, invokeCode = fun args ->
+                        <@@
                             let e = ((%%args.[0] : obj ):?> IWithDataContext).DataContext.CreateEntity(key)
                             e._State <- Created
                             ((%%args.[0] : obj ):?> IWithDataContext ).DataContext.SubmitChangedEntity e
-                            e 
+                            e
                         @@> )
-                    
-                    // Create: ('a * 'b * 'c * ...) -> SqlEntity 
-                    let create2 = 
+
+                    // Create: ('a * 'b * 'c * ...) -> SqlEntity
+                    let create2 =
                         if normalParameters.Length = 0 then Unchecked.defaultof<ProvidedMethod> else
-                        ProvidedMethod("Create", normalParameters, entityType, invokeCode = fun args -> 
-                          
+                        ProvidedMethod("Create", normalParameters, entityType, invokeCode = fun args ->
+
                           let dc = args.Head
                           let args = args.Tail
                           let columns =
@@ -544,21 +544,21 @@ type SqlTypeProvider(config: TypeProviderConfig) as this =
                                       typeof<string*obj>,
                                       args
                                       |> Seq.toList
-                                      |> List.mapi(fun i v -> Expr.NewTuple [ Expr.Value normalParameters.[i].Name 
+                                      |> List.mapi(fun i v -> Expr.NewTuple [ Expr.Value normalParameters.[i].Name
                                                                               Expr.Coerce(v, typeof<obj>) ] ))
                           <@@
                               let e = ((%%dc : obj ):?> IWithDataContext).DataContext.CreateEntity(key)
-                              e._State <- Created                            
+                              e._State <- Created
                               e.SetData(%%columns : (string *obj) array)
                               ((%%dc : obj ):?> IWithDataContext ).DataContext.SubmitChangedEntity e
-                              e 
+                              e
                           @@>)
 
-                    // Create: ('a * 'b * 'c * ...) -> SqlEntity 
-                    let create2old = 
+                    // Create: ('a * 'b * 'c * ...) -> SqlEntity
+                    let create2old =
                         if backwardCompatibilityOnly.Length = 0 || normalParameters.Length = backwardCompatibilityOnly.Length then Unchecked.defaultof<ProvidedMethod> else
-                        ProvidedMethod("Create", backwardCompatibilityOnly, entityType, invokeCode = fun args -> 
-                          
+                        ProvidedMethod("Create", backwardCompatibilityOnly, entityType, invokeCode = fun args ->
+
                           let dc = args.Head
                           let args = args.Tail
                           let columns =
@@ -566,39 +566,39 @@ type SqlTypeProvider(config: TypeProviderConfig) as this =
                                       typeof<string*obj>,
                                       args
                                       |> Seq.toList
-                                      |> List.mapi(fun i v -> Expr.NewTuple [ Expr.Value backwardCompatibilityOnly.[i].Name 
+                                      |> List.mapi(fun i v -> Expr.NewTuple [ Expr.Value backwardCompatibilityOnly.[i].Name
                                                                               Expr.Coerce(v, typeof<obj>) ] ))
                           <@@
                               let e = ((%%dc : obj ):?> IWithDataContext).DataContext.CreateEntity(key)
-                              e._State <- Created                            
+                              e._State <- Created
                               e.SetData(%%columns : (string *obj) array)
                               ((%%dc : obj ):?> IWithDataContext ).DataContext.SubmitChangedEntity e
-                              e 
+                              e
                           @@>)
 
-                    // Create: (data : seq<string*obj>) -> SqlEntity 
-                    let create3 = ProvidedMethod("Create", [ProvidedParameter("data",typeof< (string*obj) seq >)] , entityType, invokeCode = fun args -> 
+                    // Create: (data : seq<string*obj>) -> SqlEntity
+                    let create3 = ProvidedMethod("Create", [ProvidedParameter("data",typeof< (string*obj) seq >)] , entityType, invokeCode = fun args ->
                           let dc = args.[0]
                           let data = args.[1]
                           <@@
                               let e = ((%%dc : obj ):?> IWithDataContext).DataContext.CreateEntity(key)
-                              e._State <- Created                            
+                              e._State <- Created
                               e.SetData(%%data : (string * obj) seq)
                               ((%%dc : obj ):?> IWithDataContext ).DataContext.SubmitChangedEntity e
-                              e 
+                              e
                           @@>)
-                    let desc3 = 
+                    let desc3 =
                         let cols = requiredColumns |> Seq.map(fun c -> c.Name)
                         "Item array of database columns: \r\n" + String.Join(",", cols)
                     create3.AddXmlDoc (sprintf "<summary>%s</summary>" desc3)
 
-                    // ``Create(...)``: ('a * 'b * 'c * ...) -> SqlEntity 
-                    let create4 = 
+                    // ``Create(...)``: ('a * 'b * 'c * ...) -> SqlEntity
+                    let create4 =
                         if normalParameters.Length = 0 then Unchecked.defaultof<ProvidedMethod> else
                         let template=
                             let cols = normalParameters |> Seq.map(fun c -> c.Name )
                             "Create(" + String.Join(", ", cols) + ")"
-                        ProvidedMethod(template, normalParameters, entityType, invokeCode = fun args -> 
+                        ProvidedMethod(template, normalParameters, entityType, invokeCode = fun args ->
                           let dc = args.Head
                           let args = args.Tail
                           let columns =
@@ -606,31 +606,31 @@ type SqlTypeProvider(config: TypeProviderConfig) as this =
                                       typeof<string*obj>,
                                       args
                                       |> Seq.toList
-                                      |> List.mapi(fun i v -> Expr.NewTuple [ Expr.Value normalParameters.[i].Name 
+                                      |> List.mapi(fun i v -> Expr.NewTuple [ Expr.Value normalParameters.[i].Name
                                                                               Expr.Coerce(v, typeof<obj>) ] ))
                           <@@
                               let e = ((%%dc : obj ):?> IWithDataContext).DataContext.CreateEntity(key)
-                              e._State <- Created                            
+                              e._State <- Created
                               e.SetData(%%columns : (string *obj) array)
                               ((%%dc : obj ):?> IWithDataContext ).DataContext.SubmitChangedEntity e
-                              e 
+                              e
                           @@>)
-                    
-                    let minimalParameters = 
+
+                    let minimalParameters =
                         requiredColumns
                         |> Array.filter (fun c-> (not c.HasDefault))
                         |> Array.map(fun c -> ProvidedParameter(c.Name,Type.GetType c.TypeMapping.ClrType))
                         |> Array.sortBy(fun p -> p.Name)
                         |> Array.toList
 
-                    // ``Create(...)``: ('a * 'b * 'c * ...) -> SqlEntity 
-                    let create4old = 
+                    // ``Create(...)``: ('a * 'b * 'c * ...) -> SqlEntity
+                    let create4old =
                         if backwardCompatibilityOnly.Length = 0 || backwardCompatibilityOnly.Length = normalParameters.Length ||
                             backwardCompatibilityOnly.Length = minimalParameters.Length then Unchecked.defaultof<ProvidedMethod> else
                         let template=
                             let cols = backwardCompatibilityOnly |> Seq.map(fun c -> c.Name )
                             "Create(" + String.Join(", ", cols) + ")"
-                        ProvidedMethod(template, backwardCompatibilityOnly, entityType, invokeCode = fun args -> 
+                        ProvidedMethod(template, backwardCompatibilityOnly, entityType, invokeCode = fun args ->
                           let dc = args.Head
                           let args = args.Tail
                           let columns =
@@ -638,23 +638,23 @@ type SqlTypeProvider(config: TypeProviderConfig) as this =
                                       typeof<string*obj>,
                                       args
                                       |> Seq.toList
-                                      |> List.mapi(fun i v -> Expr.NewTuple [ Expr.Value backwardCompatibilityOnly.[i].Name 
+                                      |> List.mapi(fun i v -> Expr.NewTuple [ Expr.Value backwardCompatibilityOnly.[i].Name
                                                                               Expr.Coerce(v, typeof<obj>) ] ))
                           <@@
                               let e = ((%%dc : obj ):?> IWithDataContext).DataContext.CreateEntity(key)
-                              e._State <- Created                            
+                              e._State <- Created
                               e.SetData(%%columns : (string *obj) array)
                               ((%%dc : obj ):?> IWithDataContext ).DataContext.SubmitChangedEntity e
-                              e 
+                              e
                           @@>)
-                    
-                    // ``Create(...)``: ('a * 'b * 'c * ...) -> SqlEntity 
-                    let create5 = 
+
+                    // ``Create(...)``: ('a * 'b * 'c * ...) -> SqlEntity
+                    let create5 =
                         if minimalParameters.Length = 0 || normalParameters.Length = minimalParameters.Length then Unchecked.defaultof<ProvidedMethod> else
                         let template=
                             let cols = minimalParameters |> Seq.map(fun c -> c.Name )
                             "Create(" + String.Join(", ", cols) + ")"
-                        ProvidedMethod(template, minimalParameters, entityType, invokeCode = fun args -> 
+                        ProvidedMethod(template, minimalParameters, entityType, invokeCode = fun args ->
                           let dc = args.Head
                           let args = args.Tail
                           let columns =
@@ -662,14 +662,14 @@ type SqlTypeProvider(config: TypeProviderConfig) as this =
                                       typeof<string*obj>,
                                       args
                                       |> Seq.toList
-                                      |> List.mapi(fun i v -> Expr.NewTuple [ Expr.Value minimalParameters.[i].Name 
+                                      |> List.mapi(fun i v -> Expr.NewTuple [ Expr.Value minimalParameters.[i].Name
                                                                               Expr.Coerce(v, typeof<obj>) ] ))
                           <@@
                               let e = ((%%dc : obj ):?> IWithDataContext).DataContext.CreateEntity(key)
-                              e._State <- Created                            
+                              e._State <- Created
                               e.SetData(%%columns : (string *obj) array)
                               ((%%dc : obj ):?> IWithDataContext ).DataContext.SubmitChangedEntity e
-                              e 
+                              e
                           @@>)
 
 
@@ -680,22 +680,22 @@ type SqlTypeProvider(config: TypeProviderConfig) as this =
                      individuals.AddXmlDoc("<summary>Get individual items from the table. Requires single primary key.</summary>")
                      yield individuals :> MemberInfo
                      if normalParameters.Length > 0 then yield create2 :> MemberInfo
-                     if backwardCompatibilityOnly.Length > 0 && normalParameters.Length <> backwardCompatibilityOnly.Length then 
+                     if backwardCompatibilityOnly.Length > 0 && normalParameters.Length <> backwardCompatibilityOnly.Length then
                         create2old.AddXmlDoc("This will be obsolete soon. Migrate away from this!")
                         yield create2old :> MemberInfo
                      yield create3 :> MemberInfo
                      yield create1 :> MemberInfo
-                     if normalParameters.Length > 0 then 
+                     if normalParameters.Length > 0 then
                         create4.AddXmlDoc("Create version that breaks if your columns change. Only non-nullable parameters.")
-                        yield create4 :> MemberInfo 
-                     if minimalParameters.Length > 0 && normalParameters.Length <> minimalParameters.Length then 
+                        yield create4 :> MemberInfo
+                     if minimalParameters.Length > 0 && normalParameters.Length <> minimalParameters.Length then
                         create5.AddXmlDoc("Create version that breaks if your columns change. No default value parameters.")
-                        yield create5 :> MemberInfo 
+                        yield create5 :> MemberInfo
                      if backwardCompatibilityOnly.Length > 0 && backwardCompatibilityOnly.Length <> normalParameters.Length &&
-                        backwardCompatibilityOnly.Length <> minimalParameters.Length then 
+                        backwardCompatibilityOnly.Length <> minimalParameters.Length then
                             create4old.AddXmlDoc("This will be obsolete soon. Migrate away from this!")
-                            yield create4old :> MemberInfo 
-                     
+                            yield create4old :> MemberInfo
+
                      } |> Seq.toList
                 )
 
@@ -704,36 +704,36 @@ type SqlTypeProvider(config: TypeProviderConfig) as this =
                 let tname = ct.Name
                 match con with
                 | Some con ->
-                    prop.AddXmlDocDelayed (fun () -> 
+                    prop.AddXmlDocDelayed (fun () ->
                         let details = prov.GetTableDescription(con, tname).Replace("<","&lt;").Replace(">","&gt;")
                         let separator = if (String.IsNullOrWhiteSpace desc) || (String.IsNullOrWhiteSpace details) then "" else "/"
                         sprintf "<summary>%s %s %s</summary>" details separator desc)
-                | None -> 
+                | None ->
                     prop.AddXmlDocDelayed (fun () -> "<summary>Offline mode.</summary>")
                     ()
                 schemaType.AddMember ct
                 schemaType.AddMember prop
 
                 yield entityType :> MemberInfo
-                //yield ct         :> MemberInfo                
+                //yield ct         :> MemberInfo
                 //yield prop       :> MemberInfo
                 yield! Seq.cast<MemberInfo> it
 
               yield! containers |> Seq.map(fun p -> ProvidedProperty(p.Name.Replace("Container",""), p, getterCode = fun args -> <@@ ((%%args.[0] : obj) :?> ISqlDataContext) @@>)) |> Seq.cast<MemberInfo>
               let submit = ProvidedMethod("SubmitUpdates",[],typeof<unit>, invokeCode = fun args -> <@@ ((%%args.[0] : obj) :?> ISqlDataContext).SubmitPendingChanges() @@>)
-              submit.AddXmlDoc("<summary>Save changes to data-source. May throws errors: To deal with non-saved items use GetUpdates() and ClearUpdates().</summary>") 
+              submit.AddXmlDoc("<summary>Save changes to data-source. May throws errors: To deal with non-saved items use GetUpdates() and ClearUpdates().</summary>")
               yield submit :> MemberInfo
               let submitAsync = ProvidedMethod("SubmitUpdatesAsync",[],typeof<Async<unit>>, invokeCode = fun args -> <@@ ((%%args.[0] : obj) :?> ISqlDataContext).SubmitPendingChangesAsync() @@>)
-              submitAsync.AddXmlDoc("<summary>Save changes to data-source. May throws errors: Use Async.Catch and to deal with non-saved items use GetUpdates() and ClearUpdates().</summary>") 
+              submitAsync.AddXmlDoc("<summary>Save changes to data-source. May throws errors: Use Async.Catch and to deal with non-saved items use GetUpdates() and ClearUpdates().</summary>")
               yield submitAsync :> MemberInfo
               yield ProvidedMethod("GetUpdates",[],typeof<SqlEntity list>, invokeCode = fun args -> <@@ ((%%args.[0] : obj) :?> ISqlDataContext).GetPendingEntities() @@>)  :> MemberInfo
               yield ProvidedMethod("ClearUpdates",[],typeof<SqlEntity list>, invokeCode = fun args -> <@@ ((%%args.[0] : obj) :?> ISqlDataContext).ClearPendingChanges() @@>)  :> MemberInfo
               yield ProvidedMethod("CreateConnection",[],typeof<IDbConnection>, invokeCode = fun args -> <@@ ((%%args.[0] : obj) :?> ISqlDataContext).CreateConnection() @@>)  :> MemberInfo
-              
-              let saveResponse = ProvidedTypeDefinition("SaveContextResponse",None, isErased=true)
+
+              let saveResponse = ProvidedTypeDefinition("SaveContextResponse", Some typeof<obj>, isErased=true)
               saveResponse.AddMember(ProvidedConstructor([], empty))
-              saveResponse.AddMemberDelayed(fun () -> 
-                  let result = 
+              saveResponse.AddMemberDelayed(fun () ->
+                  let result =
                       if not(String.IsNullOrEmpty contextSchemaPath) then
                           try
                               lock mySaveLock (fun() ->
@@ -746,7 +746,7 @@ type SqlTypeProvider(config: TypeProviderConfig) as this =
                   ProvidedMethod(result,[],typeof<unit>, invokeCode = empty) :> MemberInfo
               )
               let m = ProvidedMethod("SaveContextSchema", [], (saveResponse :> Type), invokeCode = empty)
-              m.AddXmlDocComputed(fun () -> 
+              m.AddXmlDocComputed(fun () ->
                   if String.IsNullOrEmpty contextSchemaPath then "ContextSchemaPath static parameter has to be defined to use this function."
                   else "Schema location: " + contextSchemaPath + ". Write dot after SaveContextSchema() to save the schema at design time."
                   )
@@ -758,54 +758,54 @@ type SqlTypeProvider(config: TypeProviderConfig) as this =
                     yield pt :> MemberInfo
                     yield ProvidedProperty(SchemaProjections.buildTableName(name),pt, getterCode = fun args -> <@@ ((%%args.[0] : obj) :?> ISqlDataContext) @@> ) :> MemberInfo
              ])
-        
+
         rootType.AddMembers [ serviceType ]
-        
-        let referencedAssemblyExpr = QuotationHelpers.arrayExpr config.ReferencedAssemblies |> snd        
+
+        let referencedAssemblyExpr = QuotationHelpers.arrayExpr config.ReferencedAssemblies |> snd
         let resolutionFolder = config.ResolutionFolder
 
         // using a magic number for the lack of a command timeout; otherwise we'd need to convert an untyped Expr to an untyped option Expr
         // i'm pretty sure no SQL driver actually wants this as a value. still, can this be handled better?
-        let NO_COMMAND_TIMEOUT = Int32.MinValue 
-                  
+        let NO_COMMAND_TIMEOUT = Int32.MinValue
+
         // these are the definitions for the parameters that may appear in the .GetDataContext() overload
-        let customConnStr = 
-          "connectionString", 
-          "The database runtime connection string", 
+        let customConnStr =
+          "connectionString",
+          "The database runtime connection string",
           typeof<string>
 
-        let customResPath = 
-          "resolutionPath", 
-          "The location to look for dynamically loaded assemblies containing database vendor specific connections and custom types", 
+        let customResPath =
+          "resolutionPath",
+          "The location to look for dynamically loaded assemblies containing database vendor specific connections and custom types",
           typeof<string>
 
-        let customTransOpts = 
-          "transactionOptions", 
-          "TransactionOptions for the transaction created on SubmitChanges.", 
+        let customTransOpts =
+          "transactionOptions",
+          "TransactionOptions for the transaction created on SubmitChanges.",
           typeof<TransactionOptions>
 
-        let customCmdTimeout = 
-          "commandTimeout", 
-          "SQL command timeout. Maximum time for single SQL-command in seconds.", 
+        let customCmdTimeout =
+          "commandTimeout",
+          "SQL command timeout. Maximum time for single SQL-command in seconds.",
           typeof<int>
 
-        let customSelectOps = 
-          "selectOperations", 
-          "Execute select-clause operations in SQL database rather than .NET-side.", 
+        let customSelectOps =
+          "selectOperations",
+          "Execute select-clause operations in SQL database rather than .NET-side.",
           typeof<SelectOperations>
-             
+
         // these are the default values to be used if the .GetDataContext() overload doesn't include the parameter
-        let defaultConnStr =         
+        let defaultConnStr =
             <@@ match ConfigHelpers.tryGetConnectionString true resolutionFolder conStringName connectionString with
                 | "" -> failwithf "No connection string specified or could not find a connection string with name %s" conStringName
-                | cs -> cs 
+                | cs -> cs
             @@>
-        let defaultResPath = <@@ resolutionFolder @@>                
+        let defaultResPath = <@@ resolutionFolder @@>
         let defaultCmdTimeout = <@@ NO_COMMAND_TIMEOUT @@>
         let defaultTransOpts = <@@ TransactionOptions.Default @@>
-        let defaultSelectOps = <@@ SelectOperations.DotNetSide @@>             
-        
-        let optionPairs = [|              
+        let defaultSelectOps = <@@ SelectOperations.DotNetSide @@>
+
+        let optionPairs = [|
           customConnStr, defaultConnStr
           customResPath, defaultResPath
           customTransOpts, defaultTransOpts
@@ -816,7 +816,7 @@ type SqlTypeProvider(config: TypeProviderConfig) as this =
         // generates the .GetDataContext() overloads
         // each parameter can either be present (passed as argument at runtime) or missing (uses the default value)
         let overloads = [|
-          [| |] 
+          [| |]
           [| customConnStr |]
           [| customConnStr; customResPath |]
           [| customConnStr; customTransOpts |]
@@ -835,91 +835,91 @@ type SqlTypeProvider(config: TypeProviderConfig) as this =
           [| customConnStr; customResPath; customTransOpts; customCmdTimeout; customSelectOps |]
         |]
 
-        rootType.AddMembersDelayed (fun () -> 
-            [ 
+        rootType.AddMembersDelayed (fun () ->
+            [
 
               for overload in overloads do
 
                 let actualParams = [|
-                  for (customParam, defaultParam) in optionPairs do 
+                  for (customParam, defaultParam) in optionPairs do
                     match overload |> Array.exists ((=) customParam) with
-                    | true -> yield UserProvided customParam 
+                    | true -> yield UserProvided customParam
                     | false -> yield Default defaultParam
                 |]
-    
+
                 // The code that gets actually executed
                 let invoker (args: Expr list) =
 
-                  let actualArgs = 
-                    [| 
+                  let actualArgs =
+                    [|
                         let mutable argPosition = 0
                         for actualParam in actualParams do
-                            match actualParam with 
+                            match actualParam with
                             // if the parameter appears, we read it from the argument list and advance
                             | UserProvided _ -> yield args.[argPosition]; argPosition <- argPosition + 1
                             // otherwise, we use the default value
                             | Default p -> yield p
                     |]
 
-                  <@@ 
-                    let cmdTimeout = 
+                  <@@
+                    let cmdTimeout =
                       let argTimeout = %%actualArgs.[3]
                       if argTimeout = NO_COMMAND_TIMEOUT then None else Some argTimeout
 
-                    // **important**: contextSchemaPath is empty because we do not want 
+                    // **important**: contextSchemaPath is empty because we do not want
                     // to load the schema cache from (the developer's) local filesystem in production
-                    SqlDataContext(typeName = rootTypeName, connectionString = %%actualArgs.[0], providerType = dbVendor, 
-                                    resolutionPath = %%actualArgs.[1], referencedAssemblies = %%referencedAssemblyExpr, 
+                    SqlDataContext(typeName = rootTypeName, connectionString = %%actualArgs.[0], providerType = dbVendor,
+                                    resolutionPath = %%actualArgs.[1], referencedAssemblies = %%referencedAssemblyExpr,
                                     runtimeAssembly = resolutionFolder, owner = owner, caseSensitivity = caseSensitivity,
-                                    tableNames = tableNames, contextSchemaPath = "", odbcquote = odbcquote, 
-                                    sqliteLibrary = sqliteLibrary, transactionOptions = %%actualArgs.[2], 
+                                    tableNames = tableNames, contextSchemaPath = "", odbcquote = odbcquote,
+                                    sqliteLibrary = sqliteLibrary, transactionOptions = %%actualArgs.[2],
                                     commandTimeout = cmdTimeout, sqlOperationsInSelect = %%actualArgs.[4])
-                    :> ISqlDataContext 
+                    :> ISqlDataContext
                   @@>
-                        
+
                 // builds the definitions
-                let paramList = 
+                let paramList =
                   [ for actualParam in actualParams do
-                      match actualParam with 
+                      match actualParam with
                       | UserProvided(pname, pcomment, ptype) -> yield pname, pcomment, ptype
-                      | _ -> ()                      
+                      | _ -> ()
                   ]
 
-                let providerParams = 
+                let providerParams =
                   [ for (pname, _, ptype) in paramList -> ProvidedParameter(pname, ptype)]
-                         
-                let xmlComments = 
+
+                let xmlComments =
                   [|  yield "<summary>Returns an instance of the SQL Provider using the static parameters</summary>"
                       for (pname, xmlInfo, _) in paramList -> "<param name='" + pname + "'>" + xmlInfo + "</param>"
                   |]
 
-                let method = 
+                let method =
                   ProvidedMethod( methodName = "GetDataContext"
                                 , parameters = providerParams
                                 , returnType = serviceType
                                 , isStatic = true
                                 , invokeCode = invoker
-                                )                        
-                         
+                                )
+
                 method.AddXmlDoc (String.concat "" xmlComments)
-                         
-                yield method                   
+
+                yield method
             ])
 
         match con with
         | Some con -> if (dbVendor <> DatabaseProviderTypes.MSACCESS) then con.Close()
         | None -> ()
         rootType
-    
+
     let paramSqlType = ProvidedTypeDefinition(sqlRuntimeInfo.RuntimeAssembly, FSHARP_DATA_SQL, "SqlDataProvider", Some(typeof<obj>), isErased=true)
-    
+
     let conString = ProvidedStaticParameter("ConnectionString",typeof<string>, "")
-    let connStringName = ProvidedStaticParameter("ConnectionStringName", typeof<string>, "")    
+    let connStringName = ProvidedStaticParameter("ConnectionStringName", typeof<string>, "")
     let optionTypes = ProvidedStaticParameter("UseOptionTypes",typeof<bool>,false)
     let dbVendor = ProvidedStaticParameter("DatabaseVendor",typeof<DatabaseProviderTypes>,DatabaseProviderTypes.MSSQLSERVER)
     let individualsAmount = ProvidedStaticParameter("IndividualsAmount",typeof<int>,1000)
-    let owner = ProvidedStaticParameter("Owner", typeof<string>, "")    
-    let resolutionPath = ProvidedStaticParameter("ResolutionPath",typeof<string>, "")    
+    let owner = ProvidedStaticParameter("Owner", typeof<string>, "")
+    let resolutionPath = ProvidedStaticParameter("ResolutionPath",typeof<string>, "")
     let caseSensitivity = ProvidedStaticParameter("CaseSensitivityChange",typeof<CaseSensitivityChange>,CaseSensitivityChange.ORIGINAL)
     let tableNames = ProvidedStaticParameter("TableNames", typeof<string>, "")
     let contextSchemaPath = ProvidedStaticParameter("ContextSchemaPath", typeof<string>, "")
@@ -939,9 +939,9 @@ type SqlTypeProvider(config: TypeProviderConfig) as this =
                     <param name='OdbcQuote'>Odbc quote characters: Quote characters for the table and column names: `alias`, [alias]</param>
                     <param name='SQLiteLibrary'>Use System.Data.SQLite or Mono.Data.SQLite or select automatically (SQLite only)</param>
                     "
-        
-    do paramSqlType.DefineStaticParameters([dbVendor;conString;connStringName;resolutionPath;individualsAmount;optionTypes;owner;caseSensitivity; tableNames; contextSchemaPath; odbcquote; sqliteLibrary], fun typeName args -> 
-        
+
+    do paramSqlType.DefineStaticParameters([dbVendor;conString;connStringName;resolutionPath;individualsAmount;optionTypes;owner;caseSensitivity; tableNames; contextSchemaPath; odbcquote; sqliteLibrary], fun typeName args ->
+
         let arguments =
             args.[1] :?> string,                  // ConnectionString URL
             args.[2] :?> string,                  // ConnectionString Name
@@ -959,9 +959,9 @@ type SqlTypeProvider(config: TypeProviderConfig) as this =
 
         DesignTimeCache.cache.GetOrAdd(arguments, fun args ->
             let types = createTypes args
-            
+
             // This is not a perfect cache-invalidation solution, it can remove a valid item from
-            // cache after the time-out, causing one extra hit, but this is only a design-time cache 
+            // cache after the time-out, causing one extra hit, but this is only a design-time cache
             // and it will work well enough to deal with Visual Studio's multi-threading problems
             async {
                 do! Async.Sleep 30000
@@ -971,12 +971,10 @@ type SqlTypeProvider(config: TypeProviderConfig) as this =
             )
         )
 
-    do paramSqlType.AddXmlDoc helpText               
-    
-    // add them to the namespace    
+    do paramSqlType.AddXmlDoc helpText
+
+    // add them to the namespace
     do this.AddNamespace(FSHARP_DATA_SQL, [paramSqlType])
-                            
-[<assembly:TypeProviderAssembly>] 
+
+[<assembly:TypeProviderAssembly>]
 do()
-
-


### PR DESCRIPTION
This is a PR to solve the issue I mention in #575. Somehow my editor is configured to automatically remove trailing spaces so it has done this automatically upon saving the file as well.

Essentially this PR replaces all values of `None` for the basetype value of `ProvidedTypeDefinition` to `Some typeof<obj>`. To me this seems like a hack as there seems to be something fundamentally wrong with type resolution with .NET Core and F#, as there seems to be countless projects with similar issues revolving library resolution, but this is a hack which somewhat fixes it for SQLProviders for the moment.

It would be nice if this could be pulled soonish, as the fsharp language server doesn't seem to like loading SQLProviders from a locally saved project but I think it handles the nugget version reasonably.