### PR TITLE
More key columns support to group-by

### DIFF
--- a/src/SQLProvider/Providers.Firebird.fs
+++ b/src/SQLProvider/Providers.Firebird.fs
@@ -932,7 +932,9 @@ type internal FirebirdProvider(resolutionPath, contextSchemaPath, owner, referen
                     match sqlQuery.Grouping with
                     | [] -> FSharp.Data.Sql.Common.Utilities.parseAggregates fieldNotation Firebird.fieldNotationAlias sqlQuery.AggregateOp
                     | g  -> 
-                        let keys = g |> List.map(fst) |> List.concat |> List.map(fun (a,c) -> fieldNotation a c)
+                        let keys = g |> List.map(fst) |> List.concat |> List.map(fun (a,c) -> 
+                            if sqlQuery.Aliases.Count < 2 then fieldNotation a c
+                            else sprintf "%s as [%s]" (fieldNotation a c) (fieldNotation a c))
                         let aggs = g |> List.map(snd) |> List.concat
                         let res2 = FSharp.Data.Sql.Common.Utilities.parseAggregates fieldNotation Firebird.fieldNotationAlias aggs |> List.toSeq
                         [String.Join(", ", keys) + (if List.isEmpty aggs || List.isEmpty keys then ""  else ", ") + String.Join(", ", res2)] 

--- a/src/SQLProvider/Providers.MSAccess.fs
+++ b/src/SQLProvider/Providers.MSAccess.fs
@@ -533,7 +533,9 @@ type internal MSAccessProvider(contextSchemaPath) =
                     match sqlQuery.Grouping with
                     | [] -> FSharp.Data.Sql.Common.Utilities.parseAggregates fieldNotation fieldNotationAlias sqlQuery.AggregateOp
                     | g  -> 
-                        let keys = g |> List.map(fst) |> List.concat |> List.map(fun (a,c) -> (fieldNotation a c))
+                        let keys = g |> List.map(fst) |> List.concat |> List.map(fun (a,c) ->
+                            if sqlQuery.Aliases.Count < 2 then fieldNotation a c
+                            else sprintf "%s as [%s]" (fieldNotation a c) (fieldNotation a c))
                         let aggs = g |> List.map(snd) |> List.concat
                         let res2 = FSharp.Data.Sql.Common.Utilities.parseAggregates fieldNotation fieldNotationAlias aggs |> List.toSeq
                         [String.Join(", ", keys) + (if List.isEmpty aggs || List.isEmpty keys then ""  else ", ") + String.Join(", ", res2)] 

--- a/src/SQLProvider/Providers.MsSqlServer.fs
+++ b/src/SQLProvider/Providers.MsSqlServer.fs
@@ -894,7 +894,9 @@ type internal MSSqlServerProvider(contextSchemaPath, tableNames:string) =
                     match sqlQuery.Grouping with
                     | [] -> FSharp.Data.Sql.Common.Utilities.parseAggregates fieldNotation fieldNotationAlias sqlQuery.AggregateOp
                     | g  -> 
-                        let keys = g |> List.map(fst) |> List.concat |> List.map(fun (a,c) -> (fieldNotation a c))
+                        let keys = g |> List.map(fst) |> List.concat |> List.map(fun (a,c) ->
+                            if sqlQuery.Aliases.Count < 2 then fieldNotation a c
+                            else sprintf "%s as '%s'" (fieldNotation a c) (fieldNotation a c))
                         let aggs = g |> List.map(snd) |> List.concat
                         let res2 = FSharp.Data.Sql.Common.Utilities.parseAggregates fieldNotation fieldNotationAlias aggs |> List.toSeq
                         [String.Join(", ", keys) + (if List.isEmpty aggs || List.isEmpty keys then ""  else ", ") + String.Join(", ", res2)] 

--- a/src/SQLProvider/Providers.MySql.fs
+++ b/src/SQLProvider/Providers.MySql.fs
@@ -853,7 +853,9 @@ type internal MySqlProvider(resolutionPath, contextSchemaPath, owner:string, ref
                     match sqlQuery.Grouping with
                     | [] -> FSharp.Data.Sql.Common.Utilities.parseAggregates fieldNotation MySql.fieldNotationAlias sqlQuery.AggregateOp
                     | g  -> 
-                        let keys = g |> List.map(fst) |> List.concat |> List.map(fun (a,c) -> fieldNotation a c)
+                        let keys = g |> List.map(fst) |> List.concat |> List.map(fun (a,c) ->
+                            if sqlQuery.Aliases.Count < 2 then fieldNotation a c
+                            else sprintf "%s as '%s'" (fieldNotation a c) (fieldNotation a c))
                         let aggs = g |> List.map(snd) |> List.concat
                         let res2 = FSharp.Data.Sql.Common.Utilities.parseAggregates fieldNotation MySql.fieldNotationAlias aggs |> List.toSeq
                         [String.Join(", ", keys) + (if List.isEmpty aggs || List.isEmpty keys then ""  else ", ") + String.Join(", ", res2)] 

--- a/src/SQLProvider/Providers.Odbc.fs
+++ b/src/SQLProvider/Providers.Odbc.fs
@@ -543,7 +543,9 @@ type internal OdbcProvider(contextSchemaPath, quotechar : OdbcQuoteCharacter) =
                     match sqlQuery.Grouping with
                     | [] -> FSharp.Data.Sql.Common.Utilities.parseAggregates fieldNotation fieldNotationAlias sqlQuery.AggregateOp
                     | g  -> 
-                        let keys = g |> List.map(fst) |> List.concat |> List.map(fun (a,c) -> (fieldNotation a c))
+                        let keys = g |> List.map(fst) |> List.concat |> List.map(fun (a,c) ->
+                            if sqlQuery.Aliases.Count < 2 then fieldNotation a c
+                            else sprintf "%s as '%s'" (fieldNotation a c) (fieldNotation a c))
                         let aggs = g |> List.map(snd) |> List.concat
                         let res2 = FSharp.Data.Sql.Common.Utilities.parseAggregates fieldNotation fieldNotationAlias aggs |> List.toSeq
                         [String.Join(", ", keys) + (if List.isEmpty aggs || List.isEmpty keys then ""  else ", ") + String.Join(", ", res2)] 

--- a/src/SQLProvider/Providers.Oracle.fs
+++ b/src/SQLProvider/Providers.Oracle.fs
@@ -924,7 +924,9 @@ type internal OracleProvider(resolutionPath, contextSchemaPath, owner, reference
                     match sqlQuery.Grouping with
                     | [] -> FSharp.Data.Sql.Common.Utilities.parseAggregates fieldNotation Oracle.fieldNotationAlias sqlQuery.AggregateOp
                     | g  -> 
-                        let keys = g |> List.map(fst) |> List.concat |> List.map(fun (a,c) -> fieldNotation a c)
+                        let keys = g |> List.map(fst) |> List.concat |> List.map(fun (a,c) ->
+                            if sqlQuery.Aliases.Count < 2 then fieldNotation a c
+                            else sprintf "%s as \"%s\"" (fieldNotation a c) (fieldNotation a c))
                         let aggs = g |> List.map(snd) |> List.concat
                         let res2 = FSharp.Data.Sql.Common.Utilities.parseAggregates fieldNotation Oracle.fieldNotationAlias aggs |> List.toSeq
                         [String.Join(", ", keys) + (if List.isEmpty aggs || List.isEmpty keys then ""  else ", ") + String.Join(", ", res2)] 

--- a/src/SQLProvider/Providers.Postgresql.fs
+++ b/src/SQLProvider/Providers.Postgresql.fs
@@ -1068,7 +1068,9 @@ type internal PostgresqlProvider(resolutionPath, contextSchemaPath, owner, refer
                     match sqlQuery.Grouping with
                     | [] -> FSharp.Data.Sql.Common.Utilities.parseAggregates fieldNotation PostgreSQL.fieldNotationAlias sqlQuery.AggregateOp
                     | g  -> 
-                        let keys = g |> List.map(fst) |> List.concat |> List.map(fun (a,c) -> fieldNotation a c)
+                        let keys = g |> List.map(fst) |> List.concat |> List.map(fun (a,c) -> 
+                            if sqlQuery.Aliases.Count < 2 then fieldNotation a c
+                            else sprintf "%s as \"%s\"" (fieldNotation a c) (fieldNotation a c))
                         let aggs = g |> List.map(snd) |> List.concat
                         let res2 = FSharp.Data.Sql.Common.Utilities.parseAggregates fieldNotation PostgreSQL.fieldNotationAlias aggs |> List.toSeq
                         [String.Join(", ", keys) + (if List.isEmpty aggs || List.isEmpty keys then ""  else ", ") + String.Join(", ", res2)] 

--- a/src/SQLProvider/Providers.SQLite.fs
+++ b/src/SQLProvider/Providers.SQLite.fs
@@ -756,7 +756,9 @@ type internal SQLiteProvider(resolutionPath, contextSchemaPath, referencedAssemb
                     match sqlQuery.Grouping with
                     | [] -> FSharp.Data.Sql.Common.Utilities.parseAggregates fieldNotation fieldNotationAlias sqlQuery.AggregateOp
                     | g  ->
-                        let keys = g |> List.map(fst) |> List.concat |> List.map(fun (a,c) -> (fieldNotation a c))
+                        let keys = g |> List.map(fst) |> List.concat |> List.map(fun (a,c) ->
+                            if sqlQuery.Aliases.Count < 2 then fieldNotation a c
+                            else sprintf "%s as '%s'" (fieldNotation a c) (fieldNotation a c))
                         let aggs = g |> List.map(snd) |> List.concat
                         let res2 = FSharp.Data.Sql.Common.Utilities.parseAggregates fieldNotation fieldNotationAlias aggs |> List.toSeq
                         [String.Join(", ", keys) + (if List.isEmpty aggs || List.isEmpty keys then ""  else ", ") + String.Join(", ", res2)]

--- a/src/SQLProvider/SqlRuntime.Linq.fs
+++ b/src/SQLProvider/SqlRuntime.Linq.fs
@@ -15,11 +15,19 @@ open FSharp.Data.Sql.Schema
 type IWithDataContext =
     abstract DataContext : ISqlDataContext
 
-type CastTupleMaker<'T1,'T2,'T3> = 
+type CastTupleMaker<'T1,'T2,'T3,'T4,'T5,'T6,'T7> = 
     static member makeTuple2(t1:obj, t2:obj) = 
         (t1 :?> 'T1, t2 :?> 'T2) |> box
     static member makeTuple3(t1:obj, t2:obj, t3:obj) = 
         (t1 :?> 'T1, t2 :?> 'T2, t3 :?> 'T3) |> box
+    static member makeTuple4(t1:obj, t2:obj, t3:obj, t4:obj) = 
+        (t1 :?> 'T1, t2 :?> 'T2, t3 :?> 'T3, t4 :?> 'T4) |> box
+    static member makeTuple5(t1:obj, t2:obj, t3:obj, t4:obj, t5:obj) = 
+        (t1 :?> 'T1, t2 :?> 'T2, t3 :?> 'T3, t4 :?> 'T4, t5 :?> 'T5) |> box
+    static member makeTuple6(t1:obj, t2:obj, t3:obj, t4:obj, t5:obj, t6:obj) = 
+        (t1 :?> 'T1, t2 :?> 'T2, t3 :?> 'T3, t4 :?> 'T4, t5 :?> 'T5, t6 :?> 'T6) |> box
+    static member makeTuple7(t1:obj, t2:obj, t3:obj, t4:obj, t5:obj, t6:obj, t7:obj) = 
+        (t1 :?> 'T1, t2 :?> 'T2, t3 :?> 'T3, t4 :?> 'T4, t5 :?> 'T5, t6 :?> 'T6, t7 :?> 'T7) |> box
 
 module internal QueryImplementation =
     open System.Linq
@@ -80,16 +88,17 @@ module internal QueryImplementation =
                         Utilities.convertTypes key keyType.Value.GenericTypeArguments.[idx]
                     else key
                 
-                let tup2, tup3 = 
+                let tup2, tup3, tup4, tup5, tup6, tup7 = 
                     let genArg idx = 
                         if keyType.IsSome && keyType.Value.GenericTypeArguments.Length > idx then
                             keyType.Value.GenericTypeArguments.[idx]
                         else typeof<Object>
                     let tup =
-                        typedefof<CastTupleMaker<_,_,_>>.MakeGenericType(
-                            genArg 0, genArg 1, genArg 2
+                        typedefof<CastTupleMaker<_,_,_,_,_,_,_>>.MakeGenericType(
+                            genArg 0, genArg 1, genArg 2, genArg 3, genArg 4, genArg 5, genArg 6
                         )
-                    tup.GetMethod("makeTuple2"), tup.GetMethod("makeTuple3")
+                    tup.GetMethod("makeTuple2"), tup.GetMethod("makeTuple3"), tup.GetMethod("makeTuple4"),
+                    tup.GetMethod("makeTuple5"), tup.GetMethod("makeTuple6"), tup.GetMethod("makeTuple7")
 
                 // do group-read
                 let collected = 
@@ -130,10 +139,22 @@ module internal QueryImplementation =
                                 ty.GetConstructors().[1].Invoke [|keyname; keyvalue; entity;|]
                         | [|kn1, kv1; kn2, kv2|] when keyType.IsSome ->
                             let v1, v2 = getval kv1 0, getval kv2 1
-                            keyConstructor.Value.[0].Invoke [|(kn1,kn2); tup2.Invoke(null, [|v1;v2|]); entity;|]
-                        | [|kn1, kv1; kn2, kv2; kn3; kv3|] when keyType.IsSome ->
+                            keyConstructor.Value.[2].Invoke [|(kn1,kn2); tup2.Invoke(null, [|v1;v2|]); entity;|]
+                        | [|kn1, kv1; kn2, kv2; kn3, kv3|] when keyType.IsSome ->
                             let v1, v2, v3 = getval kv1 0, getval kv2 1, getval kv3 2
-                            keyConstructor.Value.[0].Invoke [|(kn1,kn2); tup3.Invoke(null, [|v1;v2;v3|]); entity;|]
+                            keyConstructor.Value.[3].Invoke [|(kn1,kn2,kn3); tup3.Invoke(null, [|v1;v2;v3|]); entity;|]
+                        | [|kn1, kv1; kn2, kv2; kn3, kv3; kn4, kv4|] when keyType.IsSome ->
+                            let v1, v2, v3, v4 = getval kv1 0, getval kv2 1, getval kv3 2, getval kv4 3
+                            keyConstructor.Value.[4].Invoke [|(kn1,kn2,kn3,kn4); tup4.Invoke(null, [|v1;v2;v3;v4|]); entity;|]
+                        | [|kn1, kv1; kn2, kv2; kn3, kv3; kn4, kv4; kn5, kv5|] when keyType.IsSome ->
+                            let v1, v2, v3, v4, v5 = getval kv1 0, getval kv2 1, getval kv3 2, getval kv4 3, getval kv5 4
+                            keyConstructor.Value.[5].Invoke [|(kn1,kn2,kn3,kn4,kn5); tup5.Invoke(null, [|v1;v2;v3;v4;v5|]); entity;|]
+                        | [|kn1, kv1; kn2, kv2; kn3, kv3; kn4, kv4; kn5, kv5; kn6, kv6|] when keyType.IsSome ->
+                            let v1, v2, v3, v4, v5, v6 = getval kv1 0, getval kv2 1, getval kv3 2, getval kv4 3, getval kv5 4, getval kv6 5
+                            keyConstructor.Value.[6].Invoke [|(kn1,kn2,kn3,kn4,kn5,kn6); tup6.Invoke(null, [|v1;v2;v3;v4;v5;v6|]); entity;|]
+                        | [|kn1, kv1; kn2, kv2; kn3, kv3; kn4, kv4; kn5, kv5; kn6, kv6; kn7, kv7|] when keyType.IsSome ->
+                            let v1, v2, v3, v4, v5, v6, v7 = getval kv1 0, getval kv2 1, getval kv3 2, getval kv4 3, getval kv5 4, getval kv6 5, getval kv7 6
+                            keyConstructor.Value.[0].Invoke [|(kn1,kn2,kn3,kn4,kn5,kn6,kn7); tup7.Invoke(null, [|v1;v2;v3;v4;v5;v6;v7|]); entity;|]
                         | lst -> failwith("Complex key columns not supported yet (" + String.Join(",", lst) + ")")
                     )// :?> IGrouping<_, _>)
 

--- a/tests/SqlProvider.Tests/QueryTests.fs
+++ b/tests/SqlProvider.Tests/QueryTests.fs
@@ -1169,10 +1169,26 @@ let ``simple select query with join and then groupBy``() =
                 where(cust.Address <> "Road" && order.ShipName <> "mcboatface")
                 groupBy (cust.City, order.ShipCity) into g
                 select (g.Key, g.Max(fun (c,o) -> c.PostalCode))
-            }
+            } 
     let res = qry |> dict  
     Assert.IsNotEmpty(res)
     Assert.AreEqual("WX3 6FW", res.["London","London"])
+
+[<Test>]
+let ``simple select query with join and then groupBy 2``() = 
+    let dc = sql.GetDataContext()
+    let qry = 
+        query {
+                for cust in dc.Main.Customers do
+                join order in dc.Main.Orders on (cust.CustomerId = order.CustomerId)
+                join order2 in dc.Main.Orders on (order.OrderId = order2.OrderId)
+                where(order2.ShipCity = "London")
+                groupBy (order.ShipName, order.ShipCity, order2.ShipCity, order.ShipCountry, order2.ShippedDate) into g
+                select (g.Key, g.Max(fun (c,o1,o2) -> c.PostalCode))
+            }
+    let res = qry |> Seq.toList  
+    Assert.IsNotEmpty(res)
+    Assert.AreEqual(32, res.Length)
 
 [<Test>]
 let ``simple select query with joins and then groupBy``() = 


### PR DESCRIPTION
The current group-by supported only 2 key columns.
However, in SQL, you often have to group over multiple columns, just to be able to include some data columns from other tables with the group-operation. So this PR raises the supported columns up to 7.
