### PR TITLE
Fixes error for netstandard where it tries to load SqlClient 4.6.1.0

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -255,7 +255,7 @@ Target "CopyFiles" (fun _ ->
     //     copyDotnetLibraries dotnetSdk212
     copyDotnetLibraries "packages/standard/NETStandard.Library/build/netstandard2.0/ref/"
 
-    CopyFile "bin/netstandard2.0" "packages/System.Data.SqlClient/lib/net461/System.Data.SqlClient.dll" 
+    CopyFile "bin/netstandard2.0" "packages/standard/System.Data.SqlClient/lib/netstandard2.0/System.Data.SqlClient.dll" 
 
 #endif
 


### PR DESCRIPTION
## Proposed Changes

In reference to issue #645 where a .NET Core project fails with an error message about not being able to load System.Data.SqlClient Version=4.6.1.0 - and also my similar issue where the SSDT Provider gives the same error from VS Code (but not in VS 2019): this change to the build script fixes the issue for me in VS Code.


## Types of changes

What types of changes does your code introduce to SQLProvider?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Build and tests pass locally
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Further comments

This just copies the netstandard2.0 version of System.Data.SqlClient instead of net461 to the bin/netstandard2.0 output folder.