### PR TITLE
Fix cached return columns for function

### DIFF
--- a/src/SQLProvider.DesignTime/SqlDesignTime.fs
+++ b/src/SQLProvider.DesignTime/SqlDesignTime.fs
@@ -132,8 +132,12 @@ type public SqlTypeProvider(config: TypeProviderConfig) as this =
             | None ->
                 let ok, pars = prov.GetSchemaCache().SprocsParams.TryGetValue sprocname
                 if ok then
-                    pars |> List.filter (fun p -> p.Direction = ParameterDirection.Output)
-                else []
+                    pars |> List.filter (fun p ->
+                        not (p.Name |> String.IsNullOrWhiteSpace)
+                        && (p.Direction = ParameterDirection.Output
+                        || p.Direction = ParameterDirection.InputOutput
+                        || p.Direction = ParameterDirection.ReturnValue))
+                 else []
 
         let getTableData name = tableColumns.Force().[name].Force()
         let serviceType = ProvidedTypeDefinition( "dataContext", Some typeof<obj>, isErased=true)


### PR DESCRIPTION
## Proposed Changes

The `getSprocReturnColumns` is being modified that, when using a context schema file, it will return `InputOutput` and `ReturnValue` parameters as well as `Output` parameters.  Also, it will filter out any parameters which do not have a name.

Fixes #829

## Types of changes

What types of changes does your code introduce to SQLProvider?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Build and tests pass locally
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

