### PR TITLE
Corrects documentation by fixing broken hyperlink to MySQL web page

### DIFF
--- a/docs/content/core/mysql.fsx
+++ b/docs/content/core/mysql.fsx
@@ -18,7 +18,7 @@ open System
 
 Basic connection string used to connect to MySQL instance; typical connection 
 string parameters apply here.  See 
-[MySQL Connector/NET Connection Strings Documentation](https://dev.mysql.com/doc/connector-net/en/connector-net-connection-options.html) 
+[MySQL Connector/NET Connection Strings Documentation](https://dev.mysql.com/doc/connectors/en/connector-net-connections-string.html) 
 for a complete list of connection string options.
 
 *)


### PR DESCRIPTION
There was a broken link on
https://fsprojects.github.io/SQLProvider/core/mysql.html
I fixed it.