### PR TITLE
Azure Functions .dacpac Resolution Fix

### DIFF
--- a/src/SQLProvider.Runtime/Providers.MsSqlServer.Ssdt.fs
+++ b/src/SQLProvider.Runtime/Providers.MsSqlServer.Ssdt.fs
@@ -5,6 +5,9 @@ open System
 open System.Collections.Concurrent
 open System.Data
 open System.Data.SqlClient
+open System.IO
+open System.Reflection
+open System.Text
 open FSharp.Data.Sql
 open FSharp.Data.Sql.Transactions
 open FSharp.Data.Sql.Schema
@@ -13,22 +16,60 @@ open FSharp.Data.Sql.Ssdt.DacpacParser
 
 module MSSqlServerSsdt =
 
+
     /// Tries to find .dacpac file using the given path at design time or by searching the runtime assembly path.
     let findDacPacFile (dacPacPath: string) =
         // Find at design time using SsdtPath
         let ssdtFile = IO.FileInfo(dacPacPath)
-        if ssdtFile.Exists then ssdtFile.FullName
-        else
-            // Try to find it in the Entry Assembly folder
-            match Reflection.Assembly.GetEntryAssembly() |> Option.ofObj with
-            | Some entryAssembly ->
-                let entryDll = IO.FileInfo(entryAssembly.Location)
-                let newFile = IO.FileInfo(IO.Path.Combine(entryDll.Directory.FullName, ssdtFile.Name))
-                if newFile.Exists then newFile.FullName
-                else failwithf "Unable to find .dacpac file at the following locations: \n- Configured SsdtPath: '%s'\n- Entry Assembly Path: '%s'" ssdtFile.FullName newFile.FullName
-            | None ->
-                failwithf "Unable to find .dacpac at '%s'." ssdtFile.FullName
-            
+        let dacPacFileName = ssdtFile.Name
+        let origPath = ssdtFile.Directory.FullName
+
+        let asmToPath (asm:Assembly) =
+            match asm with
+            | null -> None
+            | a ->
+                let dllPath = IO.FileInfo(a.Location)
+                let dllDir = dllPath.Directory.FullName
+                Some dllDir
+
+        /// generate many combinations to try.
+        let paths = [
+            yield origPath
+            // working dir
+            yield Environment.CurrentDirectory
+            yield Path.Combine(Environment.CurrentDirectory, origPath)
+            // entry asm dir
+            match asmToPath (Assembly.GetEntryAssembly()) with
+            | Some p ->
+                yield p
+                yield Path.Combine(p, origPath)
+            | _ -> ()
+            // executing assembly dir
+            match asmToPath (Assembly.GetExecutingAssembly()) with
+            | Some p ->
+                yield p
+                yield Path.Combine(p, origPath)
+            | _ -> ()
+        ]
+
+        let allPossiblePaths =
+            paths
+            |> List.map (fun p -> Path.Combine(p, dacPacFileName) |> IO.FileInfo)
+
+        let bestOption = allPossiblePaths |> List.tryFind (fun fi -> fi.Exists)
+
+        match bestOption with
+        | Some b -> b.FullName
+        | None ->
+            let sb = new StringBuilder()
+            sb.AppendLine("Unable to find .dacpac file. Search path includes executing assembly, configured ssd path, and entry assembly.") |> ignore
+            sb.AppendLine("Looked in:") |> ignore
+            for s in allPossiblePaths do
+                sb.Append("\t") |> ignore
+                sb.AppendLine(s.FullName) |> ignore
+            failwith (sb.ToString())
+
+
 
     /// Tries to parse a schema model from the given .dacpac file path.
     let parseDacpac = findDacPacFile >> extractModelXml >> parseXml
@@ -78,18 +119,18 @@ module MSSqlServerSsdt =
               TypeMapping.ProviderType = providerType }
         )
         |> Map.ofList
-    
+
     let tryFindMapping (dataType: string) =
         typeMappingsByName.TryFind (dataType.ToUpper())
-    
+
     let tryFindMappingOrVariant (dataType: string) =
         match typeMappingsByName.TryFind (dataType.ToUpper()) with
         | Some tm -> tm
         | None -> (typeMappingsByName.TryFind "SQL_VARIANT").Value
-            
+
     let ssdtTableToTable (tbl: SsdtTable) =
         { Schema = tbl.Schema ; Name = tbl.Name ; Type =  if tbl.IsView then "view" else "base table" }
-    
+
     let ssdtColumnToColumn (tbl: SsdtTable) (col: SsdtColumn) =
         match tryFindMapping col.DataType with
         | Some typeMapping ->
@@ -107,7 +148,7 @@ module MSSqlServerSsdt =
                   Column.TypeInfo = if col.DataType = "" then None else Some col.DataType }
         | None ->
             None
-    
+
 
 type internal MSSqlServerProviderSsdt(tableNames: string, ssdtPath: string) =
     let schemaCache = SchemaCache.Empty
@@ -143,7 +184,7 @@ type internal MSSqlServerProviderSsdt(tableNames: string, ssdtPath: string) =
     interface ISqlProvider with
         member __.GetLockObject() = myLock
         member __.GetTableDescription(con,tableName) =
-            tableName + 
+            tableName +
             (ssdtSchema.Value.Descriptions
              |> List.filter(fun d -> (d.DecriptionType = "SqlTableBase" || d.DecriptionType = "SqlView") && d.ColumnName.IsNone)
              |> List.tryFind(fun d -> if tableName.Contains "." then d.Schema + "." + d.TableName = tableName else d.TableName = tableName)
@@ -170,7 +211,7 @@ type internal MSSqlServerProviderSsdt(tableNames: string, ssdtPath: string) =
              |> List.filter(fun d -> d.DecriptionType = "SqlColumn" && d.ColumnName.IsSome && d.ColumnName.Value = columnName)
              |> List.tryFind(fun d ->
                     if tableName.Contains "." then d.Schema + "." + d.TableName = tableName else d.TableName = tableName)
-             |> Option.map(fun d -> 
+             |> Option.map(fun d ->
                     if String.IsNullOrEmpty d.Description then ""
                     elif d.Description.StartsWith("N'") then
                         " / " + d.Description.Substring(0, d.Description.Length-1).Replace("N'", "")
@@ -192,7 +233,7 @@ type internal MSSqlServerProviderSsdt(tableNames: string, ssdtPath: string) =
             | _ -> ()
             p :> IDbDataParameter
         member __.ExecuteSprocCommand(com, inputParameters, returnCols, values:obj array) =
-                let returnCols2 = 
+                let returnCols2 =
                     try getSprocReturnParams com.Connection com.CommandText (inputParameters |> Seq.toList)
                     with _ -> returnCols
 
@@ -200,7 +241,7 @@ type internal MSSqlServerProviderSsdt(tableNames: string, ssdtPath: string) =
                 MSSqlServer.executeSprocCommand com inputParameters returnCols2 values
         member __.ExecuteSprocCommandAsync(com, inputParameters, returnCols, values:obj array) =
             async {
-                let returnCols2 = 
+                let returnCols2 =
                     try getSprocReturnParams com.Connection com.CommandText (inputParameters |> Seq.toList)
                     with _ -> returnCols
                 if com.Connection.State <> ConnectionState.Open then
@@ -210,7 +251,7 @@ type internal MSSqlServerProviderSsdt(tableNames: string, ssdtPath: string) =
             }
         member __.CreateTypeMappings(con) = ()
         member __.GetSchemaCache() = schemaCache
-        
+
         member __.GetTables(con,_) =
             let allowed = tableNames.Split([|','|], StringSplitOptions.RemoveEmptyEntries) |> Array.map (fun s -> s.Trim())
 
@@ -245,9 +286,9 @@ type internal MSSqlServerProviderSsdt(tableNames: string, ssdtPath: string) =
             |> Seq.map (fun kvp -> kvp.Value)
             |> Seq.iter (fun col ->
                 if col.IsPrimaryKey then
-                    schemaCache.PrimaryKeys.AddOrUpdate(table.FullName, [col.Name], fun key old -> 
-                         match col.Name with 
-                         | "" -> old 
+                    schemaCache.PrimaryKeys.AddOrUpdate(table.FullName, [col.Name], fun key old ->
+                         match col.Name with
+                         | "" -> old
                          | x -> match old with
                                 | [] -> [x]
                                 | os -> x::os |> Seq.distinct |> Seq.toList |> List.sort
@@ -340,15 +381,15 @@ type internal MSSqlServerProviderSsdt(tableNames: string, ssdtPath: string) =
                 let paramName = nextParam()
                 parameters.Add(MSSqlServer.createOpenParameter(paramName,value):> IDbDataParameter)
                 paramName
-                        
-            let mssqlPaging =               
+
+            let mssqlPaging =
               match mssqlVersionCache.TryGetValue(con.ConnectionString) with
               // SQL 2008 and earlier do not support OFFSET
               | true, mssqlVersion when mssqlVersion.Value.Major < 11 -> MSSQLPagingCompatibility.RowNumber
               | _ -> MSSQLPagingCompatibility.Offset
 
-            let rec fieldNotation (al:alias) (c:SqlColumnType) = 
-                let buildf (c:Condition)= 
+            let rec fieldNotation (al:alias) (c:SqlColumnType) =
+                let buildf (c:Condition)=
                     let sb = System.Text.StringBuilder()
                     let (~~) (t:string) = sb.Append t |> ignore
                     filterBuilder (~~) [c]
@@ -356,8 +397,8 @@ type internal MSSqlServerProviderSsdt(tableNames: string, ssdtPath: string) =
                 let x = fieldNotation
                 let colSprint =
                     match String.IsNullOrEmpty(al) with
-                    | true -> sprintf "[%s]" 
-                    | false -> sprintf "[%s].[%s]" al 
+                    | true -> sprintf "[%s]"
+                    | false -> sprintf "[%s].[%s]" al
                 match c with
                 // Custom database spesific overrides for canonical functions:
                 | SqlColumnType.CanonicalOperation(cf,col) ->
@@ -480,15 +521,15 @@ type internal MSSqlServerProviderSsdt(tableNames: string, ssdtPath: string) =
                                         match operator with
                                         | FSharp.Data.Sql.IsNull -> sprintf "%s IS NULL" column
                                         | FSharp.Data.Sql.NotNull -> sprintf "%s IS NOT NULL" column
-                                        | FSharp.Data.Sql.In 
+                                        | FSharp.Data.Sql.In
                                         | FSharp.Data.Sql.NotIn -> operatorIn operator paras
-                                        | FSharp.Data.Sql.NestedExists 
-                                        | FSharp.Data.Sql.NestedNotExists 
-                                        | FSharp.Data.Sql.NestedIn 
+                                        | FSharp.Data.Sql.NestedExists
+                                        | FSharp.Data.Sql.NestedNotExists
+                                        | FSharp.Data.Sql.NestedIn
                                         | FSharp.Data.Sql.NestedNotIn -> operatorInQuery operator paras
                                         | _ ->
                                             let aliasformat = sprintf "%s %s %s" column
-                                            match data with 
+                                            match data with
                                             | Some d when (box d :? alias * SqlColumnType) ->
                                                 let alias2, col2 = box d :?> (alias * SqlColumnType)
                                                 let alias2f = fieldNotation alias2 col2
@@ -569,7 +610,7 @@ type internal MSSqlServerProviderSsdt(tableNames: string, ssdtPath: string) =
                 let extracolumns =
                     match sqlQuery.Grouping with
                     | [] -> FSharp.Data.Sql.Common.Utilities.parseAggregates fieldNotation MSSqlServer.fieldNotationAlias sqlQuery.AggregateOp
-                    | g  -> 
+                    | g  ->
                         let keys = g |> List.map(fst) |> List.concat |> List.map(fun (a,c) ->
                             let fn = fieldNotation a c
                             if not (tmpGrpParams.ContainsKey (a,c)) then
@@ -578,7 +619,7 @@ type internal MSSqlServerProviderSsdt(tableNames: string, ssdtPath: string) =
                             else sprintf "%s as '%s'" fn fn)
                         let aggs = g |> List.map(snd) |> List.concat
                         let res2 = FSharp.Data.Sql.Common.Utilities.parseAggregates fieldNotation MSSqlServer.fieldNotationAlias aggs |> List.toSeq
-                        [String.Join(", ", keys) + (if List.isEmpty aggs || List.isEmpty keys then ""  else ", ") + String.Join(", ", res2)] 
+                        [String.Join(", ", keys) + (if List.isEmpty aggs || List.isEmpty keys then ""  else ", ") + String.Join(", ", res2)]
                 match extracolumns with
                 | [] -> selectcolumns
                 | h::t -> h
@@ -614,7 +655,7 @@ type internal MSSqlServerProviderSsdt(tableNames: string, ssdtPath: string) =
 
             if isDeleteScript then
                 ~~(sprintf "DELETE FROM [%s].[%s] " baseTable.Schema baseTable.Name)
-            else 
+            else
                 // SELECT
                 if sqlQuery.Distinct && sqlQuery.Count then ~~(sprintf "SELECT COUNT(DISTINCT %s) " (columns.Substring(0, columns.IndexOf(" as "))))
                 elif sqlQuery.Distinct then ~~(sprintf "SELECT DISTINCT %s%s " (if sqlQuery.Take.IsSome then sprintf "TOP %i " sqlQuery.Take.Value else "")   columns)
@@ -625,7 +666,7 @@ type internal MSSqlServerProviderSsdt(tableNames: string, ssdtPath: string) =
                     | _ -> ~~(sprintf "SELECT %s " columns)
                 //ROW_NUMBER
                 match mssqlPaging,sqlQuery.Skip, sqlQuery.Take with
-                | MSSQLPagingCompatibility.RowNumber, Some _, _ -> 
+                | MSSQLPagingCompatibility.RowNumber, Some _, _ ->
                     //INCLUDE order by clause in ROW_NUMBER () OVER() of CTE
                     if sqlQuery.Ordering.Length > 0 then
                         ~~", ROW_NUMBER() OVER(ORDER BY  "
@@ -667,7 +708,7 @@ type internal MSSqlServerProviderSsdt(tableNames: string, ssdtPath: string) =
               if sqlQuery.Ordering.Length > 0 then
                   ~~"ORDER BY "
                   orderByBuilder()
-            | _ -> 
+            | _ ->
               //when RowNumber compatibility with SKIP, ommit order by clause as it's already in CTE
               ()
 
@@ -675,18 +716,18 @@ type internal MSSqlServerProviderSsdt(tableNames: string, ssdtPath: string) =
             | Some(UnionType.UnionAll, suquery, pars) ->
                 parameters.AddRange pars
                 ~~(sprintf " UNION ALL %s " suquery)
-            | Some(UnionType.NormalUnion, suquery, pars) -> 
+            | Some(UnionType.NormalUnion, suquery, pars) ->
                 parameters.AddRange pars
                 ~~(sprintf " UNION %s " suquery)
-            | Some(UnionType.Intersect, suquery, pars) -> 
+            | Some(UnionType.Intersect, suquery, pars) ->
                 parameters.AddRange pars
                 ~~(sprintf " INTERSECT %s " suquery)
-            | Some(UnionType.Except, suquery, pars) -> 
+            | Some(UnionType.Except, suquery, pars) ->
                 parameters.AddRange pars
                 ~~(sprintf " EXCEPT %s " suquery)
             | None -> ()
-        
-            let sql = 
+
+            let sql =
                 match mssqlPaging with
                 | MSSQLPagingCompatibility.RowNumber ->
                     let outerSb = System.Text.StringBuilder()
@@ -702,7 +743,7 @@ type internal MSSqlServerProviderSsdt(tableNames: string, ssdtPath: string) =
                         outerSb.Append ")" |> ignore
                         outerSb.Append (sprintf "SELECT %s FROM CTE [%s] WHERE RN > %i " columns (if baseAlias = "" then baseTable.Name else baseAlias) skip)  |> ignore
                         outerSb.ToString()
-                    | _ -> 
+                    | _ ->
                       sb.ToString()
                 | _ ->
                     match sqlQuery.Skip, sqlQuery.Take with
@@ -724,7 +765,7 @@ type internal MSSqlServerProviderSsdt(tableNames: string, ssdtPath: string) =
 
             CommonTasks.``ensure columns have been loaded`` (this :> ISqlProvider) con entities
 
-            if entities.Count = 0 then 
+            if entities.Count = 0 then
                 ()
             else
             use scope = TransactionUtils.ensureTransaction transactionOptions
@@ -774,7 +815,7 @@ type internal MSSqlServerProviderSsdt(tableNames: string, ssdtPath: string) =
 
             CommonTasks.``ensure columns have been loaded`` (this :> ISqlProvider) con entities
 
-            if entities.Count = 0 then 
+            if entities.Count = 0 then
                 async { () }
             else
 


### PR DESCRIPTION
## Proposed Changes

This simply searches a much wider set of locations to try and find a .dacpac. Doing some path magic (and it's best effort) to try and ensure that the path is resolved in wider circumstances.

Specifically, this solves the case where EntryAssembly points to a totally different location, such as when running under the Azure Functions harness.

## Types of changes

What types of changes does your code introduce to SQLProvider?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Build and tests pass locally
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
