### PR TITLE
ValueOption support

### DIFF
--- a/docs/content/core/async.fsx
+++ b/docs/content/core/async.fsx
@@ -17,7 +17,7 @@ type TypeProviderConnection =
         ConnectionString = "Server=localhost;Database=test;User=test;Password=test",
         DatabaseVendor = Common.DatabaseProviderTypes.MSSQLSERVER,
         IndividualsAmount=1000,
-        UseOptionTypes=FSharp.Data.Sql.Common.OPTION, 
+        UseOptionTypes=FSharp.Data.Sql.Common.NullableColumnType.OPTION, 
         CaseSensitivityChange = Common.CaseSensitivityChange.ORIGINAL>
 
 (**

--- a/docs/content/core/async.fsx
+++ b/docs/content/core/async.fsx
@@ -17,7 +17,7 @@ type TypeProviderConnection =
         ConnectionString = "Server=localhost;Database=test;User=test;Password=test",
         DatabaseVendor = Common.DatabaseProviderTypes.MSSQLSERVER,
         IndividualsAmount=1000,
-        UseOptionTypes=true, 
+        UseOptionTypes=FSharp.Data.Sql.Common.OPTION, 
         CaseSensitivityChange = Common.CaseSensitivityChange.ORIGINAL>
 
 (**

--- a/docs/content/core/mssql.fsx
+++ b/docs/content/core/mssql.fsx
@@ -63,11 +63,11 @@ let [<Literal>] indivAmount = 1000
 
 If true, F# option types will be used in place of nullable database columns.
 If false, you will receive the default value of the column's type
-if the value is null in the database. The default is true.
+if the value is null in the database. The default is FSharp.Data.Sql.Common.NO_OPTION.
 
 *)
 
-let [<Literal>] useOptTypes  = true
+let [<Literal>] useOptTypes  = FSharp.Data.Sql.Common.OPTION
 
 type sql =
     SqlDataProvider<

--- a/docs/content/core/mssql.fsx
+++ b/docs/content/core/mssql.fsx
@@ -63,11 +63,11 @@ let [<Literal>] indivAmount = 1000
 
 If true, F# option types will be used in place of nullable database columns.
 If false, you will receive the default value of the column's type
-if the value is null in the database. The default is FSharp.Data.Sql.Common.NO_OPTION.
+if the value is null in the database. The default is FSharp.Data.Sql.Common.NullableColumnType.NO_OPTION.
 
 *)
 
-let [<Literal>] useOptTypes  = FSharp.Data.Sql.Common.OPTION
+let [<Literal>] useOptTypes  = FSharp.Data.Sql.Common.NullableColumnType.OPTION
 
 type sql =
     SqlDataProvider<

--- a/docs/content/core/mssqlssdt.fsx
+++ b/docs/content/core/mssqlssdt.fsx
@@ -62,7 +62,7 @@ It is helpful to keep the above Design Time Command commented out just below you
 
 ### UseOptionTypes
 
-If true, F# option types will be used in place of nullable database columns. If false, you will always receive the default value of the column's type even if it is null in the database.
+If FSharp.Data.Sql.Common.OPTION, F# option types will be used in place of nullable database columns. If NO_OPTION, you will always receive the default value of the column's type even if it is null in the database.
 
 ### Table Names Filter
 

--- a/docs/content/core/mssqlssdt.fsx
+++ b/docs/content/core/mssqlssdt.fsx
@@ -62,7 +62,7 @@ It is helpful to keep the above Design Time Command commented out just below you
 
 ### UseOptionTypes
 
-If FSharp.Data.Sql.Common.OPTION, F# option types will be used in place of nullable database columns. If NO_OPTION, you will always receive the default value of the column's type even if it is null in the database.
+If FSharp.Data.Sql.Common.NullableColumnType.OPTION, F# option types will be used in place of nullable database columns. If NO_OPTION, you will always receive the default value of the column's type even if it is null in the database.
 
 ### Table Names Filter
 

--- a/docs/content/core/mysql.fsx
+++ b/docs/content/core/mysql.fsx
@@ -75,7 +75,7 @@ If true, F# option types will be used in place of nullable database columns.  If
 
 *)
 [<Literal>]
-let useOptTypes = true
+let useOptTypes = FSharp.Data.Sql.Common.OPTION
 
 (**
 ### Example

--- a/docs/content/core/mysql.fsx
+++ b/docs/content/core/mysql.fsx
@@ -75,7 +75,7 @@ If true, F# option types will be used in place of nullable database columns.  If
 
 *)
 [<Literal>]
-let useOptTypes = FSharp.Data.Sql.Common.OPTION
+let useOptTypes = FSharp.Data.Sql.Common.NullableColumnType.OPTION
 
 (**
 ### Example

--- a/docs/content/core/parameters.fsx
+++ b/docs/content/core/parameters.fsx
@@ -121,12 +121,15 @@ let indivAmt = 500
 (**
 ### UseOptionTypes
 
-If set to FSharp.Data.Sql.Common.OPTION, all nullable fields will be represented by F# option types.  If NO_OPTION, nullable
+If set to FSharp.Data.Sql.Common.NullableColumnType.OPTION, all nullable fields will be represented by F# option types.  If NO_OPTION, nullable
 fields will be represented by the default value of the column type - this is important because
 the provider will return 0 instead of null, which might cause problems in some scenarios.
+
+The third option is VALUE_OPTION where nullable fields are represented by ValueOption struct.
+
 *)
 [<Literal>]
-let useOptionTypes = FSharp.Data.Sql.Common.OPTION
+let useOptionTypes = FSharp.Data.Sql.Common.NullableColumnType.OPTION
 
 (**
 ### ContextSchemaPath

--- a/docs/content/core/parameters.fsx
+++ b/docs/content/core/parameters.fsx
@@ -121,12 +121,12 @@ let indivAmt = 500
 (**
 ### UseOptionTypes
 
-If set to true, all nullable fields will be represented by F# option types.  If false, nullable
+If set to FSharp.Data.Sql.Common.OPTION, all nullable fields will be represented by F# option types.  If NO_OPTION, nullable
 fields will be represented by the default value of the column type - this is important because
 the provider will return 0 instead of null, which might cause problems in some scenarios.
 *)
 [<Literal>]
-let useOptionTypes = true
+let useOptionTypes = FSharp.Data.Sql.Common.OPTION
 
 (**
 ### ContextSchemaPath

--- a/docs/content/index.fsx
+++ b/docs/content/index.fsx
@@ -79,7 +79,7 @@ type sql = SqlDataProvider<
               DatabaseVendor = Common.DatabaseProviderTypes.SQLITE,
               ResolutionPath = resolutionPath,
               IndividualsAmount = 1000,
-              UseOptionTypes = true >
+              UseOptionTypes = FSharp.Data.Sql.Common.OPTION >
 let ctx = sql.GetDataContext()
 
 // To use dynamic runtime connectionString, you could use:

--- a/docs/content/index.fsx
+++ b/docs/content/index.fsx
@@ -79,7 +79,7 @@ type sql = SqlDataProvider<
               DatabaseVendor = Common.DatabaseProviderTypes.SQLITE,
               ResolutionPath = resolutionPath,
               IndividualsAmount = 1000,
-              UseOptionTypes = FSharp.Data.Sql.Common.OPTION >
+              UseOptionTypes = FSharp.Data.Sql.Common.NullableColumnType.OPTION >
 let ctx = sql.GetDataContext()
 
 // To use dynamic runtime connectionString, you could use:

--- a/src/SQLProvider.DesignTime/SqlDesignTime.fs
+++ b/src/SQLProvider.DesignTime/SqlDesignTime.fs
@@ -326,7 +326,7 @@ type public SqlTypeProvider(config: TypeProviderConfig) as this =
                                         Expr.Call(args.[0],meth,[Expr.Value name;args.[1]]))
                                  )
                         let nfo = c.TypeInfo
-                        let typeInfo = match nfo with None -> "" | Some x -> x.ToString()
+                        let typeInfo = match nfo with ValueNone -> "" | ValueSome x -> x.ToString()
                         match con with
                         | Some con ->
                             prop.AddXmlDocDelayed(fun () ->

--- a/src/SQLProvider.Runtime/Providers.MSAccess.fs
+++ b/src/SQLProvider.Runtime/Providers.MSAccess.fs
@@ -47,8 +47,8 @@ type internal MSAccessProvider(contextSchemaPath) =
                     let oleDbType = string r.["NativeDataType"]
                     let providerType = unbox<int> r.["ProviderDbType"]
                     let dbType = getDbType providerType
-                    yield { ProviderTypeName = Some oleDbType; ClrType = clrType; DbType = dbType; ProviderType = Some providerType; }
-                yield { ProviderTypeName = Some "cursor"; ClrType = (typeof<SqlEntity[]>).ToString(); DbType = DbType.Object; ProviderType = None; }
+                    yield { ProviderTypeName = ValueSome oleDbType; ClrType = clrType; DbType = dbType; ProviderType = ValueSome providerType; }
+                yield { ProviderTypeName = ValueSome "cursor"; ClrType = (typeof<SqlEntity[]>).ToString(); DbType = DbType.Object; ProviderType = ValueNone; }
             ]
 
         let clrMappings =
@@ -205,7 +205,7 @@ type internal MSAccessProvider(contextSchemaPath) =
             let p = OleDbParameter(param.Name,value)
             p.DbType <- param.TypeMapping.DbType
             p.Direction <- param.Direction
-            Option.iter (fun l -> p.Size <- l) param.Length
+            ValueOption.iter (fun l -> p.Size <- l) param.Length
             upcast p
 
         member __.ExecuteSprocCommand(_,_,_,_) =  raise(NotImplementedException())
@@ -260,9 +260,9 @@ type internal MSAccessProvider(contextSchemaPath) =
                                         let ti = 
                                             if row.IsNull("CHARACTER_MAXIMUM_LENGTH") then ""
                                             else row.["CHARACTER_MAXIMUM_LENGTH"].ToString()
-                                        if String.IsNullOrEmpty ti then None
-                                        else Some ("Max length: " + ti)
-                                    with :? KeyNotFoundException -> None
+                                        if String.IsNullOrEmpty ti then ValueNone
+                                        else ValueSome ("Max length: " + ti)
+                                    with :? KeyNotFoundException -> ValueNone
                                 }
                             (col.Name,col)
                         |_ -> failwith "failed to map datatypes")

--- a/src/SQLProvider.Runtime/Providers.Odbc.fs
+++ b/src/SQLProvider.Runtime/Providers.Odbc.fs
@@ -56,15 +56,15 @@ type internal OdbcProvider(contextSchemaPath, quotechar : OdbcQuoteCharacter) =
                         let oleDbType = string r.["TypeName"]
                         let providerType = unbox<int> r.["ProviderDbType"]
                         let dbType = getDbType providerType
-                        yield { ProviderTypeName = Some oleDbType; ClrType = clrType; DbType = dbType; ProviderType = Some providerType; }
+                        yield { ProviderTypeName = ValueSome oleDbType; ClrType = clrType; DbType = dbType; ProviderType = ValueSome providerType; }
                     
                     if r.Table <> null && r.Table.Columns.Contains("DataType")  && r.Table.Columns.Contains("TypeName")  && r.Table.Columns.Contains("ProviderDbType") then
                         let clrType = getClrType (r.Table.Columns.["DataType"].DataType.ToString())
                         let oleDbType = r.Table.Columns.["TypeName"].DataType.ToString()
                         let providerType = unbox<int> r.Table.Columns.["ProviderDbType"].Ordinal
                         let dbType = getDbType providerType
-                        yield { ProviderTypeName = Some oleDbType; ClrType = clrType; DbType = dbType; ProviderType = Some providerType; }
-                yield { ProviderTypeName = Some "cursor"; ClrType = (typeof<SqlEntity[]>).ToString(); DbType = DbType.Object; ProviderType = None; }
+                        yield { ProviderTypeName = ValueSome oleDbType; ClrType = clrType; DbType = dbType; ProviderType = ValueSome providerType; }
+                yield { ProviderTypeName = ValueSome "cursor"; ClrType = (typeof<SqlEntity[]>).ToString(); DbType = DbType.Object; ProviderType = ValueNone; }
             ]
 
         let clrMappings =
@@ -231,7 +231,7 @@ type internal OdbcProvider(contextSchemaPath, quotechar : OdbcQuoteCharacter) =
             p.ParameterName <- param.Name
             p.DbType <- param.TypeMapping.DbType
             p.Direction <- param.Direction
-            Option.iter (fun l -> p.Size <- l) param.Length
+            ValueOption.iter (fun l -> p.Size <- l) param.Length
             upcast p
 
         /// Not implemented yet
@@ -302,8 +302,8 @@ type internal OdbcProvider(contextSchemaPath, quotechar : OdbcQuoteCharacter) =
                                   HasDefault = false
                                   IsComputed = false
                                   TypeInfo = 
-                                    if maxlen < 1 then Some dt
-                                    else Some (dt + "(" + maxlen.ToString() + ")")
+                                    if maxlen < 1 then ValueSome dt
+                                    else ValueSome (dt + "(" + maxlen.ToString() + ")")
                                   }
                             if col.IsPrimaryKey then 
                                 schemaCache.PrimaryKeys.AddOrUpdate(table.FullName, [col.Name], fun key old ->

--- a/src/SQLProvider.Runtime/Providers.SQLite.fs
+++ b/src/SQLProvider.Runtime/Providers.SQLite.fs
@@ -210,8 +210,8 @@ type internal SQLiteProvider(resolutionPath, contextSchemaPath, referencedAssemb
                     let sqlliteType = string r.["TypeName"]
                     let providerType = unbox<int> r.["ProviderDbType"]
                     let dbType = Enum.ToObject(typeof<DbType>, providerType) :?> DbType
-                    yield { ProviderTypeName = Some sqlliteType; ClrType = clrType; DbType = dbType; ProviderType = Some providerType; }
-                yield { ProviderTypeName = Some "cursor"; ClrType = (typeof<SqlEntity[]>).ToString(); DbType = DbType.Object; ProviderType = None; }
+                    yield { ProviderTypeName = ValueSome sqlliteType; ClrType = clrType; DbType = dbType; ProviderType = ValueSome providerType; }
+                yield { ProviderTypeName = ValueSome "cursor"; ClrType = (typeof<SqlEntity[]>).ToString(); DbType = DbType.Object; ProviderType = ValueNone; }
             ]
 
         let clrMappings =
@@ -378,7 +378,7 @@ type internal SQLiteProvider(resolutionPath, contextSchemaPath, referencedAssemb
             let p = Activator.CreateInstance(paramterType.Value,[|box param.Name;box value|]) :?> IDbDataParameter
             p.DbType <- param.TypeMapping.DbType
             p.Direction <- param.Direction
-            Option.iter (fun l -> p.Size <- l) param.Length
+            ValueOption.iter (fun l -> p.Size <- l) param.Length
             p
 
         member __.ExecuteSprocCommand(com, _, returnCols, values:obj array) =
@@ -467,7 +467,7 @@ type internal SQLiteProvider(resolutionPath, contextSchemaPath, referencedAssemb
                                   IsAutonumber = pkColumn
                                   IsComputed = false
                                   HasDefault = not (reader.IsDBNull 4)
-                                  TypeInfo = Some dtv }
+                                  TypeInfo = ValueSome dtv }
                             if col.IsPrimaryKey then
                                 schemaCache.PrimaryKeys.AddOrUpdate(table.FullName, [col.Name], fun key old ->
                                     match col.Name with

--- a/src/SQLProvider.Runtime/SqlRuntime.QueryExpression.fs
+++ b/src/SQLProvider.Runtime/SqlRuntime.QueryExpression.fs
@@ -342,6 +342,9 @@ module internal QueryExpressionTransformer =
                                                                                     | :? ConstantExpression as c when c.Value = box(true) -> transform en e.IfTrue
                                                                                     | :? ConstantExpression as c when c.Value = box(false) -> transform en e.IfFalse
                                                                                     | _ -> upcast Expression.Condition(testExp, transform en e.IfTrue, transform en e.IfFalse)
+            | ExpressionType.Constant,           (:? ConstantExpression as e)  when e.Type.FullName.StartsWith("Microsoft.FSharp.Core.FSharpValueOption`1") ->
+                                                                                    // https://github.com/dotnet/fsharp/issues/13370
+                                                                                    upcast Expression.Constant(e.Value, typeof<obj>)
             | ExpressionType.Constant,           (:? ConstantExpression as e)    -> upcast e
             | ExpressionType.Parameter,          (:? ParameterExpression as e)   -> match en with
                                                                                     | Some(en) when en = e.Name && (replaceParams=null || not(replaceParams.ContainsKey(e))) ->

--- a/src/SQLProvider.Runtime/SqlRuntime.QueryExpression.fs
+++ b/src/SQLProvider.Runtime/SqlRuntime.QueryExpression.fs
@@ -290,7 +290,7 @@ module internal QueryExpressionTransformer =
 
 
         // this is not tail recursive but it shouldn't matter in practice ....
-        let rec transform  (en:String option) (e:Expression): Expression =
+        let rec transform  (en:String voption) (e:Expression): Expression =
             let e = ExpressionOptimizer.doReduction e
             if e = null then null else
             match e.NodeType, e with
@@ -347,7 +347,7 @@ module internal QueryExpressionTransformer =
                                                                                     upcast Expression.Constant(e.Value, typeof<obj>)
             | ExpressionType.Constant,           (:? ConstantExpression as e)    -> upcast e
             | ExpressionType.Parameter,          (:? ParameterExpression as e)   -> match en with //Todo:ValueOption upcast here too
-                                                                                    | Some(en) when en = e.Name && (replaceParams=null || not(replaceParams.ContainsKey(e))) ->
+                                                                                    | ValueSome(en) when en = e.Name && (replaceParams=null || not(replaceParams.ContainsKey(e))) ->
                                                                                          match projectionMap.TryGetValue en with
                                                                                          | true, values -> values.Clear()
                                                                                          | false, _ -> projectionMap.Add(en,new ResizeArray<_>())
@@ -411,9 +411,9 @@ module internal QueryExpressionTransformer =
                     projectionMap.Add(x,ResizeArray<_>())
                     Expression.Lambda(databaseParam,[databaseParam]) :> Expression
                 | SingleTable(OptionalQuote(Lambda([ParamName x], (NewExpr(ci, args ) )))) ->
-                    Expression.Lambda(Expression.New(ci, (List.map (transform (Some x)) args)),[databaseParam]) :> Expression
+                    Expression.Lambda(Expression.New(ci, (List.map (transform (ValueSome x)) args)),[databaseParam]) :> Expression
                 | SingleTable(OptionalQuote(lambda))
-                | MultipleTables(OptionalQuote(lambda)) -> transform None lambda
+                | MultipleTables(OptionalQuote(lambda)) -> transform ValueNone lambda
 
         newProjection, projectionMap, groupProjectionMap
 

--- a/src/SQLProvider.Runtime/SqlRuntime.QueryExpression.fs
+++ b/src/SQLProvider.Runtime/SqlRuntime.QueryExpression.fs
@@ -346,7 +346,7 @@ module internal QueryExpressionTransformer =
                                                                                     // https://github.com/dotnet/fsharp/issues/13370
                                                                                     upcast Expression.Constant(e.Value, typeof<obj>)
             | ExpressionType.Constant,           (:? ConstantExpression as e)    -> upcast e
-            | ExpressionType.Parameter,          (:? ParameterExpression as e)   -> match en with
+            | ExpressionType.Parameter,          (:? ParameterExpression as e)   -> match en with //Todo:ValueOption upcast here too
                                                                                     | Some(en) when en = e.Name && (replaceParams=null || not(replaceParams.ContainsKey(e))) ->
                                                                                          match projectionMap.TryGetValue en with
                                                                                          | true, values -> values.Clear()

--- a/src/SQLProvider.Runtime/SqlSchema.fs
+++ b/src/SQLProvider.Runtime/SqlSchema.fs
@@ -14,22 +14,22 @@ module internal Patterns =
         if m.Success then Some (List.tail [ for g in m.Groups -> g.Value ]) else None
 
 type TypeMapping =
-    { ProviderTypeName: string option
+    { ProviderTypeName: string voption
       ClrType: string
-      ProviderType: int option
+      ProviderType: int voption
       DbType: DbType }
     with
         static member Create(?clrType, ?dbType, ?providerTypeName, ?providerType) =
             { ClrType = defaultArg clrType ((typeof<string>).ToString())
               DbType = defaultArg dbType (DbType.String)
-              ProviderTypeName = providerTypeName
-              ProviderType = providerType }
+              ProviderTypeName = match providerTypeName with Some x -> ValueSome x | None -> ValueNone
+              ProviderType = match providerType with Some x -> ValueSome x | None -> ValueNone }
 
 type QueryParameter =
     { Name: string
       TypeMapping: TypeMapping
       Direction: ParameterDirection
-      Length: int option
+      Length: int voption
       Ordinal: int }
     with
         static member Create(name, ordinal, ?typeMapping, ?direction, ?length) =
@@ -37,7 +37,7 @@ type QueryParameter =
               Ordinal = ordinal
               TypeMapping = defaultArg typeMapping (TypeMapping.Create())
               Direction = defaultArg direction ParameterDirection.Input
-              Length = length }
+              Length = match length with Some x -> ValueSome x | None -> ValueNone }
 
 type Column =
     { Name: string
@@ -47,7 +47,7 @@ type Column =
       IsAutonumber: bool
       HasDefault: bool
       IsComputed: bool
-      TypeInfo: string option }
+      TypeInfo: string voption }
     with
         static member FromQueryParameter(q: QueryParameter) =
             { Name = q.Name
@@ -57,7 +57,7 @@ type Column =
               IsAutonumber = false
               HasDefault = false
               IsComputed = false
-              TypeInfo = None }
+              TypeInfo = ValueNone }
 
 type ColumnLookup = Map<string,Column>
 

--- a/src/SQLProvider.Runtime/Utils.fs
+++ b/src/SQLProvider.Runtime/Utils.fs
@@ -103,6 +103,28 @@ module internal Utilities =
             | :? DateTimeOffset as t -> Option.Some t |> box
             | :? TimeSpan as t -> Option.Some t |> box
             | t -> Option.Some t |> box
+        elif (returnType.Name.StartsWith("ValueOption") || returnType.Name.StartsWith("FSharpValueOption")) && returnType.GenericTypeArguments.Length = 1 then
+            if itm = null then ValueNone |> box
+            else
+            match convertTypes itm (returnType.GenericTypeArguments.[0]) with
+            | :? String as t -> ValueOption.Some t |> box
+            | :? Int32 as t -> ValueOption.Some t |> box
+            | :? Decimal as t -> ValueOption.Some t |> box
+            | :? Int64 as t -> ValueOption.Some t |> box
+            | :? Single as t -> ValueOption.Some t |> box
+            | :? UInt32 as t -> ValueOption.Some t |> box
+            | :? Double as t -> ValueOption.Some t |> box
+            | :? UInt64 as t -> ValueOption.Some t |> box
+            | :? Int16 as t -> ValueOption.Some t |> box
+            | :? UInt16 as t -> ValueOption.Some t |> box
+            | :? DateTime as t -> ValueOption.Some t |> box
+            | :? Boolean as t -> ValueOption.Some t |> box
+            | :? Byte as t -> ValueOption.Some t |> box
+            | :? SByte as t -> ValueOption.Some t |> box
+            | :? Char as t -> ValueOption.Some t |> box
+            | :? DateTimeOffset as t -> ValueOption.Some t |> box
+            | :? TimeSpan as t -> ValueOption.Some t |> box
+            | t -> ValueOption.Some t |> box
         elif returnType.Name.StartsWith("Nullable") && returnType.GenericTypeArguments.Length = 1 then
             if itm = null then null |> box
             else convertTypes itm (returnType.GenericTypeArguments.[0])

--- a/src/scripts/Firebird.fsx
+++ b/src/scripts/Firebird.fsx
@@ -18,7 +18,7 @@ type sql = SqlDataProvider<
               DatabaseVendor = Common.DatabaseProviderTypes.FIREBIRD,
               ResolutionPath = resolutionPath,
               IndividualsAmount = 1000,
-              UseOptionTypes = FSharp.Data.Sql.Common.OPTION >
+              UseOptionTypes = FSharp.Data.Sql.Common.NullableColumnType.OPTION >
 
 let ctx = sql.GetDataContext()
 

--- a/src/scripts/Firebird.fsx
+++ b/src/scripts/Firebird.fsx
@@ -18,7 +18,7 @@ type sql = SqlDataProvider<
               DatabaseVendor = Common.DatabaseProviderTypes.FIREBIRD,
               ResolutionPath = resolutionPath,
               IndividualsAmount = 1000,
-              UseOptionTypes = true >
+              UseOptionTypes = FSharp.Data.Sql.Common.OPTION >
 
 let ctx = sql.GetDataContext()
 

--- a/tests/SqlProvider.Tests/QueryTests.fs
+++ b/tests/SqlProvider.Tests/QueryTests.fs
@@ -1857,7 +1857,7 @@ let ``simple select query async2``() =
     CollectionAssert.Contains(r, ("55 Grizzly Peak Rd.", "Butte", "Liu Wong"))
 
 
-type sqlOption = SqlDataProvider<Common.DatabaseProviderTypes.SQLITE, connectionString, CaseSensitivityChange=Common.CaseSensitivityChange.ORIGINAL, UseOptionTypes=true, ResolutionPath = resolutionPath, SQLiteLibrary=Common.SQLiteLibrary.SystemDataSQLite>
+type sqlOption = SqlDataProvider<Common.DatabaseProviderTypes.SQLITE, connectionString, CaseSensitivityChange=Common.CaseSensitivityChange.ORIGINAL, UseOptionTypes=FSharp.Data.Sql.Common.OPTION, ResolutionPath = resolutionPath, SQLiteLibrary=Common.SQLiteLibrary.SystemDataSQLite>
 
 [<Test>]
 let ``simple select with contains query with where boolean option type``() =

--- a/tests/SqlProvider.Tests/QueryTests.fs
+++ b/tests/SqlProvider.Tests/QueryTests.fs
@@ -1857,7 +1857,7 @@ let ``simple select query async2``() =
     CollectionAssert.Contains(r, ("55 Grizzly Peak Rd.", "Butte", "Liu Wong"))
 
 
-type sqlOption = SqlDataProvider<Common.DatabaseProviderTypes.SQLITE, connectionString, CaseSensitivityChange=Common.CaseSensitivityChange.ORIGINAL, UseOptionTypes=FSharp.Data.Sql.Common.OPTION, ResolutionPath = resolutionPath, SQLiteLibrary=Common.SQLiteLibrary.SystemDataSQLite>
+type sqlOption = SqlDataProvider<Common.DatabaseProviderTypes.SQLITE, connectionString, CaseSensitivityChange=Common.CaseSensitivityChange.ORIGINAL, UseOptionTypes=FSharp.Data.Sql.Common.NullableColumnType.OPTION, ResolutionPath = resolutionPath, SQLiteLibrary=Common.SQLiteLibrary.SystemDataSQLite>
 
 [<Test>]
 let ``simple select with contains query with where boolean option type``() =
@@ -2457,3 +2457,17 @@ let ``simple mapTo test``() =
         |> Seq.toList
     qry |> Assert.IsNotEmpty
     qry |> List.exists(fun i -> i.FirstName = "Laura") |> Assert.IsTrue
+
+type sqlValueOption = SqlDataProvider<Common.DatabaseProviderTypes.SQLITE, connectionString, CaseSensitivityChange=Common.CaseSensitivityChange.ORIGINAL, UseOptionTypes=FSharp.Data.Sql.Common.NullableColumnType.VALUE_OPTION, ResolutionPath = resolutionPath, SQLiteLibrary=Common.SQLiteLibrary.SystemDataSQLite>
+
+[<Test>]
+let ``simple select with ValueOption type query``() =
+    let dcv = sqlValueOption.GetDataContext()
+    let qry = 
+        query {
+            for cust in dcv.Main.Customers do
+            where (cust.City.IsSome && cust.City.StartsWith "Lo")
+            select cust.City
+        } |> Seq.toList
+
+    qry |> Assert.IsNotEmpty

--- a/tests/SqlProvider.Tests/QueryTests.fs
+++ b/tests/SqlProvider.Tests/QueryTests.fs
@@ -2466,7 +2466,7 @@ let ``simple select with ValueOption type query``() =
     let qry = 
         query {
             for cust in dcv.Main.Customers do
-            where (cust.City.IsSome && cust.City.StartsWith "Lo")
+            where (cust.City.IsSome && (cust.City.Value.StartsWith "Lo" || cust.City.Value="Berlin"))
             select cust.City
         } |> Seq.toList
 

--- a/tests/SqlProvider.Tests/Readme.md
+++ b/tests/SqlProvider.Tests/Readme.md
@@ -191,7 +191,7 @@ query {
 ```
 
 If you don't like null-values in your F#-code,
-you can use `UseOptionTypes=true`
+you can use `UseOptionTypes=FSharp.Data.Sql.Common.OPTION`
 parameter and handle nullable columns as FSharp Option-types,
 converting .IsNone and .IsSome to the proper SQL null-checking.
 

--- a/tests/SqlProvider.Tests/Readme.md
+++ b/tests/SqlProvider.Tests/Readme.md
@@ -191,7 +191,7 @@ query {
 ```
 
 If you don't like null-values in your F#-code,
-you can use `UseOptionTypes=FSharp.Data.Sql.Common.OPTION`
+you can use `UseOptionTypes=FSharp.Data.Sql.Common.NullableColumnType.OPTION`
 parameter and handle nullable columns as FSharp Option-types,
 converting .IsNone and .IsSome to the proper SQL null-checking.
 

--- a/tests/SqlProvider.Tests/scripts/OdbcTests.fsx
+++ b/tests/SqlProvider.Tests/scripts/OdbcTests.fsx
@@ -27,7 +27,7 @@ let contributors =
 [<Literal>]
 let connectionStringAccess = @"Driver={Microsoft Access Driver (*.mdb, *.accdb)};Dbq=" + __SOURCE_DIRECTORY__ + @"\..\..\..\docs\files\msaccess\Northwind.mdb"
 
-type dbOdbcAccess = SqlDataProvider<Common.DatabaseProviderTypes.ODBC, connectionStringAccess, Owner="", UseOptionTypes = FSharp.Data.Sql.Common.OPTION, OdbcQuote=Common.OdbcQuoteCharacter.DOUBLE_QUOTES>
+type dbOdbcAccess = SqlDataProvider<Common.DatabaseProviderTypes.ODBC, connectionStringAccess, Owner="", UseOptionTypes = FSharp.Data.Sql.Common.NullableColumnType.OPTION, OdbcQuote=Common.OdbcQuoteCharacter.DOUBLE_QUOTES>
 
 // Sadly MS-Access ODBC driver doesn't support DTC at all.
 let odbcaContext = 

--- a/tests/SqlProvider.Tests/scripts/OdbcTests.fsx
+++ b/tests/SqlProvider.Tests/scripts/OdbcTests.fsx
@@ -27,7 +27,7 @@ let contributors =
 [<Literal>]
 let connectionStringAccess = @"Driver={Microsoft Access Driver (*.mdb, *.accdb)};Dbq=" + __SOURCE_DIRECTORY__ + @"\..\..\..\docs\files\msaccess\Northwind.mdb"
 
-type dbOdbcAccess = SqlDataProvider<Common.DatabaseProviderTypes.ODBC, connectionStringAccess, Owner="", UseOptionTypes = true, OdbcQuote=Common.OdbcQuoteCharacter.DOUBLE_QUOTES>
+type dbOdbcAccess = SqlDataProvider<Common.DatabaseProviderTypes.ODBC, connectionStringAccess, Owner="", UseOptionTypes = FSharp.Data.Sql.Common.OPTION, OdbcQuote=Common.OdbcQuoteCharacter.DOUBLE_QUOTES>
 
 // Sadly MS-Access ODBC driver doesn't support DTC at all.
 let odbcaContext = 

--- a/tests/SqlProvider.Tests/scripts/PostgreSQLTests.fsx
+++ b/tests/SqlProvider.Tests/scripts/PostgreSQLTests.fsx
@@ -38,7 +38,7 @@ type HR =
       DatabaseVendor = Common.DatabaseProviderTypes.POSTGRESQL,
       ConnectionString = connStr,
       ResolutionPath=resolutionPath,
-      UseOptionTypes=FSharp.Data.Sql.Common.OPTION,
+      UseOptionTypes=FSharp.Data.Sql.Common.NullableColumnType.OPTION,
       Owner = "public, other_schema"
   >
 

--- a/tests/SqlProvider.Tests/scripts/PostgreSQLTests.fsx
+++ b/tests/SqlProvider.Tests/scripts/PostgreSQLTests.fsx
@@ -38,7 +38,7 @@ type HR =
       DatabaseVendor = Common.DatabaseProviderTypes.POSTGRESQL,
       ConnectionString = connStr,
       ResolutionPath=resolutionPath,
-      UseOptionTypes=true,
+      UseOptionTypes=FSharp.Data.Sql.Common.OPTION,
       Owner = "public, other_schema"
   >
 

--- a/tests/SqlProvider.Tests/scripts/SQLLiteTests.fsx
+++ b/tests/SqlProvider.Tests/scripts/SQLLiteTests.fsx
@@ -120,7 +120,7 @@ let query2 =
     |> Seq.toArray
 
 
-type sqlOpt = SqlDataProvider<Common.DatabaseProviderTypes.SQLITE, connectionString, ResolutionPath = resolutionPath, CaseSensitivityChange = Common.CaseSensitivityChange.ORIGINAL, UseOptionTypes=FSharp.Data.Sql.Common.OPTION>
+type sqlOpt = SqlDataProvider<Common.DatabaseProviderTypes.SQLITE, connectionString, ResolutionPath = resolutionPath, CaseSensitivityChange = Common.CaseSensitivityChange.ORIGINAL, UseOptionTypes=FSharp.Data.Sql.Common.NullableColumnType.OPTION>
 let ctxOpt = sqlOpt.GetDataContext()
 let ``none option in left join`` =
         query { 

--- a/tests/SqlProvider.Tests/scripts/SQLLiteTests.fsx
+++ b/tests/SqlProvider.Tests/scripts/SQLLiteTests.fsx
@@ -120,7 +120,7 @@ let query2 =
     |> Seq.toArray
 
 
-type sqlOpt = SqlDataProvider<Common.DatabaseProviderTypes.SQLITE, connectionString, ResolutionPath = resolutionPath, CaseSensitivityChange = Common.CaseSensitivityChange.ORIGINAL, UseOptionTypes=true>
+type sqlOpt = SqlDataProvider<Common.DatabaseProviderTypes.SQLITE, connectionString, ResolutionPath = resolutionPath, CaseSensitivityChange = Common.CaseSensitivityChange.ORIGINAL, UseOptionTypes=FSharp.Data.Sql.Common.OPTION>
 let ctxOpt = sqlOpt.GetDataContext()
 let ``none option in left join`` =
         query { 

--- a/tests/SqlProvider.Tests/scripts/SqlServerTests.fsx
+++ b/tests/SqlProvider.Tests/scripts/SqlServerTests.fsx
@@ -309,7 +309,7 @@ query {
 
 //************** Option types test ******************//
 
-type HR2 = SqlDataProvider<Common.DatabaseProviderTypes.MSSQLSERVER, connStr, ResolutionPath = resolutionFolder, UseOptionTypes = FSharp.Data.Sql.Common.OPTION>
+type HR2 = SqlDataProvider<Common.DatabaseProviderTypes.MSSQLSERVER, connStr, ResolutionPath = resolutionFolder, UseOptionTypes = FSharp.Data.Sql.Common.NullableColumnType.OPTION>
 let ctxOpt = HR2.GetDataContext()
 
 let getOptionFilter (postcode : string option) = 

--- a/tests/SqlProvider.Tests/scripts/SqlServerTests.fsx
+++ b/tests/SqlProvider.Tests/scripts/SqlServerTests.fsx
@@ -309,7 +309,7 @@ query {
 
 //************** Option types test ******************//
 
-type HR2 = SqlDataProvider<Common.DatabaseProviderTypes.MSSQLSERVER, connStr, ResolutionPath = resolutionFolder, UseOptionTypes = true>
+type HR2 = SqlDataProvider<Common.DatabaseProviderTypes.MSSQLSERVER, connStr, ResolutionPath = resolutionFolder, UseOptionTypes = FSharp.Data.Sql.Common.OPTION>
 let ctxOpt = HR2.GetDataContext()
 
 let getOptionFilter (postcode : string option) = 


### PR DESCRIPTION
## Proposed Changes

This changes the parameter UseOptionTypes to be, instead of current true/false,
an DU:

- FSharp.Data.Sql.Common.NullableColumnType.NO_OPTION - database nulls are default (as current false)
- FSharp.Data.Sql.Common.NullableColumnType.OPTION - database nulls are `option<_>` (as current true)
- FSharp.Data.Sql.Common.NullableColumnType.VALUE_OPTION - database nulls are `voption<_>` (new feature)

Many of the database types are primitives and thus a struct would do fine.
This is not changing the SqlEntity class itself, so you can still update the database values and save datacontext as usual.
