### PR TITLE
Fix UseOptionTypes documentation

### DIFF
--- a/docs/content/core/mssql.fsx
+++ b/docs/content/core/mssql.fsx
@@ -62,8 +62,8 @@ let [<Literal>] indivAmount = 1000
 ### UseOptionTypes
 
 If true, F# option types will be used in place of nullable database columns.
-If false, you will always receive the default value of the column's type, even
-if it is null in the database.
+If false, you will receive the default value of the column's type
+if the value is null in the database. The default is true.
 
 *)
 


### PR DESCRIPTION
## Proposed Changes

Documentation fix. Correct that a default value isn't always returned if UseOptionTypes is false. Also indicate default.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [ ] Build and tests pass locally
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added necessary documentation (if appropriate)
