### PR TITLE
Change issuestats to shields badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Issue Stats](http://issuestats.com/github/fsprojects/SQLProvider/badge/issue)](http://issuestats.com/github/fsprojects/SQLProvider)
-[![Issue Stats](http://issuestats.com/github/fsprojects/SQLProvider/badge/pr)](http://issuestats.com/github/fsprojects/SQLProvider)
+[![Issue Status](https://img.shields.io/github/issues/fsprojects/SQLProvider.svg?style=flat)](https://github.com/fsprojects/SQLProvider/issues)
+[![PR Status](https://img.shields.io/github/issues-pr/fsprojects/SQLProvider.svg?style=flat)](https://github.com/fsprojects/SQLProvider/pulls)
 
 # SQLProvider [![NuGet Status](http://img.shields.io/nuget/v/SQLProvider.svg?style=flat)](https://www.nuget.org/packages/SQLProvider/)
 


### PR DESCRIPTION
## Proposed Changes

Badges were broken in README.md. The issuestats.com used previously did not work properly because the domain was sold, and the badge was changed to Shields to work properly.