### PR TITLE
(Odbc) Add support for views instead of only tables

### DIFF
--- a/src/SQLProvider.Runtime/Providers.Odbc.fs
+++ b/src/SQLProvider.Runtime/Providers.Odbc.fs
@@ -189,9 +189,11 @@ type internal OdbcProvider(contextSchemaPath, quotechar : OdbcQuoteCharacter) =
     interface ISqlProvider with
         member __.GetLockObject() = myLock
         member __.GetTableDescription(con,tableName) = 
-            let t = tableName.Substring(tableName.LastIndexOf(".")+1) 
+            let t = tableName.Substring(tableName.LastIndexOf(".")+1)
+            let table = (con:?>OdbcConnection).GetSchema("Tables",[|null;null;t.Replace("\"", "")|]).AsEnumerable()
+            let view = (con:?>OdbcConnection).GetSchema("Views",[|null;null;t.Replace("\"", "")|]).AsEnumerable() 
             let desc = 
-                (con:?>OdbcConnection).GetSchema("Tables",[|null;null;t.Replace("\"", "")|]).AsEnumerable() 
+                Seq.append table view
                 |> Seq.map(fun row ->
                     try 
                         let remarks = row.["REMARKS"].ToString()
@@ -261,7 +263,8 @@ type internal OdbcProvider(contextSchemaPath, quotechar : OdbcQuoteCharacter) =
             let con = con :?> OdbcConnection
             if con.State <> ConnectionState.Open then con.Open()
             let dataTables = con.GetSchema("Tables").Rows |> Seq.cast<DataRow> |> Seq.map (fun i -> i.ItemArray)
-            [ for dataTable in dataTables do
+            let dataViews = con.GetSchema("Views").Rows |> Seq.cast<DataRow> |> Seq.map (fun i -> i.ItemArray)
+            [ for dataTable in Seq.append dataTables dataViews do
                 let schema = 
                     if String.IsNullOrEmpty(dataTable.[1].ToString()) then
                         "dbo"

--- a/src/SQLProvider.Runtime/Providers.Odbc.fs
+++ b/src/SQLProvider.Runtime/Providers.Odbc.fs
@@ -285,7 +285,10 @@ type internal OdbcProvider(contextSchemaPath, quotechar : OdbcQuoteCharacter) =
             | _ ->
                 let con = con :?> OdbcConnection
                 if con.State <> ConnectionState.Open then con.Open()
-                let primaryKey = con.GetSchema("Indexes", [| null; null; table.Name |]).Rows |> Seq.cast<DataRow> |> Seq.map (fun i -> i.ItemArray) |> Array.ofSeq
+                let primaryKey =
+                    if table.Type = "table"
+                    then con.GetSchema("Indexes", [| null; null; table.Name |]).Rows |> Seq.cast<DataRow> |> Seq.map (fun i -> i.ItemArray) |> Array.ofSeq
+                    else Array.empty
                 let dataTable = con.GetSchema("Columns", [| null; null; table.Name; null|]).Rows |> Seq.cast<DataRow> |> Seq.map (fun i -> i.ItemArray)
                 let columns =
                     [ for i in dataTable do


### PR DESCRIPTION
## Proposed Changes

Currently the Odbc provider only returns the table schemas. I found that the Access driver also provides views (called queries in access) for the `accdb` file type. This pr changes the Odbc provider to also include these views.

## Types of changes

What types of changes does your code introduce to SQLProvider?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Build and tests pass locally
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Further comments


