### PR TITLE
Add OnConflict handling for MySQL.

### DIFF
--- a/docs/content/core/crud.fsx
+++ b/docs/content/core/crud.fsx
@@ -190,7 +190,7 @@ ctx.SubmitUpdatesAsync() // |> Async.AwaitTask
 (**
 ### OnConflict
 
-The [SQLite](http://sqlite.org/lang_conflict.html) and [PostgreSQL 9.5+](https://www.postgresql.org/docs/current/static/sql-insert.html#SQL-ON-CONFLICT) providers support conflict resolution for INSERT statements.
+The [SQLite](http://sqlite.org/lang_conflict.html), [PostgreSQL 9.5+](https://www.postgresql.org/docs/current/static/sql-insert.html#SQL-ON-CONFLICT) and [MySQL 8.0+](https://dev.mysql.com/doc/refman/8.0/en/insert-on-duplicate.html) providers support conflict resolution for INSERT statements.
 
 They allow the user to specify if a unique constraint violation should be solved by ignoring the statement (DO NOTHING) or updating existing rows (DO UPDATE).
 

--- a/src/SQLProvider.Runtime/Providers.MySql.fs
+++ b/src/SQLProvider.Runtime/Providers.MySql.fs
@@ -398,10 +398,10 @@ type internal MySqlProvider(resolutionPath, contextSchemaPath, owner:string, ref
         | Throw -> ()
         | Update ->
           ~~(sprintf " ON DUPLICATE KEY UPDATE %s"
-                (String.Join(",", columnNamesWithValues |> List.map(fun (c,p) -> sprintf "`%s`=%s" c p.ParameterName))))
+                (String.Join(",", columnNamesWithValues |> Array.map(fun (c,p) -> sprintf "`%s`=%s" c p.ParameterName))))
         | DoNothing ->
           ~~(sprintf " AS x ON DUPLICATE KEY UPDATE %s"
-                (String.Join(",", columnNamesWithValues |> List.map(fun (c,p) -> sprintf "`%s`=x.`%s`" c p.ParameterName))))
+                (String.Join(",", columnNamesWithValues |> Array.map(fun (c,_) -> sprintf "`%s`=x.`%s`" c c))))
 
         ~~"; SELECT LAST_INSERT_ID();"
 

--- a/src/SQLProvider.Runtime/Providers.MySql.fs
+++ b/src/SQLProvider.Runtime/Providers.MySql.fs
@@ -400,8 +400,8 @@ type internal MySqlProvider(resolutionPath, contextSchemaPath, owner:string, ref
           ~~(sprintf " ON DUPLICATE KEY UPDATE %s"
                 (String.Join(",", columnNamesWithValues |> Array.map(fun (c,p) -> sprintf "`%s`=%s" c p.ParameterName))))
         | DoNothing ->
-          ~~(sprintf " AS x ON DUPLICATE KEY UPDATE %s"
-                (String.Join(",", columnNamesWithValues |> Array.map(fun (c,_) -> sprintf "`%s`=x.`%s`" c c))))
+          ~~(sprintf " ON DUPLICATE KEY UPDATE %s"
+                (String.Join(",", columnNamesWithValues |> Array.map(fun (c,_) -> sprintf "`%s`=`%s`" c c))))
 
         ~~"; SELECT LAST_INSERT_ID();"
 

--- a/tests/SqlProvider.Tests/scripts/MySqlTests.fsx
+++ b/tests/SqlProvider.Tests/scripts/MySqlTests.fsx
@@ -157,8 +157,6 @@ let stdDevTest =
 
 
 //************************ CRUD *************************//
-
-
 let antartica =
     let result =
         query {
@@ -180,6 +178,91 @@ ctx.SubmitUpdates()
 
 antartica.Delete()
 ctx.SubmitUpdatesAsync() |> Async.AwaitTask |> Async.RunSynchronously
+
+//********************** Upsert ***************************//
+
+[<Test>]
+let ``Upsert on table with single primary key``() = 
+  let ctx = HR.GetDataContext()
+
+  let readGermany =
+    query { 
+      for country in ctx.Public.Countries do 
+      where (country.CountryId = "DE") 
+      select country.CountryName.Value
+    }
+    
+  let oldGermany = Seq.head readGermany
+  let newGermany = "West " + oldGermany
+
+  let wg = ctx.Public.Countries.Create()
+  wg.CountryId <- "DE"
+  wg.CountryName <- Some newGermany
+  wg.RegionId <- Some 1
+  wg.OnConflict <- Common.OnConflict.Update
+  ctx.SubmitUpdates()
+
+  let newGermanyDb = Seq.head readGermany
+
+  Assert.AreEqual(newGermany, newGermanyDb)
+
+[<Test>]
+let ``Upsert on table with composite primary key``() = 
+  let ctx = HR.GetDataContext()
+  
+  let employeeId, startDate, jobId, oldEndDate =
+    query { 
+      for jobHistory in ctx.Public.JobHistory do 
+      select (jobHistory.EmployeeId, jobHistory.StartDate, jobHistory.JobId, jobHistory.EndDate)
+    }
+    |> Seq.head
+  
+  let newEndDate = oldEndDate.AddDays(1.0)
+    
+  let jh = ctx.Public.JobHistory.Create()
+  jh.EmployeeId <- employeeId
+  jh.StartDate <- startDate
+  jh.EndDate <- newEndDate
+  jh.JobId <- jobId
+
+  jh.OnConflict <- Common.OnConflict.Update
+  ctx.SubmitUpdates()
+
+  let newEndDateDb =
+    query { 
+      for jobHistory in ctx.Public.JobHistory do 
+      where (jobHistory.EmployeeId = employeeId)
+      where (jobHistory.StartDate = startDate)
+      select (jobHistory.EndDate)
+    }
+    |> Seq.head
+
+  Assert.AreEqual(newEndDate, newEndDateDb)
+
+[<Test>]
+let ``Upsert with DO NOTHING leaves data unchanged``() = 
+  let ctx = HR.GetDataContext()
+  
+  let readGermanyRegion =
+    query { 
+      for country in ctx.Public.Countries do 
+      where (country.CountryId = "DE") 
+      select country.RegionId.Value
+    }
+
+  let oldGermanyRegion = Seq.head readGermanyRegion
+  let newGermanyRegionThatShouldNotBeSet = oldGermanyRegion + 1
+
+  let wg = ctx.Public.Countries.Create()
+  wg.CountryId <- "DE"
+  wg.CountryName <- Some "Germany"
+  wg.RegionId <- Some newGermanyRegionThatShouldNotBeSet
+  wg.OnConflict <- Common.OnConflict.DoNothing 
+  ctx.SubmitUpdates()
+
+  let newGermanyRegionDb = Seq.head readGermanyRegion
+
+  Assert.AreEqual(oldGermanyRegion, newGermanyRegionDb)
 
 //********************** Procedures **************************//
 

--- a/tests/SqlProvider.Tests/scripts/MySqlTests.fsx
+++ b/tests/SqlProvider.Tests/scripts/MySqlTests.fsx
@@ -157,6 +157,8 @@ let stdDevTest =
 
 
 //************************ CRUD *************************//
+
+
 let antartica =
     let result =
         query {
@@ -178,91 +180,6 @@ ctx.SubmitUpdates()
 
 antartica.Delete()
 ctx.SubmitUpdatesAsync() |> Async.AwaitTask |> Async.RunSynchronously
-
-//********************** Upsert ***************************//
-
-[<Test>]
-let ``Upsert on table with single primary key``() = 
-  let ctx = HR.GetDataContext()
-
-  let readGermany =
-    query { 
-      for country in ctx.Public.Countries do 
-      where (country.CountryId = "DE") 
-      select country.CountryName.Value
-    }
-    
-  let oldGermany = Seq.head readGermany
-  let newGermany = "West " + oldGermany
-
-  let wg = ctx.Public.Countries.Create()
-  wg.CountryId <- "DE"
-  wg.CountryName <- Some newGermany
-  wg.RegionId <- Some 1
-  wg.OnConflict <- Common.OnConflict.Update
-  ctx.SubmitUpdates()
-
-  let newGermanyDb = Seq.head readGermany
-
-  Assert.AreEqual(newGermany, newGermanyDb)
-
-[<Test>]
-let ``Upsert on table with composite primary key``() = 
-  let ctx = HR.GetDataContext()
-  
-  let employeeId, startDate, jobId, oldEndDate =
-    query { 
-      for jobHistory in ctx.Public.JobHistory do 
-      select (jobHistory.EmployeeId, jobHistory.StartDate, jobHistory.JobId, jobHistory.EndDate)
-    }
-    |> Seq.head
-  
-  let newEndDate = oldEndDate.AddDays(1.0)
-    
-  let jh = ctx.Public.JobHistory.Create()
-  jh.EmployeeId <- employeeId
-  jh.StartDate <- startDate
-  jh.EndDate <- newEndDate
-  jh.JobId <- jobId
-
-  jh.OnConflict <- Common.OnConflict.Update
-  ctx.SubmitUpdates()
-
-  let newEndDateDb =
-    query { 
-      for jobHistory in ctx.Public.JobHistory do 
-      where (jobHistory.EmployeeId = employeeId)
-      where (jobHistory.StartDate = startDate)
-      select (jobHistory.EndDate)
-    }
-    |> Seq.head
-
-  Assert.AreEqual(newEndDate, newEndDateDb)
-
-[<Test>]
-let ``Upsert with DO NOTHING leaves data unchanged``() = 
-  let ctx = HR.GetDataContext()
-  
-  let readGermanyRegion =
-    query { 
-      for country in ctx.Public.Countries do 
-      where (country.CountryId = "DE") 
-      select country.RegionId.Value
-    }
-
-  let oldGermanyRegion = Seq.head readGermanyRegion
-  let newGermanyRegionThatShouldNotBeSet = oldGermanyRegion + 1
-
-  let wg = ctx.Public.Countries.Create()
-  wg.CountryId <- "DE"
-  wg.CountryName <- Some "Germany"
-  wg.RegionId <- Some newGermanyRegionThatShouldNotBeSet
-  wg.OnConflict <- Common.OnConflict.DoNothing 
-  ctx.SubmitUpdates()
-
-  let newGermanyRegionDb = Seq.head readGermanyRegion
-
-  Assert.AreEqual(oldGermanyRegion, newGermanyRegionDb)
 
 //********************** Procedures **************************//
 


### PR DESCRIPTION
## Proposed Changes

I'd like to propose adding support for `OnConflict` in the `MySQL` provider. I believe it can be handled via the `ON DUPLICATE KEY UPDATE` clause that is available in MySQL. 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] Build and tests pass locally
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added necessary documentation (if appropriate)

## Further comments

I've not written any tests yet as I wanted to check that you open to accepting this new feature first and to also ask a few questions about the implementation, which I will point out in comments on the changes.
