### PR TITLE
(sqlite) add support for column that has no type showed in `pragma table_info`

### DIFF
--- a/src/SQLProvider.Runtime/Providers.SQLite.fs
+++ b/src/SQLProvider.Runtime/Providers.SQLite.fs
@@ -458,20 +458,29 @@ type internal SQLiteProvider(resolutionPath, contextSchemaPath, referencedAssemb
             match schemaCache.Columns.TryGetValue table.FullName with
             | (true,data) when data.Count > 0 -> data
             | _ ->
+                let typeofColumn colName =
+                    let query = $"SELECT typeof([%s{colName}]) FROM [%s{table.Name}] LIMIT 1"
+                    use com = (this:>ISqlProvider).CreateCommand(con,query)
+                    use reader = com.ExecuteReader()
+                    reader.Read()
+                    reader.GetString(0).ToLower()
+
                 if con.State <> ConnectionState.Open then con.Open()
                 let query = sprintf "pragma table_info(%s)" table.Name
                 use com = (this:>ISqlProvider).CreateCommand(con,query)
                 use reader = com.ExecuteReader()
                 let columns =
                     [ while reader.Read() do
+                        let colName = reader.GetString(1)
                         let dtv = reader.GetString(2).ToLower()
+                        let dtv = if String.IsNullOrWhiteSpace dtv then typeofColumn colName else dtv
                         let dt = if dtv.Contains("(") then dtv.Substring(0,dtv.IndexOf("(")) else dtv
                         let dt = dt.Trim()
                         match findDbType dt with
                         | Some(m) ->
                             let pkColumn = if reader.GetBoolean(5) then true else false
                             let col =
-                                { Column.Name = reader.GetString(1);
+                                { Column.Name = colName
                                   TypeMapping = m
                                   IsNullable = not <| reader.GetBoolean(3);
                                   IsPrimaryKey = pkColumn


### PR DESCRIPTION
## Proposed Changes

Currently when connecting to a sqlite database, if a view contains columns that have no type showed in `pragma table_info` (such as string concat by `||`, a CASE-WHEN expression, etc), the SQLProvider will ignore them. This PR tries to make them visible to SQLProvider. 

## Types of changes

What types of changes does your code introduce to SQLProvider?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Build and tests pass locally
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
