### PR TITLE
fix for where-clause parameter type selection, #801

### DIFF
--- a/src/SQLProvider.Runtime/Providers.MsSqlServer.fs
+++ b/src/SQLProvider.Runtime/Providers.MsSqlServer.fs
@@ -701,9 +701,12 @@ type internal MSSqlServerProvider(contextSchemaPath, tableNames:string) =
                 incr param
                 sprintf "@param%i" !param
 
-            let createParam (value:obj) =
+            let createParam (columnDataType:DbType voption) (value:obj) =
                 let paramName = nextParam()
                 let p = MSSqlServer.createOpenParameter(paramName,value)
+                match columnDataType with
+                | ValueNone -> ()
+                | ValueSome colType -> p.DbType <- colType
                 p :> IDbDataParameter
 
             let fieldParam (value:obj) =
@@ -808,6 +811,7 @@ type internal MSSqlServerProvider(contextSchemaPath, tableNames:string) =
                         let build op preds (rest:Condition list option) =
                             ~~ "("
                             preds |> List.iteri( fun i (alias,col,operator,data) ->
+                                    let columnDataType = CommonTasks.searchDataTypeFromCache schemaCache sqlQuery baseAlias baseTable alias col
                                     let column = fieldNotation alias col
                                     let extractData data =
                                             match data with
@@ -815,9 +819,9 @@ type internal MSSqlServerProvider(contextSchemaPath, tableNames:string) =
                                             | Some(x) when (box x :? obj array) ->
                                                 // in and not in operators pass an array
                                                 let elements = box x :?> obj array
-                                                Array.init (elements.Length) (elements.GetValue >> createParam)
-                                            | Some(x) -> [|createParam (box x)|]
-                                            | None ->    [|createParam DBNull.Value|]
+                                                Array.init (elements.Length) (elements.GetValue >> createParam columnDataType)
+                                            | Some(x) -> [|createParam columnDataType (box x)|]
+                                            | None ->    [|createParam columnDataType DBNull.Value|]
 
                                     let operatorIn operator (array : IDbDataParameter[]) =
                                         if Array.isEmpty array then

--- a/src/SQLProvider.Runtime/Providers.MySql.fs
+++ b/src/SQLProvider.Runtime/Providers.MySql.fs
@@ -659,12 +659,16 @@ type internal MySqlProvider(resolutionPath, contextSchemaPath, owner:string, ref
                 incr param
                 sprintf "@param%i" !param
 
-            let createParamet (value:obj) =
+            let createParamet (columnDataType:DbType voption) (value:obj) =
                 let paramName = nextParam()
-                MySql.createCommandParameter false (MySql.createParam paramName !param value) value
+                let p = MySql.createCommandParameter false (MySql.createParam paramName !param value) value
+                match columnDataType with
+                | ValueNone -> ()
+                | ValueSome colType -> p.DbType <- colType
+                p
 
             let fieldParam (value:obj) =
-                let p = createParamet value
+                let p = createParamet ValueNone value
                 parameters.Add p
                 p.ParameterName
 
@@ -754,6 +758,7 @@ type internal MySqlProvider(resolutionPath, contextSchemaPath, owner:string, ref
                         let build op preds (rest:Condition list option) =
                             ~~ "("
                             preds |> List.iteri( fun i (alias,col,operator,data) ->
+                                    let columnDataType = CommonTasks.searchDataTypeFromCache schemaCache sqlQuery baseAlias baseTable alias col
                                     let column = fieldNotation alias col
                                     let extractData data =
                                             match data with
@@ -761,9 +766,9 @@ type internal MySqlProvider(resolutionPath, contextSchemaPath, owner:string, ref
                                             | Some(x) when (box x :? obj array) ->
                                                 // in and not in operators pass an array
                                                 let elements = box x :?> obj array
-                                                Array.init (elements.Length) (elements.GetValue >> createParamet)
-                                            | Some(x) -> [|createParamet (box x)|]
-                                            | None ->    [|createParamet DBNull.Value|]
+                                                Array.init (elements.Length) (elements.GetValue >> createParamet columnDataType)
+                                            | Some(x) -> [|createParamet columnDataType (box x)|]
+                                            | None ->    [|createParamet columnDataType DBNull.Value|]
 
                                     let operatorIn operator (array : IDbDataParameter[]) =
                                         if Array.isEmpty array then


### PR DESCRIPTION
Override where-clause parameter type for simple columns if we know the type.
Should be enough to fix #801 and similar issues

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Build and tests pass locally
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)

