### PR TITLE
Postgres 8 TimestampTZ to TimestampTz, potential fix for #838

### DIFF
--- a/src/SQLProvider.Runtime/Providers.Postgresql.fs
+++ b/src/SQLProvider.Runtime/Providers.Postgresql.fs
@@ -185,9 +185,11 @@ module PostgreSQL =
               "time without time zone"      , typemap<TimeSpan>                   ["Time"]
               "time with time zone",    (if isLegacyVersion.Value
                                          then namemap "NpgsqlTimeTZ"              ["TimeTZ"]
-                                         else typemap<DateTimeOffset>             ["TimeTZ"])
+                                         else typemap<DateTimeOffset>             ["TimeTz"])
               "timestamp without time zone" , typemap<DateTime>                   ["Timestamp"]
-              "timestamp with time zone"    , typemap<DateTime>                   ["TimestampTZ"]
+              "timestamp with time zone", (if isLegacyVersion.Value
+                                           then typemap<DateTime>                 ["TimestampTZ"]
+                                           else typemap<DateTimeOffset>           ["TimestampTz"])
               "tsquery"                     , namemap "NpgsqlTsQuery"             ["TsQuery"]
               "tsvector"                    , namemap "NpgsqlTsVector"            ["TsVector"]
             //"txid_snapshot"               , typemap<???>                        ["???"]


### PR DESCRIPTION
This could fix the "timestamp with time zone" field.
Also, I think it should be mapped to `DateTimeOffset` and not to `DateTime`.
