### PR TITLE
Utils: fix ArgumentNullException in tryLoadAssemblyFrom

### DIFF
--- a/src/SQLProvider.Runtime/Utils.fs
+++ b/src/SQLProvider.Runtime/Utils.fs
@@ -394,7 +394,7 @@ module internal Reflection =
 
         let ifNotNull (x:Assembly) =
             if x = null then ""
-            elif x.Location = null then ""
+            elif String.IsNullOrWhiteSpace x.Location then ""
             else x.Location |> Path.GetDirectoryName
 
 //#if NETSTANDARD


### PR DESCRIPTION
Building .NET 6 project with PublishSingleFile flag results in
Assembly.GetExecutingAssembly() and GetEntryAssembly() returning an
assembly object that has an empty string (String.empty) as Location
which causes Path.GetDirectoryName to return null which then when passed
to Path.Combine will cause ArgumentNullException.

```
System.ArgumentNullException: Value cannot be null. (Parameter 'path1')
 at System.IO.Path.Combine(String path1, String path2)
 at FSharp.Data.Sql.Common.Reflection.dirs@417.Invoke(String d)
 at Microsoft.FSharp.Primitives.Basics.List.mapToFreshConsTail[a,b](FSharpList`1 cons, FSharpFunc`2 f, FSharpList`1 x) in D:\a\_work\1\s\src\fsharp\FSharp.Core\local.fs:line 237
 at Microsoft.FSharp.Primitives.Basics.List.map[T,TResult](FSharpFunc`2 mapping, FSharpList`1 x) in D:\a\_work\1\s\src\fsharp\FSharp.Core\local.fs:line 247
 at Microsoft.FSharp.Collections.ListModule.Map[T,TResult](FSharpFunc`2 mapping, FSharpList`1 list) in D:\a\_work\1\s\src\fsharp\FSharp.Core\list.fs:line 74
 at FSharp.Data.Sql.Common.Reflection.tryLoadAssemblyFrom(String resolutionPath, String[] referencedAssemblies, FSharpList`1 assemblyNames)
 at FSharp.Data.Sql.Providers.PostgreSQL.assembly@28-3.Invoke(Unit unitVar)
 at System.Lazy`1.ViaFactory(LazyThreadSafetyMode mode)
 at System.Lazy`1.ExecutionAndPublication(LazyHelper executionAndPublication, Boolean useDefaultConstructor)
 at System.Lazy`1.CreateValue()
 at System.Lazy`1.get_Value()
 at FSharp.Data.Sql.Providers.PostgreSQL.findType(String name)
 at FSharp.Data.Sql.Providers.PostgreSQL.getType@51.Invoke(String name)
 at FSharp.Data.Sql.Providers.PostgreSQL.getType@51-2.Invoke(String x)
 at FSharp.Data.Sql.Providers.PostgreSQL.connectionType@53-3.Invoke(Unit unitVar)
 at System.Lazy`1.ViaFactory(LazyThreadSafetyMode mode)
--- End of stack trace from previous location ---
 at System.Lazy`1.CreateValue()
 at System.Lazy`1.get_Value()
 at FSharp.Data.Sql.Providers.PostgreSQL.createConnection[a](a connectionString)
 at FSharp.Data.Sql.Providers.PostgresqlProvider.FSharp-Data-Sql-Common-ISqlProvider-CreateConnection(String connectionString)
 at <StartupCode$FSharp-Data-SqlProvider>.$SqlRuntime.DataContext.addCache@38-1.Invoke(Unit unitVar)
 at System.Lazy`1.ViaFactory(LazyThreadSafetyMode mode)
 at System.Lazy`1.ExecutionAndPublication(LazyHelper executionAndPublication, Boolean useDefaultConstructor)
 at System.Lazy`1.CreateValue()
 at System.Lazy`1.get_Value()
 at FSharp.Data.Sql.Runtime.SqlDataContext..ctor(String typeName, String connectionString, DatabaseProviderTypes providerType, String resolutionPath, String[] referencedAssemblies, String runtimeAssembly, String owner, CaseSensitivityChange caseSensitivity, String tableNames, String contextSchemaPath, OdbcQuoteCharacter odbcquote, SQLiteLibrary sqliteLibrary, TransactionOptions transactionOptions, FSharpOption`1 commandTimeout, SelectOperations sqlOperationsInSelect, String ssdtPath)
```

## Proposed Changes

This change fixed the ArgumentNullException happening when used in SingleFile published projects.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [X] Build and tests pass locally
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)
