### PR TITLE
Fix: Read .dacpac file from SSDT on Read-only File System (Azure Functions)

### DIFF
--- a/src/SQLProvider.Runtime/Ssdt.DacpacParser.fs
+++ b/src/SQLProvider.Runtime/Ssdt.DacpacParser.fs
@@ -124,7 +124,7 @@ module RegexParsers =
     
 /// Extracts model.xml from the given .dacpac file path.
 let extractModelXml (dacPacPath: string) = 
-    use stream = new IO.FileStream(dacPacPath, IO.FileMode.Open)
+    use stream = new IO.FileStream(dacPacPath, IO.FileMode.Open, IO.FileAccess.Read)
     use zip = new ZipArchive(stream, ZipArchiveMode.Read, false)
     let modelEntry = zip.GetEntry("model.xml")
     use modelStream = modelEntry.Open()


### PR DESCRIPTION
## Proposed Changes

Closes https://github.com/fsprojects/SQLProvider/issues/743

This change allows a .dacpac file to be loaded from a read-only FS like Azure Functions. Previously, it was opening in read/write mode. Now it's only using read.

## Types of changes

What types of changes does your code introduce to SQLProvider?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Build and tests pass locally
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added necessary documentation (if appropriate)

## Further comments

Thanks for the great maintainership of this project. Enormously appreciated to get stuff merged so fast, as this was a real blocker for us!
