### PR TITLE
Fix "timestamp with timezone" mapping into DateTimeOffset

### DIFF
--- a/src/SQLProvider/Providers.Postgresql.fs
+++ b/src/SQLProvider/Providers.Postgresql.fs
@@ -177,7 +177,7 @@ module PostgreSQL =
                                          then namemap "NpgsqlTimeTZ"              ["TimeTZ"]
                                          else typemap<DateTimeOffset>             ["TimeTZ"])
               "timestamp without time zone" , typemap<DateTime>                   ["Timestamp"]
-              "timestamp with time zone"    , typemap<DateTime>                   ["TimestampTZ"]
+              "timestamp with time zone"    , typemap<DateTimeOffset>             ["TimestampTZ"]
               "tsquery"                     , namemap "NpgsqlTsQuery"             ["TsQuery"]
               "tsvector"                    , namemap "NpgsqlTsVector"            ["TsVector"]
             //"txid_snapshot"               , typemap<???>                        ["???"]


### PR DESCRIPTION
Columns of type "timestamp with timezone" should have time DateTimeOffset instead of `DateTime` because otherwise you lose the timezone information