### PR TITLE
fix NET8 macos - please try on mac and net8 (not working)

### DIFF
--- a/tests/SqlProvider.Tests/scripts/PGSqlNet8MacOs.fsx
+++ b/tests/SqlProvider.Tests/scripts/PGSqlNet8MacOs.fsx
@@ -1,0 +1,32 @@
+#r "nuget:Npgsql"
+#r "nuget:SQLProvider"
+
+open Npgsql
+open FSharp.Data.Sql
+
+
+[<AutoOpen>]
+module Settings =
+
+    [<Literal>]
+    let dbVendor = Common.DatabaseProviderTypes.POSTGRESQL
+
+    [<Literal>]
+    let connString =
+        // spinup a local docker PGSQL, e.g. with docker compose with all set to postgres
+        "Host=localhost;Username=postgres;Password=postgres;Database=postgres"
+
+    [<Literal>]
+    let owner = "public, admin, references"
+
+    [<Literal>]
+    let resPath = "~/.nuget/packages/npgsql/8.0.2/lib/net8.0"
+
+    [<Literal>]
+    let useOptTypes = Common.NullableColumnType.NO_OPTION
+
+type sql =
+    SqlDataProvider<DatabaseVendor=dbVendor, ConnectionString=connString, ResolutionPath=resPath, UseOptionTypes=useOptTypes, Owner=owner>
+
+let ctxFactory connectionStringRuntime =
+    sql.GetDataContext(connectionStringRuntime: string)


### PR DESCRIPTION
not working macos net8

## Proposed Changes

Fix PGSQL on NET8 and MacOs, not working yet.

```
error FS3033: The type provider 'FSharp.Data.Sql.SqlTypeProvider' reported an error: Could not create the connection, most likely this means that the connectionString is wrong. See error from Npgsql to troubleshoot: Could not load file or assembly 'Microsoft.Extensions.Logging.Abstractions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'. The system cannot find the file specified.
```

## Types of changes

- [X ] Bugfix (non-breaking change which fixes an issue)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Build and tests pass locally
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)
- [X] I have added the test to showcase that PGSQL is broken for MacOs NET8

## Further comments

not clear why this dependency is needed, and also why resolution path has to be specified manually and cannot be inferred with search in default nuget package folders for different operating systems?
