### PR TITLE
Add user defined data type support for SQL Server SSDT

### DIFF
--- a/src/SQLProvider.Runtime/Providers.MsSqlServer.Ssdt.fs
+++ b/src/SQLProvider.Runtime/Providers.MsSqlServer.Ssdt.fs
@@ -170,8 +170,8 @@ module MSSqlServerSsdt =
         match typeMappingsByName.TryFind dataType with
         | Some tm -> tm
         | None ->
-            match Map.tryFind dataType uddts with
-            | Some x -> tryFindMappingOrVariant uddts x
+            match Map.tryFind (UDDTName dataType) uddts with
+            | Some (UDDTInheritedType x) -> tryFindMappingOrVariant uddts x
             | None -> (typeMappingsByName.TryFind "SQL_VARIANT").Value
 
     let ssdtTableToTable (tbl: SsdtTable) =

--- a/src/SQLProvider.Runtime/Providers.MsSqlServer.Ssdt.fs
+++ b/src/SQLProvider.Runtime/Providers.MsSqlServer.Ssdt.fs
@@ -165,32 +165,32 @@ module MSSqlServerSsdt =
     let tryFindMapping (dataType: string) =
         typeMappingsByName.TryFind (dataType.ToUpper())
 
-    let tryFindMappingOrVariant (dataType: string) =
+    let rec tryFindMappingOrVariant (uddts: SsdtUserDefinedDataType list) (dataType: string) =
         match typeMappingsByName.TryFind (dataType.ToUpper()) with
         | Some tm -> tm
-        | None -> (typeMappingsByName.TryFind "SQL_VARIANT").Value
+        | None ->
+            match List.tryFind (fun x -> x.Name = dataType) uddts with
+            | Some x -> tryFindMappingOrVariant uddts x.Inheritance
+            | None -> (typeMappingsByName.TryFind "SQL_VARIANT").Value
 
     let ssdtTableToTable (tbl: SsdtTable) =
         { Schema = tbl.Schema ; Name = tbl.Name ; Type =  if tbl.IsView then "view" else "base table" }
 
-    let ssdtColumnToColumn (tbl: SsdtTable) (col: SsdtColumn) =
-        match tryFindMapping col.DataType with
-        | Some typeMapping ->
-            Some
-                { Column.Name = col.Name
-                  Column.TypeMapping = typeMapping
-                  Column.IsNullable = col.AllowNulls
-                  Column.IsPrimaryKey =
-                    tbl.PrimaryKey
-                    |> ValueOption.map (fun pk -> pk.Columns |> List.exists (fun pkCol -> pkCol.Name = col.Name))
-                    |> ValueOption.defaultValue false
-                  Column.IsAutonumber = col.IsIdentity
-                  Column.HasDefault = col.HasDefault
-                  Column.IsComputed = col.ComputedColumn
-                  Column.TypeInfo = if col.DataType = "" then ValueNone else ValueSome col.DataType }
-        | None ->
-            None
 
+    let ssdtColumnToColumn uddts (tbl: SsdtTable) (col: SsdtColumn) =
+        let typeMapping = tryFindMappingOrVariant uddts col.DataType
+        Some
+            { Column.Name = col.Name
+              Column.TypeMapping = typeMapping
+              Column.IsNullable = col.AllowNulls
+              Column.IsPrimaryKey =
+                tbl.PrimaryKey
+                |> ValueOption.map (fun pk -> pk.Columns |> List.exists (fun pkCol -> pkCol.Name = col.Name))
+                |> ValueOption.defaultValue false
+              Column.IsAutonumber = col.IsIdentity
+              Column.HasDefault = col.HasDefault
+              Column.IsComputed = col.ComputedColumn
+              Column.TypeInfo = if col.DataType = "" then ValueNone else ValueSome col.DataType }
 
 type internal MSSqlServerProviderSsdt(tableNames: string, ssdtPath: string) =
     let schemaCache = SchemaCache.Empty
@@ -317,7 +317,7 @@ type internal MSSqlServerProviderSsdt(tableNames: string, ssdtPath: string) =
                 match ssdtSchema.Value.TryGetTableByName(table.Name) with
                 | ValueSome ssdtTbl ->
                     ssdtTbl.Columns
-                    |> List.map (MSSqlServerSsdt.ssdtColumnToColumn ssdtTbl)
+                    |> List.map (MSSqlServerSsdt.ssdtColumnToColumn (ssdtSchema.Value.UserDefinedDataTypes) ssdtTbl)
                     |> List.choose id
                     |> List.map (fun col -> col.Name, col)
                 | ValueNone -> []
@@ -375,7 +375,7 @@ type internal MSSqlServerProviderSsdt(tableNames: string, ssdtPath: string) =
                     sp.Parameters
                     |> List.mapi (fun idx p ->
                         { Name = p.Name
-                          TypeMapping = MSSqlServerSsdt.tryFindMappingOrVariant p.DataType
+                          TypeMapping = MSSqlServerSsdt.tryFindMappingOrVariant (ssdtSchema.Value.UserDefinedDataTypes) p.DataType
                           Direction = if p.IsOutput then ParameterDirection.InputOutput else ParameterDirection.Input
                           Length = p.Length
                           Ordinal = idx }
@@ -385,7 +385,7 @@ type internal MSSqlServerProviderSsdt(tableNames: string, ssdtPath: string) =
                     |> List.filter (fun p -> p.IsOutput)
                     |> List.mapi (fun idx p ->
                         { Name = p.Name
-                          TypeMapping = MSSqlServerSsdt.tryFindMappingOrVariant p.DataType
+                          TypeMapping = MSSqlServerSsdt.tryFindMappingOrVariant (ssdtSchema.Value.UserDefinedDataTypes) p.DataType
                           Direction = ParameterDirection.InputOutput
                           Length = p.Length
                           Ordinal = idx }

--- a/src/SQLProvider.Runtime/Providers.MsSqlServer.Ssdt.fs
+++ b/src/SQLProvider.Runtime/Providers.MsSqlServer.Ssdt.fs
@@ -172,7 +172,7 @@ module MSSqlServerSsdt =
         | None ->
             match Map.tryFind (UDDTName dataType) uddts with
             | Some (UDDTInheritedType x) -> tryFindMappingOrVariant uddts x
-            | None -> (typeMappingsByName.TryFind "SQL_VARIANT").Value
+            | None -> typeMappingsByName["SQL_VARIANT"]
 
     let ssdtTableToTable (tbl: SsdtTable) =
         { Schema = tbl.Schema ; Name = tbl.Name ; Type =  if tbl.IsView then "view" else "base table" }

--- a/src/SQLProvider.Runtime/Ssdt.DacpacParser.fs
+++ b/src/SQLProvider.Runtime/Ssdt.DacpacParser.fs
@@ -87,7 +87,9 @@ and SsdtDescriptionItem = {
     ColumnName: string voption
     Description: string
 }
-and SsdtUserDefinedDataType = Map<string, string>
+and SsdtUserDefinedDataType = Map<UDDTName, UDDTInheritedType>
+and UDDTName = UDDTName of string
+and UDDTInheritedType = UDDTInheritedType of string
 
 module RegexParsers =
     open System.Text.RegularExpressions
@@ -390,7 +392,7 @@ let parseXml(xml: string) =
 
     let parseUserDefinedDataType (udts: XmlNode) =
         let name = udts |> att "Name"
-        let name = name |> RegexParsers.splitFullName |> fun parsed -> String.Join(".", parsed) |> fun n -> n.ToUpper()
+        let name = name |> RegexParsers.splitFullName |> fun parsed -> String.Join(".", parsed) |> fun n -> n.ToUpper() |> UDDTName
         let inheritedType =
             udts
             |> nodes "x:Relationship"
@@ -400,6 +402,7 @@ let parseXml(xml: string) =
             |> RegexParsers.splitFullName
             |> fun parsed -> String.Join(".", parsed)
             |> fun t -> t.ToUpper()
+            |> UDDTInheritedType
         (name, inheritedType)
 
     let userDefinedDataTypes =

--- a/src/SQLProvider.Runtime/Ssdt.DacpacParser.fs
+++ b/src/SQLProvider.Runtime/Ssdt.DacpacParser.fs
@@ -390,11 +390,11 @@ let parseXml(xml: string) =
             Description = description
         }
 
-    let parseUserDefinedDataType (udts: XmlNode) =
-        let name = udts |> att "Name"
+    let parseUserDefinedDataType (uddts: XmlNode) =
+        let name = uddts |> att "Name"
         let name = name |> RegexParsers.splitFullName |> fun parsed -> String.Join(".", parsed) |> fun n -> n.ToUpper() |> UDDTName
         let inheritedType =
-            udts
+            uddts
             |> nodes "x:Relationship"
             |> Seq.find (fun n -> n |> att "Name" = "Type")
             |> node "x:Entry/x:References"

--- a/tests/SqlProvider.Core.Tests/MsSqlSsdt/MsSqlSsdt.Tests/MsSqlSsdt.Tests.fsproj
+++ b/tests/SqlProvider.Core.Tests/MsSqlSsdt/MsSqlSsdt.Tests/MsSqlSsdt.Tests.fsproj
@@ -22,6 +22,7 @@
     <Compile Include="Dacpac\UnzipTests.fs" />
     <Compile Include="Dacpac\ParseSchemaTests.fs" />
     <Compile Include="Dacpac\TypeAnnotationTests.fs" />
+    <Compile Include="UserDefinedDataTypes.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 

--- a/tests/SqlProvider.Core.Tests/MsSqlSsdt/MsSqlSsdt.Tests/UserDefinedDataTypes.fs
+++ b/tests/SqlProvider.Core.Tests/MsSqlSsdt/MsSqlSsdt.Tests/UserDefinedDataTypes.fs
@@ -1,0 +1,18 @@
+module UserDefinedDataTypesTests
+open FSharp.Data.Sql
+open FSharp.Data.Sql.Schema
+
+[<Literal>]
+let AdventureWorks = @"Server=localhost\SQLEXPRESS;Database=AdventureWorksLT2019;Trusted_Connection=True;"
+
+[<Literal>]
+let SsdtPath = __SOURCE_DIRECTORY__ + "/AdventureWorks_SSDT/bin/Debug/AdventureWorks_SSDT.dacpac"
+
+type DB = SqlDataProvider<Common.DatabaseProviderTypes.MSSQLSERVER_SSDT, SsdtPath = SsdtPath>
+
+let ctx = DB.GetDataContext(AdventureWorks)
+
+let ``Flag UDDT should be equals to a System.Boolean`` =
+    let entity = ctx.SalesLt.SalesOrderHeader.Create()
+    if (entity.OnlineOrderFlag.GetType().FullName) <> "System.Boolean"
+    then failwith "Failed test condition for user defined data type: Flag UDDT should be equals to a System.Boolean."


### PR DESCRIPTION
## Proposed Changes

Currently, SSDTs for SQL Server do not support user defined data types. This means if a simple custom type is defined, such as the one from below, the column does not get translated to F#.

A simple UDDT:

```tsql
CREATE TYPE LATITUDE FROM REAL;
GO
CREATE
    RULE RuleLatitudeRange
    AS
    @per >= -180.0 AND @per <= 180.0
GO
EXEC SP_bindrule 'RuleLatitudeRange', 'LATITUDE'
GO
```

From the lsp:
![Screenshot 2023-01-07 at 01 03 14](https://user-images.githubusercontent.com/14153897/211130326-1324fd8b-8a70-451c-baa8-9f4a17d2805c.png)

On the following table, where all the types are also simple overloads on REAL and INT:
```tsql
CREATE TABLE dbo.TestUDDTs
(
    ID INT PRIMARY KEY,
    A MINUTES NOT NULL,
    B COMPASS NOT NULL,
    C LATITUDE NOT NULL,
    D LONGITUDE NOT NULL,
    E DAYS NOT NULL,
);
```

With this PR we now have:
![Screenshot 2023-01-07 at 01 12 33](https://user-images.githubusercontent.com/14153897/211130537-235f42f3-4c40-4e93-96d6-49cb705e3a84.png)

A further explanation on the implementation may be found under `Further comments`

## Types of changes

Changes this PR introduces:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [ ] Build and tests pass locally
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Further comments

- The solution is:
  - Parse the nodes in XML:
```xml
<Element Type="SqlUserDefinedDataType" Name="[dbo].[MINUTES]">
	<Relationship Name="Schema">
		<Entry>
			<References ExternalSource="BuiltIns" Name="[dbo]" />
		</Entry>
	</Relationship>
	<Relationship Name="Type">
		<Entry>
			<References ExternalSource="BuiltIns" Name="[int]" />
		</Entry>
	</Relationship>
</Element>
```
  - Generate a Map<UDDTName, UDDTInheritedType> (both algebraic aliases for string), where `UDDTName` is the given name to the type, and  `UDDTInheritedType` is the base type that `UDDTName` inherits from
  - Add a new parameter to `tryFindMappingOrVariant` where such map is passed
  - Attempts to find the type in the normal `typeMappingsByName` map, if it does not find, attempts once again on the UDDT map, if something was found, searches for the base type in `typeMappingsByName`, otherwise defaults to `SQL_VARIANT` and consequently to `System.Object`
- Since UDDTs can only be referenced to simple primitives in SQL Server, I leverage the fact I don't have to worry on UDDTs being defined in terms of another UDDT.
